### PR TITLE
#504 Enroll Now Button Overlapped

### DIFF
--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -13,7 +13,7 @@
           <h1>{{ page.title }}</h1>
           <h2>{{ page.subhead }}</h2>
         </div>
-        <div class="mt-5">
+        <div class="mt-5 mb-5">
           {% if not enrolled and product_id %}
             <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_id }}">
               Enroll Now


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#504 

#### What's this PR do?
Fixes bottom margins on the "Enroll Now" button so it doesn't get overlapped by video on product detail pages.

#### How should this be manually tested?
Go to any product detail page that has video configured (view in mobile device width). The "Enroll Now" button should appear with proper margins and it should not be overlapped by video as shown in the ticket.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-12 08-21-53](https://user-images.githubusercontent.com/45350418/59321436-70d94080-8ceb-11e9-8d39-e19ce04c103d.png)
