### PR TITLE
Redirect users to /dashboard after CyberSource checkout

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -108,7 +108,7 @@ def generate_cybersource_sa_payload(order, base_url):
         "reference_number": make_reference_id(order),
         "profile_id": settings.CYBERSOURCE_PROFILE_ID,
         "signed_date_time": now_in_utc().strftime(ISO_8601_FORMAT),
-        "override_custom_receipt_page": urljoin(base_url, "dashboard"),
+        "override_custom_receipt_page": urljoin(base_url, "dashboard/"),
         "transaction_type": "sale",
         "transaction_uuid": uuid.uuid4().hex,
         "unsigned_field_names": "",

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -6,6 +6,7 @@ import decimal
 import hashlib
 import hmac
 import logging
+from urllib.parse import urljoin
 import uuid
 
 from django.conf import settings
@@ -96,16 +97,6 @@ def generate_cybersource_sa_payload(order, base_url):
 
         total += unit_price
 
-    # CyberSource requires that these links be https
-    overrides = (
-        {
-            "override_custom_cancel_page": base_url,
-            "override_custom_receipt_page": base_url,
-        }
-        if base_url.startswith("https://")
-        else {}
-    )
-
     payload = {
         "access_key": settings.CYBERSOURCE_ACCESS_KEY,
         "amount": str(total),
@@ -117,7 +108,7 @@ def generate_cybersource_sa_payload(order, base_url):
         "reference_number": make_reference_id(order),
         "profile_id": settings.CYBERSOURCE_PROFILE_ID,
         "signed_date_time": now_in_utc().strftime(ISO_8601_FORMAT),
-        **overrides,
+        "override_custom_receipt_page": urljoin(base_url, "dashboard"),
         "transaction_type": "sale",
         "transaction_uuid": uuid.uuid4().hex,
         "unsigned_field_names": "",

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -162,7 +162,7 @@ def test_signed_payload(mocker):
         "line_item_count": 3,
         "locale": "en-us",
         "reference_number": make_reference_id(order),
-        "override_custom_receipt_page": urljoin(base_url, "dashboard"),
+        "override_custom_receipt_page": urljoin(base_url, "dashboard/"),
         "profile_id": CYBERSOURCE_PROFILE_ID,
         "signed_date_time": now.strftime(ISO_8601_FORMAT),
         "signed_field_names": ",".join(signed_field_names),

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from datetime import timedelta
 import hashlib
 import hmac
+from urllib.parse import urljoin
 from unittest.mock import PropertyMock
 
 import factory
@@ -161,8 +162,7 @@ def test_signed_payload(mocker):
         "line_item_count": 3,
         "locale": "en-us",
         "reference_number": make_reference_id(order),
-        "override_custom_cancel_page": base_url,
-        "override_custom_receipt_page": base_url,
+        "override_custom_receipt_page": urljoin(base_url, "dashboard"),
         "profile_id": CYBERSOURCE_PROFILE_ID,
         "signed_date_time": now.strftime(ISO_8601_FORMAT),
         "signed_field_names": ",".join(signed_field_names),
@@ -171,14 +171,6 @@ def test_signed_payload(mocker):
         "unsigned_field_names": "",
     }
     now_mock.assert_called_once_with()
-
-
-def test_payload_overrides():
-    """No overrides should be provided if the link is not https"""
-    order = OrderFactory.create()
-    payload = generate_cybersource_sa_payload(order, "http://base_url")
-    assert "override_custom_cancel_page" not in payload
-    assert "override_custom_receipt_page" not in payload
 
 
 def test_payload_coupons():


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #233 

#### What's this PR do?
Removes cancel override field and updates the receipt override field to redirect users to `/dashboard` so that CyberSource checkout will go through.

#### How should this be manually tested?
Checkout should work (no need to verify order fulfillment)