### PR TITLE
Updated OpenEdxApiAuth refresh to account for expiration

### DIFF
--- a/courseware/factories.py
+++ b/courseware/factories.py
@@ -1,9 +1,12 @@
 """Courseware factories"""
-from factory import Faker, SubFactory, Trait
+from datetime import timedelta
+
+from factory import Faker, SubFactory, Trait, LazyAttribute
 from factory.django import DjangoModelFactory
 import pytz
 
 from courseware.models import OpenEdxApiAuth
+from mitxpro.utils import now_in_utc
 
 
 class OpenEdxApiAuthFactory(DjangoModelFactory):
@@ -18,4 +21,8 @@ class OpenEdxApiAuthFactory(DjangoModelFactory):
         model = OpenEdxApiAuth
 
     class Params:
-        expired = Trait(access_token_expires_on=Faker("past_datetime", tzinfo=pytz.utc))
+        expired = Trait(
+            access_token_expires_on=LazyAttribute(
+                lambda _: now_in_utc() - timedelta(days=1)
+            )
+        )

--- a/ecommerce/conftest.py
+++ b/ecommerce/conftest.py
@@ -19,9 +19,7 @@ from ecommerce.factories import (
 )
 
 CouponGroup = namedtuple(
-    "CouponGroup",
-    ["coupon", "coupon_version", "payment", "payment_version"],
-    verbose=True,
+    "CouponGroup", ["coupon", "coupon_version", "payment", "payment_version"]
 )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #99 

#### What's this PR do?
Refractors the existing method used to acquire a new set of tokens only if they are going to expire and does via a lock on the row.

#### How should this be manually tested?
Verify you can still enroll in a course