### PR TITLE
#499 Clicking on Continue Reading Leads to 404

### DIFF
--- a/static/js/courseware_carousel.js
+++ b/static/js/courseware_carousel.js
@@ -31,7 +31,7 @@ $(".course-slider").slick({
   ]
 });
 
-$(".slide").on("click", function() {
+$(".course-slider .slide").on("click", function() {
   const targetUrl = $(this).data("url");
   window.location.href = targetUrl;
 });


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #499 

#### What's this PR do?
Narrows the scope of click listener in courseware carousel to react only to clicks in the courseware carousel, not to react to clicks on any other carousel.

#### How should this be manually tested?
Go to any page that has the courseware carousel and any other carousel. The courseware carousel cards should be clickable and navigate to the detail page. Other carousel cards should not be clickable and function as expected.