### PR TITLE
fix static path of banner image

### DIFF
--- a/static/scss/resource.scss
+++ b/static/scss/resource.scss
@@ -7,7 +7,7 @@ html {
 .resource-banner {
   width: 100%;
   padding: 75px 0;
-  background: rgba(53, 53, 53, .97) url("$static-path/images/banner-bg.png") repeat-x 0 0;
+  background: rgba(53, 53, 53, .97) url("#{$static-path}/images/banner-bg.png") repeat-x 0 0;
   min-height: 200px;
 
   .container {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #245 

#### What's this PR do?
Fix path of banner image on resource pages.

#### How should this be manually tested?

- Add resource page.
- View its live version.
- Banner image should load.

#### Screenshots (if appropriate)
<img width="1275" alt="Screen Shot 2019-05-09 at 2 30 03 PM" src="https://user-images.githubusercontent.com/4245618/57604437-9acd0500-757d-11e9-8172-d68583cb61fa.png">

