### PR TITLE
#468 Footer links should not spawn new tab

### DIFF
--- a/mitxpro/templates/footer.html
+++ b/mitxpro/templates/footer.html
@@ -8,7 +8,7 @@
                     <div class="col-sm-6 clearfix">
                         <img src={% static 'images/help.png' %}>
                         <div class="info">
-                            <a href="https://xpro.zendesk.com" target="_blank">
+                            <a href="https://xpro.zendesk.com">
                                 <h2>Help & FAQ</h2>
                             </a>
                             <p>Answers to our most frequently asked questions are just one click away.</p>
@@ -17,7 +17,7 @@
                     <div class="col-sm-6 clearfix">
                         <img src={% static 'images/contact.png' %}>
                         <div class="info">
-                            <a href="https://xpro.zendesk.com/hc/en-us/requests/new" target="_blank">
+                            <a href="https://xpro.zendesk.com/hc/en-us/requests/new">
                                 <h2>Contact Us</h2>
                             </a>
                             <p>Get in touch with someone from our sales department to assist with your inquiry.</p>
@@ -37,8 +37,8 @@
             </div>
             <div class="right-info">
                 <ul class="footer-nav">
-                    <li><a href="/about-us/" target="_blank">About Us</a></li>
-                    <li><a href="/blog/" target="_blank">Blog</a></li>
+                    <li><a href="/about-us/">About Us</a></li>
+                    <li><a href="/blog/">Blog</a></li>
                 </ul>
                 <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
                 <![endif]-->
@@ -52,9 +52,9 @@
             </div>
         </div>
         <ul class="footer-sub-nav">
-            <li><a href="/terms-of-service/" target="_blank">Terms of Service</a></li>
-            <li><a href="/privacy-policy/" target="_blank">Privacy Policy</a></li>
-            <li><a href="/honor-code/" target="_blank">Honor Code</a></li>
+            <li><a href="/terms-of-service/">Terms of Service</a></li>
+            <li><a href="/privacy-policy/">Privacy Policy</a></li>
+            <li><a href="/honor-code/">Honor Code</a></li>
         </ul>
         <span class="copyright">© 2019 All rights reserved. <a href="#">MIT xPRO</a>.</span>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested
#### What are the relevant tickets?
Fixes #468 

#### What's this PR do?
Modifies footer links to disable redirecting to page in a new tab. Now links open in the current tab.

#### How should this be manually tested?
Click on any link in the footer. The browser should be redirected in the currently open tab, not in a new tab.