### PR TITLE
Exclude expired and enrolled runs from courserun dropdowns

### DIFF
--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -13,11 +13,6 @@ from courses.factories import (
 # pylint: disable=redefined-outer-name
 
 
-def run_id(run):
-    """ Function for sorting runs by id"""
-    return run.id
-
-
 @pytest.mark.django_db
 def test_get_user_enrollments(user):
     """Test that get_user_enrollments returns an object with a user's program and course enrollments"""
@@ -30,15 +25,19 @@ def test_get_user_enrollments(user):
     )
     program_enrollment = ProgramEnrollmentFactory.create(program=program, user=user)
 
+    def key_func(_run):
+        """ Function for sorting runs by id"""
+        return _run.id
+
     user_enrollments = get_user_enrollments(user)
     assert list(user_enrollments.programs) == [program_enrollment]
-    assert list(user_enrollments.program_runs).sort(key=run_id) == [
+    assert sorted(list(user_enrollments.program_runs), key=key_func) == sorted([
         run_enrollment
         for run_enrollment in course_run_enrollments
         if run_enrollment.run in program_course_runs
-    ].sort(key=run_id)
-    assert list(user_enrollments.non_program_runs).sort(key=run_id) == [
+    ], key=key_func)
+    assert sorted(list(user_enrollments.non_program_runs), key=key_func) == sorted([
         run_enrollment
         for run_enrollment in course_run_enrollments
         if run_enrollment.run in non_program_course_runs
-    ].sort(key=run_id)
+    ], key=key_func)

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -13,6 +13,11 @@ from courses.factories import (
 # pylint: disable=redefined-outer-name
 
 
+def run_id(run):
+    """ Function for sorting runs by id"""
+    return run.id
+
+
 @pytest.mark.django_db
 def test_get_user_enrollments(user):
     """Test that get_user_enrollments returns an object with a user's program and course enrollments"""
@@ -27,13 +32,13 @@ def test_get_user_enrollments(user):
 
     user_enrollments = get_user_enrollments(user)
     assert list(user_enrollments.programs) == [program_enrollment]
-    assert list(user_enrollments.program_runs) == [
+    assert list(user_enrollments.program_runs).sort(key=run_id) == [
         run_enrollment
         for run_enrollment in course_run_enrollments
         if run_enrollment.run in program_course_runs
-    ]
-    assert list(user_enrollments.non_program_runs) == [
+    ].sort(key=run_id)
+    assert list(user_enrollments.non_program_runs).sort(key=run_id) == [
         run_enrollment
         for run_enrollment in course_run_enrollments
         if run_enrollment.run in non_program_course_runs
-    ]
+    ].sort(key=run_id)

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -31,13 +31,19 @@ def test_get_user_enrollments(user):
 
     user_enrollments = get_user_enrollments(user)
     assert list(user_enrollments.programs) == [program_enrollment]
-    assert sorted(list(user_enrollments.program_runs), key=key_func) == sorted([
-        run_enrollment
-        for run_enrollment in course_run_enrollments
-        if run_enrollment.run in program_course_runs
-    ], key=key_func)
-    assert sorted(list(user_enrollments.non_program_runs), key=key_func) == sorted([
-        run_enrollment
-        for run_enrollment in course_run_enrollments
-        if run_enrollment.run in non_program_course_runs
-    ], key=key_func)
+    assert sorted(list(user_enrollments.program_runs), key=key_func) == sorted(
+        [
+            run_enrollment
+            for run_enrollment in course_run_enrollments
+            if run_enrollment.run in program_course_runs
+        ],
+        key=key_func,
+    )
+    assert sorted(list(user_enrollments.non_program_runs), key=key_func) == sorted(
+        [
+            run_enrollment
+            for run_enrollment in course_run_enrollments
+            if run_enrollment.run in non_program_course_runs
+        ],
+        key=key_func,
+    )

--- a/courses/models.py
+++ b/courses/models.py
@@ -202,6 +202,20 @@ class Course(TimestampedModel, PageProperties):
             )
         )
 
+    def available_runs(self, user):
+        """
+        Get all unexpired and unenrolled runs for a Course
+
+        Args:
+            user (users.models.User): The user to check available runs for.
+
+        Returns:
+            list of CourseRun: Unexpired and unenrolled Course runs
+
+        """
+        enrolled_runs = user.courserunenrollment_set.filter(run__course=self)
+        return [run for run in self.unexpired_runs if run not in enrolled_runs]
+
     class Meta:
         ordering = ("program", "title")
 

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -95,11 +95,8 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_courseruns(self, instance):
         """Unexpired and unenrolled course runs"""
-        if hasattr(self.context.get("request"), "user"):
-            user = self.context["request"].user
-            active_runs = instance.available_runs(user)
-        else:
-            active_runs = instance.unexpired_runs
+        user = self.context["request"].user
+        active_runs = instance.available_runs(user)
         return [CourseRunSerializer(instance=run).data for run in active_runs]
 
     class Meta:

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -104,7 +104,7 @@ def test_serialize_course(mocker, with_runs, with_request_user):
         enrollment.delete()
         course.courseruns.all().delete()
     page = CoursePageFactory.create(course=course)
-    course_serializer = CourseSerializer(instance=course, context=context)
+    data = CourseSerializer(instance=course, context=context).data
 
     expected_runs = []
     if with_runs:
@@ -113,7 +113,7 @@ def test_serialize_course(mocker, with_runs, with_request_user):
             expected_runs.append(enrolled_run)
     expected_runs.sort(key=lambda run: run.start_date)
 
-    assert course_serializer.data == {
+    assert data == {
         "title": course.title,
         "description": page.description,
         "readable_id": course.readable_id,

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -102,27 +102,29 @@ def test_delete_program(user_drf_client, programs):
     assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_get_courses(user_drf_client, courses):
+def test_get_courses(user_drf_client, courses, mock_context):
     """Test the view that handles requests for all Courses"""
     resp = user_drf_client.get(reverse("courses_api-list"))
     courses_data = resp.json()
     assert len(courses_data) == len(courses)
     for course, course_data in zip(courses, courses_data):
-        assert course_data == CourseSerializer(course).data
+        assert (
+            course_data == CourseSerializer(instance=course, context=mock_context).data
+        )
 
 
-def test_get_course(user_drf_client, courses):
+def test_get_course(user_drf_client, courses, mock_context):
     """Test the view that handles a request for single Course"""
     course = courses[0]
     resp = user_drf_client.get(reverse("courses_api-detail", kwargs={"pk": course.id}))
     course_data = resp.json()
-    assert course_data == CourseSerializer(course).data
+    assert course_data == CourseSerializer(instance=course, context=mock_context).data
 
 
-def test_create_course(user_drf_client, courses):
+def test_create_course(user_drf_client, courses, mock_context):
     """Test the view that handles a request to create a Course"""
     course = courses[0]
-    course_data = CourseSerializer(course).data
+    course_data = CourseSerializer(instance=course, context=mock_context).data
     del course_data["id"]
     course_data["title"] = "New Course Title"
     request_url = reverse("courses_api-list")

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -78,7 +78,9 @@ class ProductVersionSerializer(serializers.ModelSerializer):
         else:
             raise ValueError(f"Unexpected product for {model_class}")
 
-        return [CourseSerializer(course, context=self.context).data for course in courses]
+        return [
+            CourseSerializer(course, context=self.context).data for course in courses
+        ]
 
     def get_thumbnail_url(self, instance):
         """Return the thumbnail for the courserun or program"""
@@ -181,8 +183,7 @@ class BasketSerializer(serializers.ModelSerializer):
         return [
             {
                 **ProductVersionSerializer(
-                    instance=latest_product_version(item.product),
-                    context=self.context
+                    instance=latest_product_version(item.product), context=self.context
                 ).data,
                 "run_ids": list(
                     models.CourseRunSelection.objects.filter(

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -78,7 +78,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
         else:
             raise ValueError(f"Unexpected product for {model_class}")
 
-        return [CourseSerializer(course).data for course in courses]
+        return [CourseSerializer(course, context=self.context).data for course in courses]
 
     def get_thumbnail_url(self, instance):
         """Return the thumbnail for the courserun or program"""
@@ -181,7 +181,8 @@ class BasketSerializer(serializers.ModelSerializer):
         return [
             {
                 **ProductVersionSerializer(
-                    instance=latest_product_version(item.product)
+                    instance=latest_product_version(item.product),
+                    context=self.context
                 ).data,
                 "run_ids": list(
                     models.CourseRunSelection.objects.filter(

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -44,3 +44,9 @@ def mocked_responses():
     """Mocked responses for requests library"""
     with responses.RequestsMock() as rsps:
         yield rsps
+
+
+@pytest.fixture
+def mock_context(mocker, user):
+    """Mocked context for serializers"""
+    return {"request": mocker.Mock(user=user)}


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #422

#### What's this PR do?
- Modifies `CourseSerializer` to filter out runs that are no longer enrollable, and (if a request user is in the serializer context) course runs that the user is already enrolled in.
- Modifies `BucketSerializer` to pass on its context to `ProductVersionSerializer` and then on to `CourseSerializer`
- Modifies `CourseRun.is_not_beyond_enrollment` to also consider `enrollment_start`.

#### How should this be manually tested?
- Create 5+ runs for a course.  One run should have an `enrollment_start` date in the future, one should have an `enrollment_end` date in the past, one should have an `end_date` in the past, two should have some combination of null dates or real dates that should make it enrollable.
- Create `Product` and `ProductVersion` for each run.
- Go to the checkout page with one of the valid runs in your basket (`?product=<product_id>`).  The dropdown should show only the runs with valid dates.
- Enroll in one of them.
- Go back to the checkout page for the same course run product.  The dropdown should show other valid runs but not the run you just enrolled in.
- Try to go to the checkout page for an expired course run product.  The dropdown should show other valid runs for the course but not the expired run.
