### PR TITLE
Enroll/View Dashboard button

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -270,7 +270,6 @@ class Course(TimestampedModel, PageProperties):
     title = models.CharField(max_length=255)
     readable_id = models.CharField(null=True, max_length=255)
     live = models.BooleanField(default=False)
-    products = GenericRelation(Product, related_query_name="courses")
 
     @property
     def page(self):
@@ -292,17 +291,6 @@ class Course(TimestampedModel, PageProperties):
             ),
             default=None,
         )
-
-    @property
-    def current_price(self):
-        """Gets the price if it exists"""
-        product = self.products.first()
-        if not product:
-            return None
-        latest_version = product.latest_version
-        if not latest_version:
-            return None
-        return latest_version.price
 
     @property
     def first_unexpired_run(self):
@@ -380,6 +368,7 @@ class CourseRun(TimestampedModel):
     enrollment_start = models.DateTimeField(null=True, blank=True, db_index=True)
     enrollment_end = models.DateTimeField(null=True, blank=True, db_index=True)
     live = models.BooleanField(default=False)
+    products = GenericRelation(Product, related_query_name="courses")
 
     @property
     def is_past(self):
@@ -432,6 +421,17 @@ class CourseRun(TimestampedModel):
             if self.courseware_url_path
             else None
         )
+
+    @property
+    def current_price(self):
+        """Gets the price if it exists"""
+        product = self.products.first()
+        if not product:
+            return None
+        latest_version = product.latest_version
+        if not latest_version:
+            return None
+        return latest_version.price
 
     def __str__(self):
         return self.title

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -284,6 +284,19 @@ def test_course_run_unexpired(end_days, enroll_days, expected):
     )
 
 
+def test_course_run_current_price():
+    """
+    current_price should return the price of the latest product version if it exists
+    """
+    run = CourseRunFactory.create()
+    assert run.current_price is None
+    price = 10
+    ProductVersionFactory.create(
+        product=ProductFactory(content_object=run), price=price
+    )
+    assert run.current_price == price
+
+
 def test_course_first_unexpired_run():
     """
     Test that the first unexpired run of a course is returned
@@ -318,19 +331,6 @@ def test_course_next_run_date():
         2, course=course, start_date=factory.Iterator(future_dates)
     )
     assert course.next_run_date == future_dates[0]
-
-
-def test_course_current_price():
-    """
-    current_price should return the price of the latest product version if it exists
-    """
-    course = CourseFactory.create()
-    assert course.current_price is None
-    price = 10
-    ProductVersionFactory.create(
-        product=ProductFactory(content_object=course), price=price
-    )
-    assert course.current_price == price
 
 
 def test_course_page():

--- a/courses/templates/partials/hero.html
+++ b/courses/templates/partials/hero.html
@@ -9,6 +9,17 @@
           <h1>{{ obj.display_title }}</h1>
           <h2>{{ obj.subhead }}</h2>
         </div>
+        <div>
+          {% if not enrolled and product_version_id %}
+            <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_version_id }}">
+              Enroll Now
+            </a>
+          {% elif enrolled and courseware_url %}
+            <a class="enroll-button" href="{{ courseware_url }}">
+              View Course
+            </a>
+          {% endif %}
+        </div>
       </div>
       <div class="col-lg-5">
         {% if obj.video_url %}

--- a/courses/templates/partials/hero.html
+++ b/courses/templates/partials/hero.html
@@ -15,8 +15,8 @@
               Enroll Now
             </a>
           {% elif enrolled and courseware_url %}
-            <a class="enroll-button" href="{{ courseware_url }}">
-              View Course
+            <a class="enroll-button" href="{% url "user-dashboard" %}">
+              View Dashboard
             </a>
           {% endif %}
         </div>

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -246,7 +246,7 @@ def test_course_view(
             url = f'{reverse("checkout-page")}?product={product_version_id}'
             has_button = True
         if is_enrolled and has_unexpired_run:
-            url = run.courseware_url
+            url = reverse("user-dashboard")
             has_button = True
 
     assert (

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -202,6 +202,7 @@ def test_course_catalog_view(client):
     assert list(resp.context["courses"]) == exp_courses
 
 
+# pylint: disable=too-many-arguments
 @pytest.mark.parametrize("is_enrolled", [True, False])
 @pytest.mark.parametrize("has_unexpired_run", [True, False])
 @pytest.mark.parametrize("has_product", [True, False])

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -58,6 +58,15 @@
     }
   }
 
+  .enroll-button {
+    margin: 0;
+    border-radius: 5px;
+    background-color: $primary;
+    color: white;
+    padding: 20px 40px;
+    text-transform: uppercase;
+  }
+
   video {
     width: 100%;
     border: 5px solid white;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #101 

#### What's this PR do?
Adds a link, styled as a button, which will direct the user to purchase the product for the next unexpired
course run for the course, or to view the course in edX if they are already enrolled. 

#### How should this be manually tested?
Have a course with an unexpired course run, and make sure a `Product` and `ProductVersion` exist for that course run. Visit the course product page and you should see an "Enroll now" link. Click on it and you should be directed to the checkout page with the course run listed as the item on the checkout page.

To test the 'View course' link, it may be easiest to just fake a couple things:
 - update `courseware_url_path` on the `CourseRun` you created to have some path, as long as it's not none. The link may not work but it will show up at least. 
 - Create `CourseRunEnrollment` between your user and the run. Alternatively you could complete the order fulfillment with a 100% off coupon to skip CyberSource.

Then you should see a 'View Course' link.

You should not see any button if:
 - you don't have a product associated with the course run
 - your course run is not enrollable

#### Any background context you want to provide?
The alignment of the button is off compared to the mockup, but I didn't want to touch the header CSS to fix as there are other changes happening at the moment.