### PR TITLE
max_redemptions should be 1 for single-use coupons

### DIFF
--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -10,7 +10,6 @@ import * as yup from "yup"
 import {
   COUPON_TYPE_PROMO,
   COUPON_TYPE_SINGLE_USE,
-  PRODUCT_TYPE_COURSE,
   PRODUCT_TYPE_COURSERUN,
   PRODUCT_TYPE_PROGRAM
 } from "../../constants"
@@ -231,17 +230,6 @@ export const CouponForm = ({
             checked={values.product_type === PRODUCT_TYPE_PROGRAM}
           />
           Programs
-          <Field
-            type="radio"
-            name="product_type"
-            value={PRODUCT_TYPE_COURSE}
-            onClick={evt => {
-              setFieldValue("product_type", evt.target.value)
-              setFieldValue("products", [])
-            }}
-            checked={values.product_type === PRODUCT_TYPE_COURSE}
-          />
-          Courses
           <Field
             type="radio"
             name="product_type"

--- a/static/js/containers/pages/admin/CreateCouponPage.js
+++ b/static/js/containers/pages/admin/CreateCouponPage.js
@@ -50,7 +50,7 @@ export class CreateCouponPage extends React.Component<Props, State> {
     const { createCoupon } = this.props
     couponData.product_ids = couponData.products.map(product => product.id)
     if (couponData.coupon_type === COUPON_TYPE_SINGLE_USE) {
-      couponData.max_redemptions = couponData.num_coupon_codes
+      couponData.max_redemptions = 1
     } else {
       couponData.num_coupon_codes = 1
     }

--- a/static/js/containers/pages/admin/CreateCouponPage_test.js
+++ b/static/js/containers/pages/admin/CreateCouponPage_test.js
@@ -10,7 +10,7 @@ import {
   makeCouponPaymentVersion,
   makeProduct
 } from "../../../factories/ecommerce"
-import { COUPON_TYPE_PROMO } from "../../../constants"
+import { COUPON_TYPE_PROMO, COUPON_TYPE_SINGLE_USE } from "../../../constants"
 import IntegrationTestHelper from "../../../util/integration_test_helper"
 
 describe("CreateCouponPage", () => {
@@ -122,6 +122,35 @@ describe("CreateCouponPage", () => {
       credentials: undefined
     })
     assert.equal(inner.state().couponId, newCoupon.id)
+  })
+
+  it("sets max_redemptions to 1 if coupon type is single-use", async () => {
+    const testCouponData = {
+      coupon_type:      COUPON_TYPE_SINGLE_USE,
+      products:         [products[0]],
+      num_coupon_codes: 100,
+      amount:           50
+    }
+    const { inner } = await renderCreateCouponPage(
+      {},
+      {
+        createCoupon: helper.handleRequestStub
+      }
+    )
+    await inner.instance().onSubmit(testCouponData, {
+      setSubmitting: setSubmittingStub,
+      setErrors:     setErrorsStub
+    })
+    sinon.assert.calledWith(helper.handleRequestStub, "/api/coupons/", "POST", {
+      body: {
+        max_redemptions: 1,
+        ...testCouponData
+      },
+      headers: {
+        "X-CSRFTOKEN": null
+      },
+      credentials: undefined
+    })
   })
 
   it("sets errors if submission is unsuccessful", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #415 

#### What's this PR do?
- Sets max_redemptions to 1 for single-use coupons when creating them via the form.
- Removes 'Course' product listings option from coupon form (no longer allowed - related to #177)

#### How should this be manually tested?
Create a new single-use coupon with ~10 coupon codes.
Check the new `CouponPaymentVersion` from django admin and verify that `max_redemptions` and `max_redemptions_per_user` are both 1.
