### PR TITLE
#372 Fix: Set HomePage as Parent of ResourcePage

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -343,6 +343,7 @@ class HomePage(Page):
         "LearningTechniquesPage",
         "UserTestimonialsPage",
         "ForTeamsPage",
+        "ResourcePage",
     ]
 
     def _get_child_page_of_type(self, cls):


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#372 

#### What's this PR do?
Sets `HomePage` as a valid parent page class of `ResourcePage` so those instances can be moved/created under `HomePage`

#### How should this be manually tested?
Try to add a `ResourcePage` under a `HomePage` instance. The CMS should allow you to add that pagae.