### PR TITLE
#469 Testimonial Carousel Read More Link

### DIFF
--- a/cms/templates/partials/testimonial-carousel.html
+++ b/cms/templates/partials/testimonial-carousel.html
@@ -14,7 +14,9 @@
           {% endif %}
           <h2>{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>
           <p>{{ testimonial.value.quote|truncatechars:150 }}</p>
-          <a data-toggle="modal" href="#testimonial-{{ forloop.counter }}" class="read-more">Continue Reading</a>
+            {% if testimonial.value.quote|length > 150 %}
+              <a data-toggle="modal" href="#testimonial-{{ forloop.counter }}" class="read-more">Continue Reading</a>
+            {% endif %}
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #469 

#### What's this PR do?
Modifies the testimonial carousel to not show the "continue reading" link if the testimonial content is less than truncation length (150 characters).

#### How should this be manually tested?
Add/Modify a testimonial to be less than/equal to 150 characters. View the relevant page on the website. The carousel should not display "continue reading" link for any of the testimonials with content up to 150 characters in length.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-12 09-59-12](https://user-images.githubusercontent.com/45350418/59324693-763d8780-8cf9-11e9-932c-3267b9546fac.png)
![Screenshot from 2019-06-12 10-00-23](https://user-images.githubusercontent.com/45350418/59324697-79387800-8cf9-11e9-915a-e4e619710870.png)
