### PR TITLE
Don't check CSRF token for index pages

### DIFF
--- a/mitxpro/views.py
+++ b/mitxpro/views.py
@@ -5,6 +5,7 @@ import json
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render
 from raven.contrib.django.raven_compat.models import client as sentry
 from rest_framework.views import APIView
@@ -29,6 +30,7 @@ def get_js_settings_context(request):
     return {"js_settings_json": json.dumps(js_settings)}
 
 
+@csrf_exempt
 def index(request):
     """
     The index view

--- a/mitxpro/views_test.py
+++ b/mitxpro/views_test.py
@@ -3,6 +3,7 @@ Test end to end django views.
 """
 import json
 
+from django.test import Client
 from django.urls import reverse
 import pytest
 from rest_framework import status
@@ -62,3 +63,12 @@ def test_app_context(settings, client):
         "environment": settings.ENVIRONMENT,
         "release_version": settings.VERSION,
     }
+
+
+@pytest.mark.parametrize("verb", ["get", "post"])
+def test_dashboard(verb):
+    """Anonymous users should be able to POST to the dashboard and see the same content as a GET"""
+    client = Client(enforce_csrf_checks=True)
+    method = getattr(client, verb)
+    response = method(reverse("user-dashboard"))
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #241 

#### What's this PR do?
Adds `@csrf_exempt` to allow POST to `/dashboard` and other HTML pages which use the same `index` view. This allows CyberSource to POST to this page without causing a CSRF error. 

#### How should this be manually tested?
Run `curl -XPOST http://mitxpro.mit.local:8053/dashboard/`. On master you should see text about a CSRF validation error, but on this branch it should show a little bit of HTML.

