### PR TITLE
Use query parameters when loading checkout page

### DIFF
--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -2,19 +2,22 @@
 import React from "react"
 import * as R from "ramda"
 import { connect } from "react-redux"
-import { connectRequest, mutateAsync } from "redux-query"
+import { mutateAsync, requestAsync } from "redux-query"
 import { compose } from "redux"
+import queryString from "query-string"
 
 import queries from "../../lib/queries"
 import {
   calculateDiscount,
   calculatePrice,
   formatPrice,
-  formatRunTitle
+  formatRunTitle,
+  formatErrors
 } from "../../lib/ecommerce"
 import { createCyberSourceForm } from "../../lib/form"
 
 import type { Response } from "redux-query"
+import type { Location } from "react-router"
 import type {
   BasketResponse,
   BasketPayload,
@@ -50,6 +53,8 @@ export const calcSelectedRunIds = (item: BasketItem): { [number]: number } => {
 type Props = {
   basket: ?BasketResponse,
   checkout: () => Promise<Response<CheckoutResponse>>,
+  fetchBasket: () => Promise<*>,
+  location: Location,
   updateBasket: (payload: BasketPayload) => Promise<*>
 }
 type State = {
@@ -62,6 +67,30 @@ export class CheckoutPage extends React.Component<Props, State> {
     couponCode:   null,
     selectedRuns: null,
     errors:       null
+  }
+
+  componentDidMount = async () => {
+    const {
+      fetchBasket,
+      location: { search }
+    } = this.props
+    const params = queryString.parse(search)
+    const productId = parseInt(params.product)
+    if (!productId) {
+      await fetchBasket()
+      return
+    }
+
+    try {
+      await this.updateBasket({ items: [{ id: productId }] })
+
+      const couponCode = params.code
+      if (couponCode) {
+        await this.updateBasket({ coupons: [{ code: couponCode }] })
+      }
+    } catch (_) {
+      // prevent complaints about unresolved promises
+    }
   }
 
   handleErrors = async (responsePromise: Promise<*>) => {
@@ -202,13 +231,14 @@ export class CheckoutPage extends React.Component<Props, State> {
     const { basket } = this.props
     const { couponCode, errors } = this.state
 
-    if (!basket) {
-      return null
-    }
-
-    const item = basket.items[0]
-    if (!item) {
-      return <div>No item in basket</div>
+    const item = basket && basket.items[0]
+    if (!basket || !item) {
+      return (
+        <div className="checkout-page">
+          No item in basket
+          {formatErrors(errors)}
+        </div>
+      )
     }
 
     const coupon = basket.coupons.find(coupon =>
@@ -259,7 +289,7 @@ export class CheckoutPage extends React.Component<Props, State> {
                     Apply
                   </button>
                 </div>
-                {errors ? <div className="error">Error: {errors}</div> : null}
+                {formatErrors(errors)}
               </form>
             </div>
           </div>
@@ -302,15 +332,14 @@ const mapStateToProps = state => ({
 })
 const mapDispatchToProps = dispatch => ({
   checkout:     () => dispatch(mutateAsync(queries.ecommerce.checkoutMutation())),
+  fetchBasket:  () => dispatch(requestAsync(queries.ecommerce.basketQuery())),
   updateBasket: payload =>
     dispatch(mutateAsync(queries.ecommerce.basketMutation(payload)))
 })
-const mapPropsToConfigs = () => [queries.ecommerce.basketQuery()]
 
 export default compose(
   connect(
     mapStateToProps,
     mapDispatchToProps
-  ),
-  connectRequest(mapPropsToConfigs)
+  )
 )(CheckoutPage)

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -11,10 +11,9 @@ import {
   calculateDiscount,
   calculatePrice,
   formatPrice,
-  formatRunTitle,
-  formatErrors
+  formatRunTitle
 } from "../../lib/ecommerce"
-import { createCyberSourceForm } from "../../lib/form"
+import { createCyberSourceForm, formatErrors } from "../../lib/form"
 
 import type { Response } from "redux-query"
 import type { Location } from "react-router"

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -212,21 +212,14 @@ describe("CheckoutPage", () => {
           "PATCH",
           productPayload
         )
-        if (hasValidProductId) {
-          sinon.assert.calledWith(
-            helper.handleRequestStub,
+        assert.equal(
+          helper.handleRequestStub.calledWith(
             "/api/basket/",
             "PATCH",
             couponPayload
-          )
-        } else {
-          sinon.assert.neverCalledWith(
-            helper.handleRequestStub,
-            "/api/basket/",
-            "PATCH",
-            couponPayload
-          )
-        }
+          ),
+          hasValidProductId
+        )
 
         assert.equal(inner.state().errors, expError)
       })

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -18,7 +18,7 @@ import {
   formatPrice,
   formatRunTitle
 } from "../../lib/ecommerce"
-import { assertRaises, wait } from "../../lib/util"
+import { assertRaises } from "../../lib/util"
 import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants"
 
 describe("CheckoutPage", () => {
@@ -205,7 +205,7 @@ describe("CheckoutPage", () => {
           }
         )
         // wait for componentDidMount to resolve
-        await wait(0)
+        await Promise.resolve()
         sinon.assert.calledWith(
           helper.handleRequestStub,
           "/api/basket/",

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -142,31 +142,40 @@ describe("CheckoutPage", () => {
     })
   })
 
-  //
-  ;[[true, false], [true, true], [false, false], [false, true]].forEach(
-    ([hasValidProductId, hasValidCoupon]) => {
+  describe("mount", () => {
+    const productError = "product error",
+      couponError = "coupon error",
+      couponCode = "codeforcoupon",
+      productId = 12345
+    let couponPayload, productPayload
+
+    beforeEach(() => {
+      couponPayload = {
+        body:        { coupons: [{ code: couponCode }] },
+        credentials: undefined,
+        headers:     {
+          "X-CSRFTOKEN": null
+        }
+      }
+      productPayload = {
+        body:        { items: [{ id: productId }] },
+        credentials: undefined,
+        headers:     {
+          "X-CSRFTOKEN": null
+        }
+      }
+    })
+    ;[
+      [true, false, couponError],
+      [true, true, null],
+      [false, false, productError],
+      [false, true, productError]
+    ].forEach(([hasValidProductId, hasValidCoupon, expError]) => {
       it(`updates the basket with a ${
         hasValidProductId ? "" : "in"
       }valid product id and a ${
         hasValidCoupon ? "" : "in"
       }valid coupon code from the query parameter`, async () => {
-        const couponCode = "codeforcoupon"
-        const productId = 12345
-        const couponPayload = {
-          body:        { coupons: [{ code: couponCode }] },
-          credentials: undefined,
-          headers:     {
-            "X-CSRFTOKEN": null
-          }
-        }
-        const productPayload = {
-          body:        { items: [{ id: productId }] },
-          credentials: undefined,
-          headers:     {
-            "X-CSRFTOKEN": null
-          }
-        }
-
         if (!hasValidProductId) {
           helper.handleRequestStub
             .withArgs("/api/basket/", "PATCH", productPayload)
@@ -196,7 +205,7 @@ describe("CheckoutPage", () => {
           }
         )
         // wait for componentDidMount to resolve
-        await wait(15)
+        await wait(0)
         sinon.assert.calledWith(
           helper.handleRequestStub,
           "/api/basket/",
@@ -219,17 +228,10 @@ describe("CheckoutPage", () => {
           )
         }
 
-        assert.equal(
-          inner.state().errors,
-          !hasValidProductId
-            ? "product error"
-            : !hasValidCoupon
-              ? "coupon error"
-              : null
-        )
+        assert.equal(inner.state().errors, expError)
       })
-    }
-  )
+    })
+  })
 
   it("displays the coupon code", async () => {
     const { inner } = await renderPage()

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -1,5 +1,4 @@
 // @flow
-import React from "react"
 import Decimal from "decimal.js-light"
 import * as R from "ramda"
 import { equals } from "ramda"

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -58,24 +58,6 @@ const formatDateForRun = (dateString: ?string) =>
 export const formatRunTitle = (run: CourseRun) =>
   `${formatDateForRun(run.start_date)} - ${formatDateForRun(run.end_date)}`
 
-export const formatErrors = (errors: string | Object) => {
-  if (!errors) {
-    return null
-  }
-
-  let errorString
-  if (typeof errors === "object") {
-    if (errors.items) {
-      errorString = errors.items[0]
-    } else {
-      errorString = errors[0]
-    }
-  } else {
-    errorString = errors
-  }
-  return <div className="error">{errorString}</div>
-}
-
 export const isPromo = equals(COUPON_TYPE_PROMO)
 
 export const createProductMap = (

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -1,4 +1,5 @@
 // @flow
+import React from "react"
 import Decimal from "decimal.js-light"
 import * as R from "ramda"
 import { equals } from "ramda"
@@ -56,6 +57,24 @@ const formatDateForRun = (dateString: ?string) =>
 
 export const formatRunTitle = (run: CourseRun) =>
   `${formatDateForRun(run.start_date)} - ${formatDateForRun(run.end_date)}`
+
+export const formatErrors = (errors: string | Object) => {
+  if (!errors) {
+    return null
+  }
+
+  let errorString
+  if (typeof errors === "object") {
+    if (errors.items) {
+      errorString = errors.items[0]
+    } else {
+      errorString = errors[0]
+    }
+  } else {
+    errorString = errors
+  }
+  return <div className="error">{errorString}</div>
+}
 
 export const isPromo = equals(COUPON_TYPE_PROMO)
 

--- a/static/js/lib/form.js
+++ b/static/js/lib/form.js
@@ -1,5 +1,6 @@
 // @flow
 import type { CheckoutPayload } from "../flow/ecommerceTypes"
+import React from "react"
 
 /**
  * Creates a POST form with hidden input fields
@@ -24,4 +25,24 @@ export function createCyberSourceForm(
     form.appendChild(input)
   }
   return form
+}
+
+export const formatErrors = (
+  errors: string | Object | null
+): React$Element<*> | null => {
+  if (!errors) {
+    return null
+  }
+
+  let errorString
+  if (typeof errors === "object") {
+    if (errors.items) {
+      errorString = errors.items[0]
+    } else {
+      errorString = errors[0]
+    }
+  } else {
+    errorString = errors
+  }
+  return <div className="error">{errorString}</div>
 }

--- a/static/js/lib/form_test.js
+++ b/static/js/lib/form_test.js
@@ -1,8 +1,9 @@
 // @flow
 import { assert } from "chai"
+import { shallow } from "enzyme"
 
 import { CYBERSOURCE_CHECKOUT_RESPONSE } from "./test_constants"
-import { createCyberSourceForm } from "./form"
+import { createCyberSourceForm, formatErrors } from "./form"
 
 describe("form functions", () => {
   it("creates a form with hidden values corresponding to the payload", () => {
@@ -22,5 +23,28 @@ describe("form functions", () => {
     assert.deepEqual(clone, {})
     assert.equal(form.getAttribute("action"), url)
     assert.equal(form.getAttribute("method"), "post")
+  })
+
+  describe("formatErrors", () => {
+    it("should return null if there is no error", () => {
+      assert.isNull(formatErrors(null))
+    })
+
+    it("should return a div with the error string if the error is a string", () => {
+      const wrapper = shallow(formatErrors("error"))
+      assert.equal(wrapper.find(".error").text(), "error")
+    })
+
+    it("should return the first item in the items in the error object if it has items", () => {
+      const error = { items: ["error"] }
+      const wrapper = shallow(formatErrors(error))
+      assert.equal(wrapper.find(".error").text(), "error")
+    })
+
+    it("should return the first item in the error if there is no 'items'", () => {
+      const error = ["error"]
+      const wrapper = shallow(formatErrors(error))
+      assert.equal(wrapper.find(".error").text(), "error")
+    })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #121 

#### What's this PR do?
Uses query parameters to populate the basket on checkout page load. This will allow links from the catalog pages to the checkout page.

#### How should this be manually tested?
Go to `/checkout/?product_id=123456` where `123456` is a valid `ProductVersion` id. You should see that page loaded. If you go to `?product_id=123456&code=xyz` for a valid coupon code, it should automatically apply the discount and show it on the checkout page.

If you have no query parameters, it should show you whatever your basket looked like previously.

If you have an invalid product id, the page should load with whatever the old basket content was and an error message should be displayed at the bottom of the screen. This is a rare case so the error message won't be more prominent than that.

If you have an invalid coupon code, the page should try again to patch the basket with the given product id from the query parameter and an error message should be displayed at the bottom of the screen, near the coupon code textbox.