### PR TITLE
#510 Courseware carousel links not working

### DIFF
--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -8,7 +8,7 @@
       {% else %}
         <img src="{% static 'images/mit-dome.png' %}" alt="{{ courseware_page.title }}">
       {% endif %}
-      <a class="title">{{ courseware_page.title }}</a>
+      <a class="title" href="{% pageurl courseware_page %}">{{ courseware_page.title }}</a>
       <p>{{ courseware_page.subhead }}</p>
       <a href="{% pageurl courseware_page %}" class="read-more text-uppercase mt-2 mb-2">view detail</a>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #510 

#### What's this PR do?
Adds the missing `href` attribute to title anchor in courseware carousel cards.

#### How should this be manually tested?
Go to any page with a courseware carousel. Click on the title link, it should take you to the correct page.
