### PR TITLE
Misc. improvements - dashboard style, root route, enrollment admin

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -4,7 +4,7 @@ Admin site bindings for profiles
 
 from django.contrib import admin
 
-from .models import Program, Course, CourseRun
+from .models import Program, Course, CourseRun, ProgramEnrollment, CourseRunEnrollment
 
 
 class ProgramAdmin(admin.ModelAdmin):
@@ -31,6 +31,20 @@ class CourseRunAdmin(admin.ModelAdmin):
     list_filter = ["live", "course"]
 
 
+class ProgramEnrollmentAdmin(admin.ModelAdmin):
+    """Admin for ProgramEnrollment"""
+
+    model = ProgramEnrollment
+
+
+class CourseRunEnrollmentAdmin(admin.ModelAdmin):
+    """Admin for CourseRunEnrollment"""
+
+    model = CourseRunEnrollment
+
+
 admin.site.register(Program, ProgramAdmin)
 admin.site.register(Course, CourseAdmin)
 admin.site.register(CourseRun, CourseRunAdmin)
+admin.site.register(ProgramEnrollment, ProgramEnrollmentAdmin)
+admin.site.register(CourseRunEnrollment, CourseRunEnrollmentAdmin)

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -189,7 +189,7 @@ def test_course_catalog_view(client):
     CourseFactory.create(no_program=True, live=False)
     exp_programs = [program]
     exp_courses = [course_in_program, course_no_program]
-    resp = client.get(reverse("mitxpro-index"))
+    resp = client.get(reverse("mitxpro-catalog"))
     assert resp.templates[0].name == "catalog.html"
     assert list(resp.context["programs"]) == exp_programs
     assert list(resp.context["courses"]) == exp_courses

--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -63,7 +63,8 @@ urlpatterns = [
         name="password-reset-confirm",
     ),
     path("terms-and-conditions/", index, name="terms-and-conditions"),
-    re_path(r"catalog/", CourseCatalogView.as_view(), name="mitxpro-index"),
+    re_path(r"^catalog/", CourseCatalogView.as_view(), name="mitxpro-catalog"),
+    re_path(r"^$", CourseCatalogView.as_view(), name="mitxpro-index"),
     re_path(r"^dashboard/", index, name="user-dashboard"),
     # Wagtail
     re_path(r"^cms/", include(wagtailadmin_urls)),

--- a/mitxpro/urls_test.py
+++ b/mitxpro/urls_test.py
@@ -9,4 +9,4 @@ class URLTests(TestCase):
 
     def test_urls(self):
         """Make sure URLs match with resolved names"""
-        assert reverse("mitxpro-index") == "/catalog/"
+        assert reverse("mitxpro-catalog") == "/catalog/"

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -31,6 +31,16 @@ export class DashboardPage extends React.Component<Props, State> {
     collapseVisible: {}
   }
 
+  enrollmentsExist = (): boolean => {
+    const { enrollments } = this.props
+
+    return (
+      enrollments &&
+      (enrollments.program_enrollments.length > 0 ||
+        enrollments.course_run_enrollments.length > 0)
+    )
+  }
+
   onCollapseToggle = (programEnrollmentId: number): void => {
     this.setState({
       collapseVisible: {
@@ -160,12 +170,18 @@ export class DashboardPage extends React.Component<Props, State> {
   render() {
     const { enrollments } = this.props
 
+    const enrollmentsExist = this.enrollmentsExist()
+
     return (
       <div className="user-dashboard container-fluid">
         <div className="row">
           <div className="header col-12">
             <h1>Dashboard</h1>
-            <h3>Courses and Programs</h3>
+            {enrollmentsExist ? (
+              <h3>Courses and Programs</h3>
+            ) : (
+              <h2>You are not yet enrolled in any courses or programs.</h2>
+            )}
           </div>
         </div>
         {enrollments ? (

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -70,6 +70,24 @@ describe("DashboardPage", () => {
     )
   })
 
+  it("shows a message if the user has no enrollments", async () => {
+    const { inner } = await renderPage({
+      entities: {
+        enrollments: {
+          program_enrollments:    [],
+          course_run_enrollments: []
+        }
+      }
+    })
+
+    const header = inner.find(".user-dashboard .header")
+    assert.isTrue(header.exists())
+    assert.include(
+      header.text(),
+      "You are not yet enrolled in any courses or programs"
+    )
+  })
+
   it("shows specific date information", async () => {
     const { inner } = await renderPage()
     sinon.assert.calledWith(

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -18,16 +18,17 @@
   }
 
   h2 {
-    font-size: 1.75rem;
+    font-size: 2rem;
     font-weight: 600;
+    line-height: 2.75rem;
 
     @include media-breakpoint-down(sm) {
-      font-size: 1.25rem;
+      font-size: 1.6rem;
     }
   }
 
   h3 {
-    font-size: 1.25rem;
+    font-size: 1.75rem;
     font-weight: 600;
     color: $navy-blue;
     border-bottom: 1px solid $detail-grid-border-color;
@@ -43,11 +44,11 @@
 
 .user-dashboard,
 .collapse-toggle {
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 600;
 
   @include media-breakpoint-down(sm) {
-    font-size: 16px;
+    font-size: 1.6rem;
   }
 }
 
@@ -99,11 +100,6 @@
     .course-enrollment {
       margin-top: 15px;
       margin-bottom: 15px;
-
-      h2 {
-        font-size: 20px;
-        font-weight: 600;
-      }
     }
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket

#### What's this PR do?
- fixed dashboard style regressions at mobile width
- added a simple message to the dashboard if a user has no enrollments
- added rule to serve course catalog at root route (this will eventually be replaced by the actual home page - #246)
- added enrollment admin classes

#### How should this be manually tested?
- Check dashboard at multiple screen widths
- Go to the root URL of the app and make sure you see the course catalog

#### Screenshots (if appropriate)
![ss 2019-05-14 at 17 35 09 ](https://user-images.githubusercontent.com/14932219/57733927-af3cfa80-766e-11e9-846e-368be0df944b.png)
![ss 2019-05-14 at 17 35 17 ](https://user-images.githubusercontent.com/14932219/57733931-b106be00-766e-11e9-8b66-ab45a3796d62.png)
![ss 2019-05-15 at 12 22 04 ](https://user-images.githubusercontent.com/14932219/57792653-80c22c80-770d-11e9-9814-0b9dfc8de8c1.png)
