### PR TITLE
Always show course run selections

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -55,8 +55,7 @@ class CourseRunSerializer(serializers.ModelSerializer):
 
     def get_product_id(self, instance):
         """ Get the product id for a course run """
-        product = instance.products.first()
-        return product.id if product else None
+        return instance.products.values_list("id", flat=True).first()
 
     class Meta:
         model = models.CourseRun

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -51,6 +51,13 @@ class BaseCourseSerializer(serializers.ModelSerializer):
 class CourseRunSerializer(serializers.ModelSerializer):
     """CourseRun model serializer"""
 
+    product_id = serializers.SerializerMethodField()
+
+    def get_product_id(self, instance):
+        """ Get the product id for a course run """
+        product = instance.products.first()
+        return product.id if product else None
+
     class Meta:
         model = models.CourseRun
         fields = [
@@ -62,6 +69,7 @@ class CourseRunSerializer(serializers.ModelSerializer):
             "courseware_url",
             "courseware_id",
             "id",
+            "product_id",
         ]
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -108,6 +108,7 @@ def test_serialize_course_run():
         "enrollment_start": drf_datetime(course_run.enrollment_start),
         "enrollment_end": drf_datetime(course_run.enrollment_end),
         "id": course_run.id,
+        "product_id": None,
     }
 
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -658,7 +658,7 @@ def validate_basket_for_checkout(basket):
         # This is != but it could be < because the > case should be covered in previous clauses.
         # The user can only select more courses than a product has if they are selecting runs outside
         # of the product, which we checked above.
-        raise ValidationError("One or more courses do not have a course run selection")
+        raise ValidationError("Each course must have a course run selection")
 
     # All run ids must be purchasable and enrollable by user
     for run in runs:

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -677,7 +677,7 @@ def test_validate_basket_course_without_run_selection(basket_and_coupons):
     CourseRunSelection.objects.all().delete()
     with pytest.raises(ValidationError) as ex:
         validate_basket_for_checkout(basket_and_coupons.basket)
-    assert ex.value.args[0] == "One or more courses do not have a course run selection"
+    assert ex.value.args[0] == "Each course must have a course run selection"
 
 
 def test_validate_basket_run_expired(mocker, basket_and_coupons):

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -237,6 +237,9 @@ class BasketSerializer(serializers.ModelSerializer):
     @classmethod
     def _get_runs_for_product(cls, *, product, run_ids, user):
         """Helper function to get and validate selected runs in a product"""
+        if None in run_ids:
+            raise ValidationError("Each course must have a course run selection")
+
         runs_for_product = list(product.run_queryset.filter(id__in=run_ids))
         run_ids_for_product = {run.id for run in runs_for_product}
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -615,17 +615,13 @@ def test_patch_basket_invalid_run(
 
     # If the product is a course, create a new run on a different course which is invalid.
     # If the product is a program, create a new run on a different program.
-    other_run_id = (
-        (
-            CourseRunFactory.create()
-            if is_program
-            else CourseRunFactory.create(
-                course__program=product.content_object.course.program
-            )
-        ).id
-        if is_selected
-        else None
+    course_run_params = (
+        dict(course__program=product.content_object.course.program)
+        if not is_program
+        else {}
     )
+    other_course_run = CourseRunFactory.create(**course_run_params)
+    other_run_id = other_course_run.id if is_selected else None
 
     resp = basket_client.patch(
         reverse("basket_api"),

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -167,22 +167,18 @@ export class CheckoutPage extends React.Component<Props, State> {
       })
 
       if (basket && item.type === PRODUCT_TYPE_COURSERUN) {
-        const course = item.courses[0]
-        const selectedRun = find(propEq("id", runId), course.courseruns)
+        const selectedRun = find(
+          propEq("id", runId),
+          item.courses[0].courseruns
+        )
         if (selectedRun && selectedRun.product_id) {
-          // update basket with selected runs
           await this.updateBasket({
-            items: basket.items.map(basketItem => ({
-              id:
-                basketItem.id === item.id
-                  ? selectedRun.product_id
-                  : basketItem.id,
-              // $FlowFixMe: flow doesn't understand that Object.values will return an array of number here
-              run_ids:
-                basketItem.id === item.id
-                  ? []
-                  : Object.values(this.getSelectedRunIds(basketItem))
-            }))
+            items: [
+              {
+                id:      selectedRun.product_id,
+                run_ids: []
+              }
+            ]
           })
         }
       }

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -23,6 +23,7 @@ import type {
   CheckoutResponse,
   BasketItem
 } from "../../flow/ecommerceTypes"
+import { PRODUCT_TYPE_COURSERUN } from "../../constants"
 
 export const calcSelectedRunIds = (item: BasketItem): { [number]: number } => {
   if (item.type === "courserun") {
@@ -165,7 +166,7 @@ export class CheckoutPage extends React.Component<Props, State> {
         }
       })
 
-      if (basket && item.type === "courserun") {
+      if (basket && item.type === PRODUCT_TYPE_COURSERUN) {
         const course = item.courses[0]
         const selectedRun = find(propEq("id", runId), course.courseruns)
         if (selectedRun && selectedRun.product_id) {

--- a/static/js/factories/course.js
+++ b/static/js/factories/course.js
@@ -16,6 +16,8 @@ import type {
 } from "../flow/courseTypes"
 
 const genCourseRunId = incrementer()
+const genProductId = incrementer()
+
 export const makeCourseRun = (): CourseRun => ({
   title:            casual.text,
   start_date:       casual.moment.add(2, "M").format(),
@@ -25,7 +27,8 @@ export const makeCourseRun = (): CourseRun => ({
   courseware_url:   casual.url,
   courseware_id:    casual.word,
   // $FlowFixMe
-  id:               genCourseRunId.next().value
+  id:               genCourseRunId.next().value,
+  product_id:       genProductId.next().value
 })
 
 const genCourseId = incrementer()

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -25,12 +25,16 @@ const genBasketItemId = incrementer()
 const genNextObjectId = incrementer()
 const genProductId = incrementer()
 
-export const makeItem = (): BasketItem => {
-  const courses = range(0, 4).map(() => makeCourse())
+export const makeItem = (itemType: ?string): BasketItem => {
+  const basketItemType =
+    itemType ||
+    casual.random_element([PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM])
+  const numCourses = basketItemType === PRODUCT_TYPE_COURSERUN ? 1 : 4
+  const courses = range(0, numCourses).map(() => makeCourse())
   const runIds = courses.map(course => course.courseruns[0].id)
 
   return {
-    type:          casual.random_element([PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM]),
+    type:          basketItemType,
     courses:       courses,
     // $FlowFixMe: flow doesn't understand generators well
     id:            genBasketItemId.next().value,
@@ -51,8 +55,8 @@ export const makeCouponSelection = (item: ?BasketItem): CouponSelection => ({
   targets: item ? [item.id] : []
 })
 
-export const makeBasketResponse = (): BasketResponse => {
-  const item = makeItem()
+export const makeBasketResponse = (itemType: ?string): BasketResponse => {
+  const item = makeItem(itemType)
   return {
     items:         [item],
     coupons:       [makeCouponSelection(item)],

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -7,7 +7,8 @@ export type CourseRun = {
   enrollment_end: ?string,
   courseware_url: ?string,
   courseware_id: string,
-  id: number
+  id: number,
+  product_id: ?number
 }
 
 export type BaseCourse = {


### PR DESCRIPTION
#418 should be fixed first, this PR assumes `Product.id` and not `ProductVersion.id` is being used.

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #231 

#### What's this PR do?
Allows user to select alternate course runs on the checkout page, regardless of whether the current product is for a program or course run.

#### How should this be manually tested?
Try both `http://xpro.odl.local:80-53/checkout?product_id=<program>` and `http://xpro.odl.local:8053/checkout?product_id=<courserun>`

In each case, you should get a select list of alternate runs (if any) for the course(s).  The checkout page should work as before for programs.  For a course run, the product's course run should be selected by default.  If you switch to another course run and it has a different price, the price should update on the page.  If the coupon is no longer valid for the new course run it should disappear.


#### Screenshots (if appropriate)
![Screen Shot 2019-06-05 at 1 51 24 PM](https://user-images.githubusercontent.com/187676/58978109-2ad72680-8799-11e9-8d59-f24b000573d4.png)

![Screen Shot 2019-06-05 at 1 51 34 PM](https://user-images.githubusercontent.com/187676/58978114-2e6aad80-8799-11e9-89d6-23f613eb9222.png)



