### PR TITLE
fix if only one date available

### DIFF
--- a/courses/templates/partials/metadata-tiles.html
+++ b/courses/templates/partials/metadata-tiles.html
@@ -5,21 +5,23 @@
         <li>
           <span class="title">START DATE</span>
           <span class="text">{{ course.next_run_date|date:"F j, Y" }}</span>
-          <span class="dates-link">
-            <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
-              data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this course"
-              data-content="
-                <div>
-                  <p>Click below to enroll in one of these dates</p>
-                </div>
-                {% for course_run in course.unexpired_runs %}
+          {% if course.unexpired_runs|length > 1 %}
+            <span class="dates-link">
+              <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this course"
+                data-content="
                   <div>
-                    <a class='date-link' href='#' data-id='{{ course_run.id }}'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                    <p>Click below to enroll in one of these dates</p>
                   </div>
-                {% endfor %}">
-              More Dates
-            </a>
-          </span>
+                  {% for course_run in course.unexpired_runs %}
+                    <div>
+                      <a class='date-link' href='#' data-id='{{ course_run.id }}'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                    </div>
+                  {% endfor %}">
+                More Dates
+              </a>
+            </span>
+          {% endif %}
         </li>
       {% endif %}
       {% if course.time_commitment %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #376 

#### What's this PR do?
Add check if there is only one date available, don't show more dates option.

#### How should this be manually tested?

- Make sure, you have course with only one open enrollment.
- Visit course page
- You should not see "More dates"


#### Screenshots (if appropriate)
<img width="643" alt="Screen Shot 2019-05-27 at 6 12 11 PM" src="https://user-images.githubusercontent.com/4245618/58422000-e23db000-80aa-11e9-8395-9bc2c9b54dcf.png">

