### PR TITLE
Added test script detail to Travis output

### DIFF
--- a/travis/js_tests.sh
+++ b/travis/js_tests.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 status=0
 
+echohighlight() {
+  echo -e "\033[1;92m$@\e[0m"
+}
+
 function run_test {
+    echohighlight "[TEST SUITE] $@"
     "$@"
     local test_status=$?
     if [ $test_status -ne 0 ]; then
         status=$test_status
     fi
+    echo ""
     return $status
 }
 

--- a/travis/python_tests.sh
+++ b/travis/python_tests.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 status=0
 
+echohighlight() {
+  echo -e "\033[1;92m$@\e[0m"
+}
+
 function run_test {
+    echohighlight "[TEST SUITE] $@"
     "$@"
     local test_status=$?
     if [ $test_status -ne 0 ]; then
         status=$test_status
     fi
+    echo ""
     return $status
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket, just a simple improvement

#### What's this PR do?
For each test suite step/command in the Python or JS travis scripts, the command is echo'ed before it's run. This should help us to visually (and programatically) parse a job log from a Travis build

#### How should this be manually tested?
Run `travis/js_tests.sh` and `travis/python_tests.sh`, make sure it looks nice

#### Screenshots (if appropriate)
![ss 2019-04-30 at 12 00 30 ](https://user-images.githubusercontent.com/14932219/56978222-04442100-6b45-11e9-9a27-9dddccb9d6ba.png)


