### PR TITLE
add seed resource pages in CMS

### DIFF
--- a/localdev/seed/api_test.py
+++ b/localdev/seed/api_test.py
@@ -4,14 +4,14 @@ from types import SimpleNamespace
 import pytest
 
 from courses.models import Program, Course, CourseRun
-from cms.models import ProgramPage, CoursePage
-from localdev.seed.api import SeedDataLoader, get_raw_course_data_from_file
+from cms.models import ProgramPage, CoursePage, ResourcePage
+from localdev.seed.api import SeedDataLoader, get_raw_seed_data_from_file
 
 
 @pytest.fixture
 def seeded():
     """Fixture for a scenario where course data has been loaded from our JSON file"""
-    data = get_raw_course_data_from_file()
+    data = get_raw_seed_data_from_file()
     seed_data_loader = SeedDataLoader()
     seed_data_loader.create_seed_data(data)
     return SimpleNamespace(raw_data=data, loader=seed_data_loader)
@@ -26,17 +26,21 @@ def test_seed_and_unseed_data(seeded):
         len(course_data.get("course_runs", []))
         for course_data in seeded.raw_data["courses"]
     )
+    expected_resource_pages = len(seeded.raw_data["resource_pages"])
     assert Program.objects.count() == expected_programs
     assert ProgramPage.objects.count() == expected_programs
     assert Course.objects.count() == expected_courses
     assert CoursePage.objects.count() == expected_courses
     assert CourseRun.objects.count() == expected_course_runs
+    assert ResourcePage.objects.count() == expected_resource_pages
+
     seeded.loader.delete_seed_data(seeded.raw_data)
     assert Program.objects.count() == 0
     assert ProgramPage.objects.count() == 0
     assert Course.objects.count() == 0
     assert CoursePage.objects.count() == 0
     assert CourseRun.objects.count() == 0
+    assert ResourcePage.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/localdev/seed/management/commands/seed_data.py
+++ b/localdev/seed/management/commands/seed_data.py
@@ -2,7 +2,7 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
-from localdev.seed.api import SeedDataLoader, get_raw_course_data_from_file
+from localdev.seed.api import SeedDataLoader, get_raw_seed_data_from_file
 
 User = get_user_model()
 
@@ -24,11 +24,11 @@ class Command(BaseCommand):
         """Handle command execution"""
         delete = options["delete"]
         seed_data_loader = SeedDataLoader()
-        raw_course_data = get_raw_course_data_from_file()
+        raw_seed_data = get_raw_seed_data_from_file()
         results = (
-            seed_data_loader.create_seed_data(raw_course_data)
+            seed_data_loader.create_seed_data(raw_seed_data)
             if not delete
-            else seed_data_loader.delete_seed_data(raw_course_data)
+            else seed_data_loader.delete_seed_data(raw_seed_data)
         )
 
         if not any(results.report.values()):

--- a/localdev/seed/resources/seed_data.json
+++ b/localdev/seed/resources/seed_data.json
@@ -44,7 +44,7 @@
                 {
                     "title": "Systems Engineering - Fall 2019",
                     "courseware_id": "course-v1:TestX+SysEngxB1+1T2019",
-                    "courseware_url_path": "/courses/course-v1:TestX+SysEngxB1+1T2019/course/", 
+                    "courseware_url_path": "/courses/course-v1:TestX+SysEngxB1+1T2019/course/",
                     "start_date": "2019-08-15T00:00:00+00:00",
                     "end_date": "2019-12-15T00:00:00+00:00",
                     "enrollment_end": "2019-08-29T00:00:00+00:00"
@@ -340,6 +340,71 @@
                     "end_date": "2019-12-15T00:00:00+00:00",
                     "start_date": "2019-08-15T00:00:00+00:00",
                     "enrollment_end": "2019-08-29T00:00:00+00:00"
+                }
+            ]
+        }
+    ],
+    "resource_pages": [
+        {
+            "title": "Terms of service",
+            "sub_heading": "Sub heading of terms of service",
+            "slug": "terms-of-service",
+            "content": [
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": "Introduction",
+                        "detail": "This is a sample data for terms of services, you can edit through cms under resources pages."
+                    }
+                },
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": "User accounts and authority",
+                        "detail": "We care about the confidentiality and security of your personal information. Please see our Privacy Policy for more information about what information about you we collect and how we use that information."
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Privacy policy",
+            "sub_heading": "Sub heading of privacy policy",
+            "slug": "privacy-policy",
+            "content": [
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": "Introduction",
+                        "detail": "This is a sample data for privacy policy, you can edit through cms under resources pages."
+                    }
+                },
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": "What personal information we collect",
+                        "detail": "Data Processors, on behalf of MIT xPRO, collect, use, store and transfer different kinds of personal information (hereinafter “Personal Information”) about you, which we have grouped together as Biographic information, Contact information and Usernames and information posted by you to our forums."
+                    }
+                }
+            ]
+        },
+        {
+            "title": "Honor code",
+            "sub_heading": "Sub heading of honor code",
+            "slug": "honor-code",
+            "content": [
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": "Introduction",
+                        "detail": "This is a sample data for honor code, you can edit through cms under resources pages."
+                    }
+                },
+                {
+                    "type": "content",
+                    "value": {
+                        "heading": "Changing the honor code",
+                        "detail": "Please note that we review and may make changes to this Honor Code from time to time. Any changes to this Honor Code will be effective immediately upon posting on this page, with an updated effective date. By accessing the Site after any changes have been made, you signify your agreement on a prospective basis to the modified Honor Code. Be sure to return to this page periodically to ensure familiarity with the most current version of this Honor Code."
+                    }
                 }
             ]
         }


### PR DESCRIPTION
#### What are the relevant tickets?
#207 

#### What's this PR do?
Add sample resource pages for `terms of services`, `privacy policy` and `honor code`.

#### How should this be manually tested?

- Run management command `./manage.py seed_data`
- Click on links (`terms of services`, `privacy policy` and `honor code`.) in footer.
- You should see sample pages.
- `./manage.py seed_data --delete` this should delete seed data.

**Note:** Terms of services page will be shown after #399 merged.