### PR TITLE
Updated readme, un-required mailgun vars, added notebook container

### DIFF
--- a/Dockerfile-nb
+++ b/Dockerfile-nb
@@ -1,0 +1,10 @@
+FROM open_discussions_python
+
+USER root
+
+WORKDIR /tmp
+
+RUN pip install --force-reinstall jupyter
+
+USER mitodl
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -1,124 +1,56 @@
 # mitxpro
- 
 
-## Major Dependencies
-- Docker
-  - OSX recommended install method: [Download from Docker website](https://docs.docker.com/mac/)
-- docker-compose
-  - Recommended install: pip (`pip install docker-compose`)
-- Virtualbox (https://www.virtualbox.org/wiki/Downloads)
-- _(OSX only)_ Node/NPM, and Yarn
-  - OSX recommended install method: [Installer on Node website](https://nodejs.org/en/download/)
-  - No specific version has been chosen yet.
+**SECTIONS**
+1. [Initial Setup](#initial-setup)
+1. [Optional Setup](#optional-setup)
 
-## (OSX only) Getting your machine Docker-ready
+# Initial Setup
 
-#### Create your docker container:
+mitxpro follows the same [initial setup steps outlined in the common ODL web app guide](https://github.com/mitodl/handbook/blob/master/common-web-app-guide.md).
+Run through those steps **including the addition of `/etc/hosts` aliases and the optional step for running the
+`createsuperuser` command**.
 
-The following commands create a Docker machine named ``mitxpro``, start the
-container, and configure environment variables to facilitate communication
-with the edX instance.
+# Optional Setup
 
-    docker-machine create --driver virtualbox mitxpro
-    docker-machine start mitxpro
-    # 'docker-machine env (machine)' prints export commands for important environment variables
-    eval "$(docker-machine env mitxpro)"
+Described below are some setup steps that are not strictly necessary
+for running the app
 
+### Running the app in a notebook
 
-## Docker Container Configuration and Start-up
+This repo includes a config for running a [Jupyter notebook](https://jupyter.org/) in a
+Docker container. This enables you to do in a Jupyter notebook anything you might 
+otherwise do in a Django shell. To get started:
 
-#### 1) Create your ``.env`` file
-
-This file should be copied from the example in the codebase:
-
-    cp .env.example .env
-
-#### 2) _(OSX only)_ Set up and run the webpack dev server on your host machine
-
-In the development environment, our static assets are served from the webpack
-dev server. When this environment variable is set, the script sources will
-look for the webpack server at that host instead of the host where Docker is running.
-
-You'll need to install the [yarn](https://yarnpkg.com/en/docs/cli/)
-package manager. You can do:
-
-    sudo node ./scripts/install_yarn.js
-
-To install it. Nice! You can check which version is installed in
-`package.json` to be make you're getting the version we are
-standardized on.
-
-Now, in a separate terminal tab, use the webpack helper script to install npm modules and run the dev server:
-
-    ./webpack_dev_server.sh --install
-
-The ``--install`` flag is only needed if you're starting up for the first time, or if updates have been made
-to the packages in ``./package.json``. If you've installed those packages and there are no ``./package.json``
-updates, you can run this without the ``--install`` flag: ``./webpack_dev_server.sh``
-
-**DEBUGGING NOTE:** If you see an error related to node-sass when you run this script, try running
-``yarn install`` again.
-
-#### 3) Build the containers
-Run this command:
-
-    docker-compose build
-
-You will also need to run this command whenever ``requirements.txt`` or ``test_requirements.txt`` change.
-
-#### 4) Run migrations
-Create the database tables from the Django models:
-
-    docker-compose run web ./manage.py migrate
-
-#### 5) Run the container
-
-Start Django, PostgreSQL, and other related services:
-
-    docker-compose up
-
-In another terminal tab, navigate to the mitxpro directory
-and add a superuser in the now-running Docker container:
-
-    docker-compose run web ./manage.py createsuperuser
-
-You should now be able to do the following:
-
-1. Visit mitxpro in your browser on port `8053`. _(OSX Only)_ Docker auto-assigns
- the container IP. Run ``docker-machine ip`` to see it. Your mitxpro URL will
- be something like this: ``192.168.99.100:8053``.
-
-## Running Commands and Testing
-
-As shown above, manage commands can be executed on the Docker-contained
-mitxpro app. For example, you can run a Python shell with the following command:
-
-    docker-compose run web ./manage.py shell
-
-Tests should be run in the Docker container, not the host machine. They can be run with the following commands:
-
-    # Run the full suite
-    ./test_suite.sh
-    # Run Python tests only
-    docker-compose run web tox
-    # Single file test
-    docker-compose run web tox /path/to/test.py
-    # Run the JS tests with coverage report
-    docker-compose run watch npm run-script coverage
-    # run the JS tests without coverage report
-    docker-compose run watch npm test
-    # run a single JS test file
-    docker-compose run watch npm run-script singleTest /path/to/test.js
-    # Run the JS linter
-    docker-compose run watch npm run-script lint
-    # Run JS type-checking
-    docker-compose run watch npm run-script flow
-    # Run SCSS linter
-    docker-compose run watch npm run scss_lint
-
-Note that running [`flow`](https://flowtype.org) may not work properly if your
-host machine isn't running Linux. If you are using a Mac, you'll need to run
-`flow` on your host machine, like this:
-
-    yarn install --frozen-lockfile
-    npm run-script flow
+- Copy the example file
+    ```bash
+    # Choose any name for the resulting .ipynb file
+    cp localdev/app.ipynb.example localdev/app.ipynb
+    ```
+- Build the `notebook` container _(for first time use, or when requirements change)_
+    ```bash
+    docker-compose -f docker-compose-notebook.yml build
+    ```
+- Run all the standard containers (`docker-compose up`)
+- In another terminal window, run the `notebook` container
+    ```bash
+    docker-compose -f docker-compose-notebook.yml run --rm --service-ports notebook
+    ```
+- Visit the running notebook server in your browser. The `notebook` container log output will
+  indicate the URL and `token` param with some output that looks like this:
+    ```
+    notebook_1  |     To access the notebook, open this file in a browser:
+    notebook_1  |         file:///home/mitodl/.local/share/jupyter/runtime/nbserver-8-open.html
+    notebook_1  |     Or copy and paste one of these URLs:
+    notebook_1  |         http://(2c19429d04d0 or 127.0.0.1):8080/?token=2566e5cbcd723e47bdb1b058398d6bb9fbf7a31397e752ea
+    ```
+  Here is a one-line command that will produce a browser-ready URL from that output. Run this in a separate terminal:
+    ```bash
+    APP_HOST="xpro.odl.local"; docker logs $(docker ps --format '{{.Names}}' | grep "_notebook_run_") | grep -E "http://(.*):8080[^ ]+\w" | tail -1 | sed -e 's/^[[:space:]]*//' | sed -e "s/(.*)/$APP_HOST/"
+    ```
+  OSX users can pipe that output to `xargs open` to open a browser window directly with the URL from that command.
+- Navigate to the `.ipynb` file that you created and click it to run the notebook
+- Execute the first block to confirm it's working properly (click inside the block
+  and press Shift+Enter)
+  
+From there, you should be able to run code snippets with a live Django app just like you 
+would in a Django shell.

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -1,0 +1,19 @@
+version: '2.1'
+services:
+  notebook:
+    build:
+      context: .
+      dockerfile: Dockerfile-nb
+    extends:
+      file: docker-compose.yml
+      service: python
+    volumes:
+      - .:/src
+    environment:
+      BASE_DJANGO_APP_NAME: mitxpro
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      jupyter notebook --no-browser --ip=0.0.0.0 --port=8080'
+    ports:
+      - "8080:8080"

--- a/localdev/app.ipynb.example
+++ b/localdev/app.ipynb.example
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import django\n",
+    "from django.contrib.auth import get_user_model\n",
+    "\n",
+    "ABS_PROJECT_ROOT_PATH = \"/src\"\n",
+    "BASE_DJANGO_APP_NAME = os.environ.get(\"BASE_DJANGO_APP_NAME\")\n",
+    "\n",
+    "if not ABS_PROJECT_ROOT_PATH in sys.path:\n",
+    "    sys.path.insert(0, ABS_PROJECT_ROOT_PATH)\n",
+    "os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{}.settings'.format(BASE_DJANGO_APP_NAME))\n",
+    "django.setup()\n",
+    "\n",
+    "User = get_user_model()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
- Updates README, which is out of date in the cookie cutter
- Set mailgun vars to no longer be mandatory (`MANDATORY_SETTINGS` appears to be removed in open-discussions, so it's likely we should remove it here too, but that could be done in a separate PR)
- Added notebook container

#### Any background context you want to provide?
All 3 of these changes should probably be applied in some way to the cookie cutter
