### PR TITLE
Fixed encrypted response getting ascii-escaped

### DIFF
--- a/compliance/api.py
+++ b/compliance/api.py
@@ -124,14 +124,18 @@ def log_exports_inquiry(user, response, last_sent, last_received):
     info_code = response.exportReply.infoCode
 
     box = SealedBox(get_encryption_public_key())
+    encrypted_request = box.encrypt(xml_request, encoder=Base64Encoder).decode("ascii")
+    encrypted_response = box.encrypt(xml_response, encoder=Base64Encoder).decode(
+        "ascii"
+    )
 
     return ExportsInquiryLog.objects.create(
         user=user,
         computed_result=compute_result_from_codes(reason_code, info_code),
         reason_code=reason_code,
         info_code=info_code,
-        encrypted_request=box.encrypt(xml_request),
-        encrypted_response=box.encrypt(xml_response),
+        encrypted_request=encrypted_request,
+        encrypted_response=encrypted_response,
     )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #327 

#### What's this PR do?
This fixes an issue where the encrypted responses were being encoded as raw byte strings, which made them more difficult to decrypt later on. This changes that to base64 encode them since we're storing them on a `TextField`

#### How should this be manually tested?
Tests passing should be sufficient since they check that the records can be decrypted with the private key and they match the input. Feel free to manually perform what the new test added here does though if you wish to verify this independently.

#### What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/sybV46NZNxLDG/giphy.gif)
