### PR TITLE
#472 Program Page: don't show "view full program"

### DIFF
--- a/cms/templates/partials/course-carousel.html
+++ b/cms/templates/partials/course-carousel.html
@@ -13,7 +13,7 @@
       {% endif  %}
     </div>
     {% if button_title and button_url %}
-      <a href="{{ button_url }}" target="_blank" class="btn btn-primary px-5">{{ button_title }}</a>
+      <a href="{{ button_url }}" class="btn btn-primary px-5">{{ button_title }}</a>
     {% endif %}
   </div>
 </div>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -52,9 +52,13 @@
     {% if page.testimonials %} {% include "partials/testimonial-carousel.html" with page=page.testimonials %} {% endif %}
     {% if page.faculty %} {% include "partials/faculty-carousel.html" with page=page.faculty %} {% endif %}
     {% if page.course_lineup and page.course_pages %}
-      {% with program_page=page.program_page courseware_pages=page.course_pages page=page.course_lineup %}
+      {% with program_page=page.program_page courseware_pages=page.course_pages %}
         {% pageurl program_page as program_url %}
-        {% include "partials/course-carousel.html" with button_title="View Full Program" button_url=program_url %}
+        {% if page.program %}
+          {% include "partials/course-carousel.html" with page=page.course_lineup %}
+        {% else %}
+          {% include "partials/course-carousel.html" with page=page.course_lineup button_title="View Full Program" button_url=program_url %}
+        {% endif %}
       {% endwith %}
     {% endif %}
     {% if page.for_teams %} {% include "partials/for-teams.html" with page=page.for_teams %} {% endif %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #472 

#### What's this PR do?
Modifies product detail page to not show the "view full program" button in courseware carousel when it is on the program page as it just links to itself.

#### How should this be manually tested?
Visit a course page and then a program page. The "view full program" button should appear in the courseware carousel on the course page but not on the program page.

#### Screenshots (if appropriate)
Course Page
![Screenshot from 2019-06-12 10-20-01](https://user-images.githubusercontent.com/45350418/59325291-ed741b00-8cfb-11e9-82e9-cfb0b96dcabf.png)



Program Page
![Screenshot from 2019-06-12 10-20-25](https://user-images.githubusercontent.com/45350418/59325300-f238cf00-8cfb-11e9-8c33-947b63464585.png)
