### PR TITLE
#470 Product page: Subnav scroll fix

### DIFF
--- a/static/js/course_detail.js
+++ b/static/js/course_detail.js
@@ -20,8 +20,13 @@ $(document).ready(function() {
       </div>'
   });
 
+  const navbar = $("#subNavBarContainer");
+
   // Navigation Bar
-  $("body").scrollspy({ target: "#subNavBar", offset: 70 });
+  $("body").scrollspy({
+    target: "#subNavBar",
+    offset: navbar.outerHeight() + 5.0
+  });
 
   $(window).on("activate.bs.scrollspy", function(e, obj) {
     $("#subNavBarSelector").text(
@@ -29,7 +34,13 @@ $(document).ready(function() {
     );
   });
 
-  $(".navbar-nav>li>a").on("click", function() {
+  $(".navbar-nav>li>a").on("click", function(event) {
+    event.preventDefault();
+
+    const target = $($(this).attr("href"));
+
+    window.scrollTo(0, target.offset().top - navbar.outerHeight());
+
     $(".navbar-collapse.show").removeClass("show");
     $(".navbar-toggler").addClass("collapsed");
   });


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#470

#### What's this PR do?
Modifies subnav scrolling to take into account of the navbar's own height while scrolling so content is not hidden behind the navbar (typically the heading of the section scrolled to).

#### How should this be manually tested?
On the product page, use the navbar to scroll to different sections. The page should scroll right up to the top of the section with the heading of the section not overlapped by the navbar.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-12 12-31-29](https://user-images.githubusercontent.com/45350418/59331833-4b116300-8d0e-11e9-9ed7-2214a35bc574.png)

![Screenshot from 2019-06-12 12-31-01](https://user-images.githubusercontent.com/45350418/59331843-4ea4ea00-8d0e-11e9-9688-8ef10c1a4a49.png)
