### PR TITLE
update styling of metadata tiles

### DIFF
--- a/static/scss/detail/tiles.scss
+++ b/static/scss/detail/tiles.scss
@@ -20,6 +20,9 @@
   padding: 0 7px;
   list-style: none;
   text-align: center;
+  @include media-breakpoint-up(lg) {
+    display: flex;
+  }
 
   li {
     letter-spacing: normal;
@@ -61,19 +64,19 @@
 
   .text {
     display: block;
-    font-size: 48px;
+    font-size: 40px;
     line-height: 50px;
     color: $light-gray;
     font-weight: 600;
     text-align: center;
 
     @include media-breakpoint-up(lg) {
-      font-size: 38px;
+      font-size: 30px;
       line-height: 50px;
     }
 
     @include media-breakpoint-up(xl) {
-      font-size: 48px;
+      font-size: 40px;
       line-height: 50px;
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #463 

#### What's this PR do?
Update styling of metadata tiles.

#### How should this be manually tested?
View course or program page.

#### Screenshots (if appropriate)
**Desktop**
<img width="1255" alt="Screen Shot 2019-06-10 at 2 44 13 PM" src="https://user-images.githubusercontent.com/4245618/59187494-03b09880-8b8f-11e9-836a-d0f288063aba.png">

**Mobile**
<img width="592" alt="Screen Shot 2019-06-10 at 2 52 15 PM" src="https://user-images.githubusercontent.com/4245618/59187592-365a9100-8b8f-11e9-8af8-462880dab000.png">

