### PR TITLE
#448 Courseware: space between text/"view detail"

### DIFF
--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -9,7 +9,7 @@
         <img src="{% static 'images/mit-dome.png' %}" alt="{{ courseware_page.title }}">
       {% endif %}
       <a class="title">{{ courseware_page.title }}</a>
-      <p class="pb-2">{{ courseware_page.subhead }}</p>
+      <p>{{ courseware_page.subhead }}</p>
       <a href="{% pageurl courseware_page %}" class="read-more text-uppercase">view detail</a>
     </div>
   </div>

--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -9,8 +9,8 @@
         <img src="{% static 'images/mit-dome.png' %}" alt="{{ courseware_page.title }}">
       {% endif %}
       <a class="title">{{ courseware_page.title }}</a>
-      <p>{{ courseware_page.subhead }}</p>
-      <a href="{% pageurl courseware_page %}" class="read-more text-uppercase mt-2 mb-2">view detail</a>
+      <p class="pb-2">{{ courseware_page.subhead }}</p>
+      <a href="{% pageurl courseware_page %}" class="read-more text-uppercase">view detail</a>
     </div>
   </div>
 {% endfor %}

--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -10,7 +10,7 @@
       {% endif %}
       <a class="title">{{ courseware_page.title }}</a>
       <p>{{ courseware_page.subhead }}</p>
-      <a href="{% pageurl courseware_page %}" class="read-more text-uppercase">view detail</a>
+      <a href="{% pageurl courseware_page %}" class="detail-link text-uppercase">view detail</a>
     </div>
   </div>
 {% endfor %}

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 <div id="faculty" class="faculty-block">
   <div class="container">
     <div class="head">
@@ -13,7 +13,7 @@
             <img src="{{ faculty_image.url }}" alt="{{ member.value.name }}">
             <h2>{{ member.value.name }}</h2>
             <div class="text-holder">
-              {{ member.value.description|safe }}
+              {{ member.value.description|richtext }}
             </div>
           </div>
         </div>

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -104,16 +104,14 @@
     text-align: start;
   }
 
-  .read-more {
+  .detail-link {
     position: absolute;
     bottom: 20px;
     left: 15px;
     font-size: 18px;
     line-height: 24px;
-    display: inline-block;
-    vertical-align: top;
     font-weight: 600;
-    color: $blue;
+    color: $primary;
 
     &:after {
       content: "\e902";

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -100,6 +100,7 @@
   p {
     margin: 0 0 10px;
     min-height: 89px;
+    color: $light-gray;
   }
 
   .read-more {

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -105,6 +105,7 @@
   .read-more {
     position: absolute;
     bottom: 5px;
+    left: 15px;
     font-size: 18px;
     line-height: 24px;
     display: inline-block;

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -99,9 +99,9 @@
   p {
     margin: 0 0 10px;
     min-height: 89px;
-    color: $light-gray;
     padding-bottom: 40px;
     padding-top: 20px;
+    text-align: start;
   }
 
   .read-more {

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -94,7 +94,6 @@
     font-weight: 500;
     margin: 0 0 20px;
     line-height: 30px;
-    color: black;
   }
 
   p {
@@ -102,6 +101,7 @@
     min-height: 89px;
     color: $light-gray;
     padding-bottom: 40px;
+    padding-top: 20px;
   }
 
   .read-more {

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -101,18 +101,19 @@
     margin: 0 0 10px;
     min-height: 89px;
     color: $light-gray;
+    padding-bottom: 40px;
   }
 
   .read-more {
     position: absolute;
-    bottom: 5px;
+    bottom: 20px;
     left: 15px;
     font-size: 18px;
     line-height: 24px;
     display: inline-block;
     vertical-align: top;
     font-weight: 600;
-    color: $primary;
+    color: $blue;
 
     &:after {
       content: "\e902";

--- a/static/scss/detail/faculty.scss
+++ b/static/scss/detail/faculty.scss
@@ -86,6 +86,7 @@
     overflow-y: auto;
     height: 78px;
     padding: 0 10px;
+    word-wrap: break-word;
   }
 
   p {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested
#### What are the relevant tickets?
Closes #448 

#### What's this PR do?
Fixes padding issues in courseware carousel that appear for very long product subheads.

#### How should this be manually tested?
Add a course/program to a courseware carousel with the maximum length subhead. View this carousel. There should be ample space between the description text and the "View Detail" button.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-12 07-40-41](https://user-images.githubusercontent.com/45350418/59319858-a3803a80-8ce5-11e9-8288-05b5c5ffc6e8.png)
![Screenshot from 2019-06-12 07-39-57](https://user-images.githubusercontent.com/45350418/59319864-a713c180-8ce5-11e9-8a6f-fd2691c70a7c.png)
