### PR TITLE
Add rule to serve static files on dev environments

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -15,6 +15,12 @@ server {
         try_files /static/images/favicon.ico /favicon.ico;
     }
 
+    location ~* /static/(.*$) {
+        expires max;
+        add_header Access-Control-Allow-Origin *;
+        try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
+    }
+
     location / {
         include uwsgi_params;
         uwsgi_pass web:8051;


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes static file serving. We are using dj-static for this on our other projects but I removed it from the cookiecutter for some reason. I think it's unnecessary anyway, we can just have nginx serve this file.

#### How should this be manually tested?
Go to /admin and verify that everything looks appropriate.
