### PR TITLE
Added support for redirect on register existing email

### DIFF
--- a/static/js/components/forms/RegisterEmailForm.js
+++ b/static/js/components/forms/RegisterEmailForm.js
@@ -21,6 +21,11 @@ type Props = {
   onSubmit: Function
 }
 
+export type RegisterEmailValues = {
+  email: string,
+  recaptcha: ?string
+}
+
 const RegisterEmailForm = ({ onSubmit }: Props) => (
   <Formik
     onSubmit={onSubmit}

--- a/static/js/containers/pages/register/RegisterConfirmPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage.js
@@ -27,7 +27,7 @@ type Props = {
   auth: ?AuthResponse
 }
 
-class RegisterProfilePage extends React.Component<Props> {
+class RegisterConfirmPage extends React.Component<Props> {
   componentDidUpdate(prevProps) {
     const { auth, history } = this.props
     const prevState = path(["auth", "state"], prevProps)
@@ -85,4 +85,4 @@ const mapPropsToConfig = ({ params: { verificationCode, partialToken } }) =>
 export default compose(
   connect(mapStateToProps),
   connectRequest(mapPropsToConfig)
-)(RegisterProfilePage)
+)(RegisterConfirmPage)

--- a/static/js/containers/pages/register/RegisterDetailsPage.js
+++ b/static/js/containers/pages/register/RegisterDetailsPage.js
@@ -62,7 +62,7 @@ type Props = {|
   ...DispatchProps
 |}
 
-class RegisterProfilePage extends React.Component<Props, State> {
+class RegisterDetailsPage extends React.Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
@@ -208,4 +208,4 @@ export default compose(
     mapDispatchToProps
   ),
   connectRequest(mapPropsToConfig)
-)(RegisterProfilePage)
+)(RegisterDetailsPage)

--- a/static/js/containers/pages/register/RegisterEmailPage.js
+++ b/static/js/containers/pages/register/RegisterEmailPage.js
@@ -8,7 +8,10 @@ import { createStructuredSelector } from "reselect"
 import { addUserNotification } from "../../../actions"
 import queries from "../../../lib/queries"
 import { routes } from "../../../lib/urls"
-import { STATE_REGISTER_CONFIRM_SENT } from "../../../lib/auth"
+import {
+  STATE_REGISTER_CONFIRM_SENT,
+  STATE_LOGIN_PASSWORD
+} from "../../../lib/auth"
 import { qsNextSelector } from "../../../lib/selectors"
 
 import RegisterEmailForm from "../../../components/forms/RegisterEmailForm"
@@ -16,6 +19,7 @@ import RegisterEmailForm from "../../../components/forms/RegisterEmailForm"
 import type { RouterHistory, Location } from "react-router"
 import type { Response } from "redux-query"
 import type { AuthResponse } from "../../../flow/authTypes"
+import type { RegisterEmailValues } from "../../../components/forms/RegisterEmailForm"
 
 type Props = {
   location: Location,
@@ -32,8 +36,11 @@ type Props = {
 const emailNotificationText = (email: string): string =>
   `We sent an email to ${email}. Please validate your address to continue.`
 
-class RegisterEmailPage extends React.Component<Props> {
-  async onSubmit({ email, recaptcha }, { setSubmitting, setErrors }) {
+export class RegisterEmailPage extends React.Component<Props> {
+  async onSubmit(
+    { email, recaptcha }: RegisterEmailValues,
+    { setSubmitting, setErrors }: any
+  ) {
     const {
       addUserNotification,
       registerEmail,
@@ -49,6 +56,8 @@ class RegisterEmailPage extends React.Component<Props> {
       if (state === STATE_REGISTER_CONFIRM_SENT) {
         addUserNotification(emailNotificationText(email))
         history.push(routes.login.begin)
+      } else if (state === STATE_LOGIN_PASSWORD) {
+        history.push(routes.login.password)
       } else if (errors.length > 0) {
         setErrors({
           email: errors[0]

--- a/static/js/containers/pages/register/RegisterEmailPage_test.js
+++ b/static/js/containers/pages/register/RegisterEmailPage_test.js
@@ -1,0 +1,134 @@
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+
+import RegisterEmailPage, {
+  RegisterEmailPage as InnerRegisterEmailPage
+} from "./RegisterEmailPage"
+import IntegrationTestHelper from "../../../util/integration_test_helper"
+import {
+  STATE_REGISTER_CONFIRM_SENT,
+  STATE_LOGIN_PASSWORD,
+  STATE_ERROR
+} from "../../../lib/auth"
+import { routes } from "../../../lib/urls"
+
+describe("RegisterEmailPage", () => {
+  const email = "email@example.com"
+  const recaptcha = "recaptchaTestValue"
+  const partialToken = "partialTokenTestValue"
+  let helper, renderPage, setSubmittingStub, setErrorsStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+
+    setSubmittingStub = helper.sandbox.stub()
+    setErrorsStub = helper.sandbox.stub()
+
+    renderPage = helper.configureHOCRenderer(
+      RegisterEmailPage,
+      InnerRegisterEmailPage,
+      {},
+      {
+        location: {
+          search: `partial_token=${partialToken}`
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("displays a form", async () => {
+    const { inner } = await renderPage()
+
+    assert.ok(inner.find("RegisterEmailForm").exists())
+  })
+
+  it("handles onSubmit for an error response", async () => {
+    const { inner } = await renderPage()
+    const error = "error message"
+
+    helper.handleRequestStub.returns({
+      body: {
+        state:  STATE_ERROR,
+        errors: [error]
+      }
+    })
+
+    const onSubmit = inner.find("RegisterEmailForm").prop("onSubmit")
+
+    await onSubmit(
+      { email, recaptcha },
+      { setSubmitting: setSubmittingStub, setErrors: setErrorsStub }
+    )
+
+    assert.lengthOf(helper.browserHistory, 1)
+    sinon.assert.calledWith(setErrorsStub, {
+      email: error
+    })
+    sinon.assert.calledWith(setSubmittingStub, false)
+  })
+
+  it("handles onSubmit for an existing user password login", async () => {
+    const { inner } = await renderPage()
+
+    helper.handleRequestStub.returns({
+      body: {
+        state:  STATE_LOGIN_PASSWORD,
+        errors: []
+      }
+    })
+
+    const onSubmit = inner.find("RegisterEmailForm").prop("onSubmit")
+
+    await onSubmit(
+      { email, recaptcha },
+      { setSubmitting: setSubmittingStub, setErrors: setErrorsStub }
+    )
+
+    assert.lengthOf(helper.browserHistory, 2)
+    assert.include(helper.browserHistory.location, {
+      pathname: routes.login.password,
+      search:   ""
+    })
+    sinon.assert.notCalled(setErrorsStub)
+    sinon.assert.calledWith(setSubmittingStub, false)
+  })
+
+  it("handles onSubmit for a confirmation email", async () => {
+    const { inner, store } = await renderPage()
+
+    helper.handleRequestStub.returns({
+      body: {
+        state:  STATE_REGISTER_CONFIRM_SENT,
+        errors: []
+      }
+    })
+
+    const onSubmit = inner.find("RegisterEmailForm").prop("onSubmit")
+
+    await onSubmit(
+      { email, recaptcha },
+      { setSubmitting: setSubmittingStub, setErrors: setErrorsStub }
+    )
+
+    assert.lengthOf(helper.browserHistory, 2)
+    assert.include(helper.browserHistory.location, {
+      pathname: routes.login.begin,
+      search:   ""
+    })
+    sinon.assert.notCalled(setErrorsStub)
+    sinon.assert.calledWith(setSubmittingStub, false)
+
+    const { ui } = store.getState()
+
+    assert.lengthOf(ui.userNotifications, 1)
+    assert.include(
+      ui.userNotifications,
+      `We sent an email to ${email}. Please validate your address to continue.`
+    )
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #344 
Some of #312 

#### What's this PR do?
- Adds a redirect to `/login/password` if a user tries to register for an account that exists
- Adds test coverage for `RegisterEmailPage.js`
- Fixes some copy/paste typos on register page class names

#### How should this be manually tested?
- Go to /signup and try to register with an existing email, it should prompt you to enter password and you should be able to login.
- Go to /signup and verify you can still signup with an email that doesn't exist