### PR TITLE
Fixed dashboard styling again

### DIFF
--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -177,11 +177,12 @@ export class DashboardPage extends React.Component<Props, State> {
         <div className="row">
           <div className="header col-12">
             <h1>Dashboard</h1>
-            {enrollmentsExist ? (
-              <h3>Courses and Programs</h3>
-            ) : (
-              <h2>You are not yet enrolled in any courses or programs.</h2>
-            )}
+            {enrollments &&
+              (enrollmentsExist ? (
+                <h3>Courses and Programs</h3>
+              ) : (
+                <h2>You are not yet enrolled in any courses or programs.</h2>
+              ))}
           </div>
         </div>
         {enrollments ? (

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -18,17 +18,17 @@
   }
 
   h2 {
-    font-size: 2rem;
+    font-size: 1.75rem;
     font-weight: 600;
-    line-height: 2.75rem;
+    line-height: 2rem;
 
     @include media-breakpoint-down(sm) {
-      font-size: 1.6rem;
+      font-size: 1.25rem;
     }
   }
 
   h3 {
-    font-size: 1.75rem;
+    font-size: 1.25rem;
     font-weight: 600;
     color: $navy-blue;
     border-bottom: 1px solid $detail-grid-border-color;
@@ -42,13 +42,17 @@
   }
 }
 
+.text-ribbon,
 .user-dashboard,
 .collapse-toggle {
-  font-size: 2rem;
+  font-size: 1.25rem;
   font-weight: 600;
+}
 
+.user-dashboard,
+.collapse-toggle {
   @include media-breakpoint-down(sm) {
-    font-size: 1.6rem;
+    font-size: 1rem;
   }
 }
 
@@ -151,6 +155,7 @@
     height: 40px;
     top: 25px;
     right: 0;
+    z-index: 10;
 
     .text {
       padding-left: 7px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket 

#### What's this PR do?
#285 fixed the dashboard styling after a regression, but the root cause of that regression was fixed, so the styling regressed again. This PR un-regresses the regression regression.

It also makes sure that the product type flags appear above the product images in the mobile view

#### How should this be manually tested?
Look at the dashboard

#### Screenshots (if appropriate)
![ss 2019-05-16 at 15 17 41 ](https://user-images.githubusercontent.com/14932219/57881016-41b7d800-77ee-11e9-8990-333615166277.png)
![ss 2019-05-16 at 15 17 52 ](https://user-images.githubusercontent.com/14932219/57881020-441a3200-77ee-11e9-878c-6296887d9f38.png)

