### PR TITLE
Bump docker to stretch debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4
+FROM python:3.6.8-stretch
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 # Install packages and add repo needed for postgres 9.6
 COPY apt.txt /tmp/apt.txt
-RUN echo deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main > /etc/apt/sources.list.d/pgdg.list
+RUN echo deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main > /etc/apt/sources.list.d/pgdg.list
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #91

#### What's this PR do?
Bumps dockerfile to use stretch instead of jessie

#### How should this be manually tested?
Travis should pass again, `docker-compose build web` and `docker-compose up` app should still work
