### PR TITLE
Fix running pytest for a subset of tests that don't create TEST_MEDIA_ROOT

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,8 @@
 """Project conftest"""
 # pylint: disable=wildcard-import,unused-wildcard-import
+import os
 import shutil
+
 import pytest
 from django.conf import settings
 
@@ -23,4 +25,5 @@ def clean_up_files():
     effectively deleting any files that were created by factories over the course of the test suite.
     """
     yield
-    shutil.rmtree(TEST_MEDIA_ROOT)
+    if os.path.exists(TEST_MEDIA_ROOT):
+        shutil.rmtree(TEST_MEDIA_ROOT)


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes an autouse fixture when testing only a subset of the suite.

#### How should this be manually tested?
Tests should pass and you should see that `pytest courseware/` passes in theis branch but fails on master.