### PR TITLE
fix error in console when no notification available

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -16,10 +16,14 @@ $(document).ready(function() {
 });
 
 function renderSiteNotification() {
-  const notificationId = $(".notification")
-    .data("notification-id")
-    .toString();
-  if (localStorage.getItem("dismissedNotification") !== notificationId) {
-    $(".notifications").removeClass("d-none");
+  const notificationId = $(".notification").data("notification-id");
+
+  if (notificationId) {
+    if (
+      localStorage.getItem("dismissedNotification") !==
+      notificationId.toString()
+    ) {
+      $(".notifications").removeClass("d-none");
+    }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #349 

#### What's this PR do?
Add check in `notifications.js` to avoid error in console.

#### How should this be manually tested?

- Make sure, there is no notification available in CMS
- Render any page
- You should not see any error in console
