### PR TITLE
#447 Disable infinite scroll on carousels

### DIFF
--- a/static/js/courseware_carousel.js
+++ b/static/js/courseware_carousel.js
@@ -4,7 +4,7 @@ $(".course-slider").slick({
   slidesToShow:   3,
   slidesToScroll: 1,
   dots:           false,
-  infinite:       true,
+  infinite:       false,
   autoplay:       false,
   responsive:     [
     {

--- a/static/js/faculty_carousel.js
+++ b/static/js/faculty_carousel.js
@@ -12,7 +12,7 @@ $(".faculty-slider").slick({
       settings:   {
         slidesToShow:   3,
         slidesToScroll: 3,
-        infinite:       true,
+        infinite:       false,
         dots:           true
       }
     },

--- a/static/js/home_page.js
+++ b/static/js/home_page.js
@@ -4,8 +4,8 @@ $(".logos-slider").slick({
   slidesToShow:   6,
   slidesToScroll: 3,
   dots:           true,
-  infinite:       true,
-  autoplay:       true,
+  infinite:       false,
+  autoplay:       false,
   autoplaySpeed:  2000,
   responsive:     [
     {

--- a/static/js/testimonials_carousel.js
+++ b/static/js/testimonials_carousel.js
@@ -12,7 +12,7 @@ $(".learners-slider").slick({
       settings:   {
         slidesToShow:   3,
         slidesToScroll: 3,
-        infinite:       true,
+        infinite:       false,
         dots:           true
       }
     },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #447

#### What's this PR do?
Switches `infinite` property to `false` on carousel settings that were missed in a previous PR.

#### How should this be manually tested?
Go to any carousel, try to scroll past the content in either direction. The slider should not wrap around and start from the beginning. It should end scroll at the end of the content.