### PR TITLE
Accept product id, not product version id, on checkout page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -747,7 +747,7 @@ class CoursePage(ProductPage):
             **super().get_context(request, **kwargs),
             **get_js_settings_context(request),
             "courseware_url": run.courseware_url if run else None,
-            "product_version_id": product_version.id
+            "product_id": product.id
             if (product_version and not is_anonymous)
             else None,
             "enrolled": enrolled,

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -14,8 +14,8 @@
           <h2>{{ page.subhead }}</h2>
         </div>
         <div class="mt-5">
-          {% if not enrolled and product_version_id %}
-            <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_version_id }}">
+          {% if not enrolled and product_id %}
+            <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_id }}">
               Enroll Now
             </a>
           {% elif enrolled and courseware_url %}

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -232,11 +232,11 @@ def test_course_view(
     else:
         run = None
     if has_product and has_unexpired_run:
-        product_version_id = ProductVersionFactory.create(
+        product_id = ProductVersionFactory.create(
             product=ProductFactory(content_object=run)
-        ).id
+        ).product.id
     else:
-        product_version_id = None
+        product_id = None
     if is_enrolled and has_unexpired_run:
         CourseRunEnrollment.objects.create(user=user, run=run)
 
@@ -246,8 +246,8 @@ def test_course_view(
     assert resp.context["course"] == course
     assert resp.context["user"] == user if not is_anonymous else AnonymousUser()
     assert resp.context["courseware_url"] == (run.courseware_url if run else None)
-    assert resp.context["product_version_id"] == (
-        product_version_id if not is_anonymous else None
+    assert resp.context["product_id"] == (
+        product_id if not is_anonymous else None
     )
     assert resp.context["enrolled"] == (
         is_enrolled and has_unexpired_run and not is_anonymous
@@ -257,7 +257,7 @@ def test_course_view(
     url = ""  # make linter happy
     if not is_anonymous:
         if not is_enrolled and has_product and has_unexpired_run:
-            url = f'{reverse("checkout-page")}?product={product_version_id}'
+            url = f'{reverse("checkout-page")}?product={product_id}'
             has_button = True
         if is_enrolled and has_unexpired_run:
             url = reverse("user-dashboard")

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -246,9 +246,7 @@ def test_course_view(
     assert resp.context["course"] == course
     assert resp.context["user"] == user if not is_anonymous else AnonymousUser()
     assert resp.context["courseware_url"] == (run.courseware_url if run else None)
-    assert resp.context["product_id"] == (
-        product_id if not is_anonymous else None
-    )
+    assert resp.context["product_id"] == (product_id if not is_anonymous else None)
     assert resp.context["enrolled"] == (
         is_enrolled and has_unexpired_run and not is_anonymous
     )

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -17,7 +17,7 @@ def get_bulk_enroll_email_context(product_coupon):
             urljoin(settings.SITE_BASE_URL, reverse("checkout-page")),
             urlencode(
                 {
-                    "product": product_coupon.product.latest_version.id,
+                    "product": product_coupon.product.id,
                     "code": product_coupon.coupon.coupon_code,
                 }
             ),

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -37,7 +37,7 @@ def test_send_bulk_enroll_emails(mocker, settings, test_company):
     )
 
     expected_qs = "product={}&code={}".format(
-        product_version.id, product_coupon.coupon.coupon_code
+        product_version.product.id, product_coupon.coupon.coupon_code
     )
     expected_context = {
         "enrollable_title": product_coupon.product.content_object.title,

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -55,8 +55,8 @@ class ProductVersionSerializer(serializers.ModelSerializer):
     """ ProductVersion serializer for viewing/updating items in basket """
 
     type = serializers.SerializerMethodField()
-    object_id = serializers.SerializerMethodField()
-    product_id = serializers.SerializerMethodField()
+    object_id = serializers.IntegerField(source="product.object_id", read_only=True)
+    product_id = serializers.IntegerField(source="product.id", read_only=True)
     courses = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -56,6 +56,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
 
     type = serializers.SerializerMethodField()
     object_id = serializers.SerializerMethodField()
+    product_id = serializers.SerializerMethodField()
     courses = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
 
@@ -66,6 +67,10 @@ class ProductVersionSerializer(serializers.ModelSerializer):
     def get_object_id(self, instance):
         """Return the object id for the product"""
         return instance.product.object_id
+
+    def get_product_id(self, instance):
+        """Return the id for the product"""
+        return instance.product.id
 
     def get_courses(self, instance):
         """ Return the courses in the product """
@@ -103,6 +108,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             "courses",
             "thumbnail_url",
             "object_id",
+            "product_id",
         ]
         model = models.ProductVersion
 
@@ -237,10 +243,10 @@ class BasketSerializer(serializers.ModelSerializer):
         return DataConsentUserSerializer(instance=data_consents, many=True).data
 
     @classmethod
-    def _get_runs_for_product(cls, *, product_version, run_ids, user):
+    def _get_runs_for_product(cls, *, product, run_ids, user):
         """Helper function to get and validate selected runs in a product"""
         runs_for_product = list(
-            product_version.product.run_queryset.filter(id__in=run_ids)
+            product.run_queryset.filter(id__in=run_ids)
         )
         run_ids_for_product = {run.id for run in runs_for_product}
 
@@ -270,50 +276,50 @@ class BasketSerializer(serializers.ModelSerializer):
             items (list of JSON objects): Basket items to update, or clear if empty list, or leave as is if None
 
         Returns:
-            tuple: ProductVersion object to assign to basket, if any, and a list of CourseRun
+            tuple: Product object to assign to basket, if any, and a list of CourseRun
 
         """
         if items:
             # Item updated
             item = items[0]
-            product_version_id = item.get("id")
+            product_id = item.get("id")
             run_ids = item.get("run_ids")
-
-            product_version = models.ProductVersion.objects.get(id=product_version_id)
+            product = models.Product.objects.get(id=product_id)
             if run_ids is not None:
                 runs = cls._get_runs_for_product(
-                    product_version=product_version, run_ids=run_ids, user=basket.user
+                    product=product, run_ids=run_ids, user=basket.user
                 )
             else:
                 runs = None
         elif items is not None:
             # Item removed
-            product_version = None
+            product = None
             runs = None
         else:
             # Item has not changed
-            product_version = latest_product_version(basket.basketitems.first().product)
+            product = basket.basketitems.first().product
             runs = list(CourseRun.objects.filter(courserunselection__basket=basket))
-        return product_version, runs
+        return product, runs
 
     @classmethod
-    def _update_coupons(cls, basket, product_version, coupons):
+    def _update_coupons(cls, basket, product, coupons):
         """
         Helper function to determine if the basket coupon should be updated, removed, or kept as is.
 
         Args:
             basket (Basket): the basket to update
-            product_version (ProductVersion): the product version coupon should apply to
+            product (Product): the product coupon should apply to
             coupons (list of JSON objects): Basket coupons to update, or clear if empty list, or leave as is if None
 
         Returns:
             CouponVersion: CouponVersion object to assign to basket, if any.
 
         """
-        if not product_version:
+        if not product:
             # No product, so clear coupon too
             return None
 
+        product_version = product.latest_version
         if coupons:
             if len(coupons) > 1:
                 raise ValidationError("Basket cannot contain more than one coupon")
@@ -360,14 +366,14 @@ class BasketSerializer(serializers.ModelSerializer):
         if items is None and coupons is None and data_consents is None:
             raise ValidationError("Invalid request")
 
-        product_version, runs = self._update_items(basket, items)
-        coupon_version = self._update_coupons(basket, product_version, coupons)
+        product, runs = self._update_items(basket, items)
+        coupon_version = self._update_coupons(basket, product, coupons)
         with transaction.atomic():
-            if product_version:
+            if product:
                 # Update basket items and coupon selection
                 basket.basketitems.all().delete()
                 models.BasketItem.objects.create(
-                    product=product_version.product, quantity=1, basket=basket
+                    product=product, quantity=1, basket=basket
                 )
 
                 if runs is not None:
@@ -401,13 +407,13 @@ class BasketSerializer(serializers.ModelSerializer):
             if len(items) > 1:
                 raise ValidationError("Basket cannot contain more than one item")
             item = items[0]
-            product_version_id = item.get("id")
+            product_id = item.get("id")
 
-            if product_version_id is None:
+            if product_id is None:
                 raise ValidationError("Invalid request")
-            if not models.ProductVersion.objects.filter(id=product_version_id).exists():
+            if not models.ProductVersion.objects.filter(product__id=product_id).exists():
                 raise ValidationError(
-                    f"Invalid product version id {product_version_id}"
+                    f"Invalid product id {product_id}"
                 )
 
         return {"items": items}

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -245,9 +245,7 @@ class BasketSerializer(serializers.ModelSerializer):
     @classmethod
     def _get_runs_for_product(cls, *, product, run_ids, user):
         """Helper function to get and validate selected runs in a product"""
-        runs_for_product = list(
-            product.run_queryset.filter(id__in=run_ids)
-        )
+        runs_for_product = list(product.run_queryset.filter(id__in=run_ids))
         run_ids_for_product = {run.id for run in runs_for_product}
 
         missing_run_ids = set(run_ids) - run_ids_for_product
@@ -411,10 +409,10 @@ class BasketSerializer(serializers.ModelSerializer):
 
             if product_id is None:
                 raise ValidationError("Invalid request")
-            if not models.ProductVersion.objects.filter(product__id=product_id).exists():
-                raise ValidationError(
-                    f"Invalid product id {product_id}"
-                )
+            if not models.ProductVersion.objects.filter(
+                product__id=product_id
+            ).exists():
+                raise ValidationError(f"Invalid product id {product_id}")
 
         return {"items": items}
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -64,14 +64,6 @@ class ProductVersionSerializer(serializers.ModelSerializer):
         """ Return the product version type """
         return instance.product.content_type.model
 
-    def get_object_id(self, instance):
-        """Return the object id for the product"""
-        return instance.product.object_id
-
-    def get_product_id(self, instance):
-        """Return the id for the product"""
-        return instance.product.id
-
     def get_courses(self, instance):
         """ Return the courses in the product """
         from courses.serializers import CourseSerializer

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -65,6 +65,7 @@ def test_serialize_basket_product_version_courserun():
         "courses": [CourseSerializer(courserun.course).data],
         "thumbnail_url": "/static/images/mit-dome.png",
         "object_id": product_version.product.object_id,
+        "product_id": product_version.product.id,
     }
 
 
@@ -85,6 +86,7 @@ def test_serialize_basket_product_version_program():
         "courses": [CourseSerializer(course).data for course in courses],
         "thumbnail_url": "/static/images/mit-dome.png",
         "object_id": product_version.product.object_id,
+        "product_id": product_version.product.id,
     }
 
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -366,7 +366,7 @@ def test_patch_basket_new_user(basket_and_coupons, user, user_drf_client):
 
 def test_patch_basket_new_item(basket_client, basket_and_coupons):
     """Test that a user can add an item to their basket"""
-    data = {"items": [{"id": basket_and_coupons.product_version.id}]}
+    data = {"items": [{"id": basket_and_coupons.product_version.product.id}]}
     BasketItem.objects.all().delete()  # clear the basket first
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
@@ -480,7 +480,7 @@ def test_patch_basket_update_valid_product_valid_coupon(
     product_version = ProductVersionFactory()
     CouponEligibilityFactory(product=product_version.product, coupon=best_coupon)
 
-    data = {"items": [{"id": product_version.id}]}
+    data = {"items": [{"id": product_version.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     resp_data = resp.json()
@@ -499,7 +499,7 @@ def test_patch_basket_update_valid_product_invalid_coupon_auto(
     product_version = ProductVersionFactory()
     CouponEligibilityFactory(product=product_version.product, coupon=auto_coupon)
 
-    data = {"items": [{"id": product_version.id}]}
+    data = {"items": [{"id": product_version.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     resp_data = resp.json()
@@ -520,7 +520,7 @@ def test_patch_basket_update_valid_product_invalid_coupon_no_auto(
         basket.couponselection_set.all().delete()
     else:
         assert basket.couponselection_set.first() is not None
-    data = {"items": [{"id": product_version.id}]}
+    data = {"items": [{"id": product_version.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     resp_data = resp.json()
@@ -537,7 +537,7 @@ def test_patch_basket_update_invalid_product(basket_client, basket_and_coupons):
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     resp_data = resp.json()
     assert (
-        "Invalid product version id {}".format(bad_id) in resp_data["errors"]["items"]
+        "Invalid product id {}".format(bad_id) in resp_data["errors"]["items"]
     )
 
 
@@ -590,7 +590,7 @@ def test_patch_basket_update_runs(basket_client, basket_and_coupons, add_new_run
         data={
             "items": [
                 {
-                    "id": product_version.id,
+                    "id": product.id,
                     "run_ids": [run1.id, run2.id] if add_new_runs else [],
                 }
             ]
@@ -625,7 +625,7 @@ def test_patch_basket_invalid_run(basket_client, basket_and_coupons, is_program)
     resp = basket_client.patch(
         reverse("basket_api"),
         type="json",
-        data={"items": [{"id": product_version.id, "run_ids": [other_run.id]}]},
+        data={"items": [{"id": product.id, "run_ids": [other_run.id]}]},
     )
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.json()["errors"] == [
@@ -655,7 +655,7 @@ def test_patch_basket_multiple_runs(
     resp = basket_client.patch(
         reverse("basket_api"),
         type="json",
-        data={"items": [{"id": product_version.id, "run_ids": [run1.id, run2.id]}]},
+        data={"items": [{"id": product.id, "run_ids": [run1.id, run2.id]}]},
     )
     if multiple_for_program:
         assert resp.status_code == status.HTTP_200_OK
@@ -680,7 +680,7 @@ def test_patch_basket_already_enrolled(basket_client, basket_and_coupons):
         type="json",
         data={
             "items": [
-                {"id": basket_and_coupons.product_version.id, "run_ids": [run.id]}
+                {"id": basket_and_coupons.product_version.product.id, "run_ids": [run.id]}
             ]
         },
     )
@@ -699,7 +699,7 @@ def test_patch_basket__another_user_enrolled(basket_client, basket_and_coupons):
         type="json",
         data={
             "items": [
-                {"id": basket_and_coupons.product_version.id, "run_ids": [run.id]}
+                {"id": basket_and_coupons.product_version.product.id, "run_ids": [run.id]}
             ]
         },
     )

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -536,9 +536,7 @@ def test_patch_basket_update_invalid_product(basket_client, basket_and_coupons):
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     resp_data = resp.json()
-    assert (
-        "Invalid product id {}".format(bad_id) in resp_data["errors"]["items"]
-    )
+    assert "Invalid product id {}".format(bad_id) in resp_data["errors"]["items"]
 
 
 @pytest.mark.parametrize("section", ["items", "coupons"])
@@ -680,7 +678,10 @@ def test_patch_basket_already_enrolled(basket_client, basket_and_coupons):
         type="json",
         data={
             "items": [
-                {"id": basket_and_coupons.product_version.product.id, "run_ids": [run.id]}
+                {
+                    "id": basket_and_coupons.product_version.product.id,
+                    "run_ids": [run.id],
+                }
             ]
         },
     )
@@ -699,7 +700,10 @@ def test_patch_basket__another_user_enrolled(basket_client, basket_and_coupons):
         type="json",
         data={
             "items": [
-                {"id": basket_and_coupons.product_version.product.id, "run_ids": [run.id]}
+                {
+                    "id": basket_and_coupons.product_version.product.id,
+                    "run_ids": [run.id],
+                }
             ]
         },
     )

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -127,7 +127,7 @@ export class CheckoutPage extends React.Component<Props, State> {
     // update basket with selected runs
     await this.updateBasket({
       items: basket.items.map(item => ({
-        id:      item.id,
+        id:      item.product_id,
         // $FlowFixMe: flow doesn't understand that Object.values will return an array of number here
         run_ids: Object.values(this.getSelectedRunIds(item))
       }))

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -375,7 +375,7 @@ describe("CheckoutPage", () => {
       body: {
         items: [
           {
-            id:      basketItem.id,
+            id:      basketItem.product_id,
             run_ids: Object.values(
               inner.instance().getSelectedRunIds(basketItem)
             )
@@ -412,7 +412,7 @@ describe("CheckoutPage", () => {
       body: {
         items: [
           {
-            id:      basketItem.id,
+            id:      basketItem.product_id,
             run_ids: Object.values(
               inner.instance().getSelectedRunIds(basketItem)
             )

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -23,6 +23,7 @@ import {
 
 const genBasketItemId = incrementer()
 const genNextObjectId = incrementer()
+const genProductId = incrementer()
 
 export const makeItem = (): BasketItem => {
   const courses = range(0, 4).map(() => makeCourse())
@@ -38,7 +39,9 @@ export const makeItem = (): BasketItem => {
     thumbnail_url: casual.url,
     run_ids:       runIds,
     // $FlowFixMe: flow doesn't understand generators well
-    object_id:     genNextObjectId.next().value
+    object_id:     genNextObjectId.next().value,
+    // $FlowFixMe: flow doesn't understand generators well
+    product_id:    genProductId.next().value
   }
 }
 
@@ -57,7 +60,6 @@ export const makeBasketResponse = (): BasketResponse => {
   }
 }
 
-const genProductId = incrementer()
 export const makeProduct = (
   productType: string = PRODUCT_TYPE_COURSERUN
 ): Product => ({

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -34,6 +34,7 @@ export type BasketItem = {
   price: string,
   description: string,
   object_id: number,
+  product_id: number,
   id: number,
   run_ids: Array<number>,
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #418

#### What's this PR do?
Updates serializers and checkout page to accept Product id instead of ProductVersion id in parameters.

#### How should this be manually tested?
Try URL `http://xpro.odl.local:8053/checkout/?product=<courserun_product_id>`.  It should display the correct course run on the page, and you should be able to purchase it.
Try URL `http://xpro.odl.local:8053/checkout/?product=<program_product_id>`.  It should display the correct program on the page, and you should be able to select a course run for each course in the program and purchase the program.
Go to a courserun or program CMS page and click the enroll link, it should use the product id and not the product_version id.
