### PR TITLE
Fix missing price on product page

### DIFF
--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -40,7 +40,7 @@
         <span class="title">FORMAT</span>
         <span class="text">Online</span>
       </li>
-      {% firstof page.product.first_unexpired_run.current_price or page.product.current_price as price%}
+      {% firstof page.product.first_unexpired_run.current_price page.product.current_price as price%}
       {% if price %}
         <li>
           <span class="title">PRICE</span>

--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -40,10 +40,11 @@
         <span class="title">FORMAT</span>
         <span class="text">Online</span>
       </li>
-      {% if page.product.current_price %}
+      {% firstof page.product.first_unexpired_run.current_price or page.product.current_price as price%}
+      {% if price %}
         <li>
           <span class="title">PRICE</span>
-          <span class="text">${{ page.product.current_price|floatformat:"0" }}</span>
+          <span class="text">${{ price|floatformat:"0" }}</span>
         </li>
       {% endif %}
     </ul>

--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -1,10 +1,10 @@
 <div class="tiles-block">
   <div class="container">
     <ul class="tiles-list">
-      {% if page.product.next_run_date %}
+      {% if page.product.first_unexpired_run.start_date %}
         <li>
           <span class="title">START DATE</span>
-          <span class="text">{{ page.product.next_run_date|date:"F j, Y" }}</span>
+          <span class="text">{{ page.product.first_unexpired_run.start_date|date:"F j, Y" }}</span>
           {% if page.product.unexpired_runs|length > 1 %}
             <span class="dates-link">
               <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
@@ -40,7 +40,7 @@
         <span class="title">FORMAT</span>
         <span class="text">Online</span>
       </li>
-      {% firstof page.product.first_unexpired_run.current_price page.product.current_price as price%}
+      {% firstof page.product.current_price page.product.first_unexpired_run.current_price as price %}
       {% if price %}
         <li>
           <span class="title">PRICE</span>

--- a/courses/models.py
+++ b/courses/models.py
@@ -131,6 +131,14 @@ class Program(TimestampedModel, PageProperties):
             return None
         return latest_version.price
 
+    @property
+    def first_unexpired_run(self):
+        """Gets the earliest unexpired CourseRun if one exists"""
+        return min(
+            filter(None, [course.first_unexpired_run for course in self.courses.all()]),
+            default=None,
+        )
+
     def __str__(self):
         return self.title
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -137,6 +137,7 @@ class Program(TimestampedModel, PageProperties):
         return min(
             filter(None, [course.first_unexpired_run for course in self.courses.all()]),
             default=None,
+            key=lambda run: run.start_date,
         )
 
     def __str__(self):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -173,6 +173,32 @@ def test_course_first_unexpired_run():
     assert course.first_unexpired_run == first_run
 
 
+def test_program_first_unexpired_run():
+    """
+    Test that the first unexpired run of a program is returned
+    """
+    program = ProgramFactory()
+    course = CourseFactory.create(program=program)
+    now = now_in_utc()
+    end_date = now + timedelta(days=100)
+    enr_end_date = now + timedelta(days=100)
+    first_run = CourseRunFactory.create(
+        start_date=now, course=course, end_date=end_date, enrollment_end=enr_end_date
+    )
+
+    # create another course and course run in program
+    another_course = CourseFactory.create(program=program)
+    second_run = CourseRunFactory.create(
+        start_date=now + timedelta(days=50),
+        course=another_course,
+        end_date=end_date,
+        enrollment_end=enr_end_date,
+    )
+
+    assert first_run.start_date < second_run.start_date
+    assert program.first_unexpired_run == first_run
+
+
 def test_course_next_run_date():
     """
     next_run_date should return the date of the CourseRun with the nearest future start date


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #408 and #410

#### What's this PR do?

- Show price on course or program page.
- For courses show first unexpired course run price as course price.

#### How should this be manually tested?

**For courses:**
- Add product against course run which is set to be first unexpired course run in your course.
- Add product version for added product.
- View course page.
- You should see `Price` tile on course product page.

**For programs:**
- Add product against program
- Add product version for added product.
- View program page.
- You should see `Price` tile on program product page.

#### Any background context you want to provide?
Initially price was present under `course`, after #336 it is moved under `courserun`. This PR will update the template to render price of first unexpired course run.
@pdpinch Your thoughts on rendering price of first unexpired course run?

#### Screenshots (if appropriate)
**Course:**
<img width="1332" alt="Screen Shot 2019-05-31 at 12 37 30 PM" src="https://user-images.githubusercontent.com/4245618/58690056-19111000-83a2-11e9-9078-e4e7071bb570.png">


**Program:**
<img width="1407" alt="Screen Shot 2019-05-31 at 12 37 17 PM" src="https://user-images.githubusercontent.com/4245618/58690043-10203e80-83a2-11e9-85d6-87dc0f1fe46b.png">


