### PR TITLE
#466 Catalog: display popover on tab hover

### DIFF
--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -9,6 +9,11 @@
   {% render_bundle 'header' %}
 {% endblock %}
 
+{% block scripts %}
+  {{ block.super }}
+  <script src="{% static 'js/tooltip.js' %}"></script>
+{% endblock %}
+
 {% block content %}
   <div class="course-catalog">
     {% block banner %}
@@ -25,10 +30,10 @@
               <li class="nav-item">
                 <a class="nav-link active" id="all-tab" data-toggle="tab" href="#all" role="tab" aria-controls="all" aria-selected="true">All</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item" data-toggle="tooltip" title="Multi-course offerings" data-trigger="hover" data-placement="auto">
                 <a id="programs-tab" class="nav-link" data-toggle="tab" href="#programs" role="tab" aria-controls="programs" aria-selected="false">programs</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item" data-toggle="tooltip" title="Single course offerings" data-trigger="hover" data-placement="auto">
                 <a class="nav-link" data-toggle="tab" id="courses-tab" href="#courses" role="tab" aria-controls="courses" aria-selected="false">Courses</a>
               </li>
             </ul>

--- a/static/js/tooltip.js
+++ b/static/js/tooltip.js
@@ -1,0 +1,6 @@
+/*eslint-env jquery*/
+/*eslint semi: ["error", "always"]*/
+// This method simply initializes all tooltips on the page if they exist.
+$(function() {
+  $('[data-toggle="tooltip"]').tooltip();
+});

--- a/static/scss/catalog/tabs.scss
+++ b/static/scss/catalog/tabs.scss
@@ -1,5 +1,31 @@
 // sass-lint:disable mixins-before-declarations
 
+.tooltip {
+  .tooltip-inner {
+    box-shadow: 0 0.05rem 0.55rem 0.1rem rgba(0, 0, 0, 0.25);
+    color: black;
+    background-color: $gray-bg;
+    font-size: 18px;
+    font-weight: 500;
+    padding: 0.25rem 0.75rem;
+    max-width: 300px;
+  }
+
+  $combinations: ("left", 2px, 0px) ("top", 0px, 2px) ("right", -2px, 0px) ("bottom", 0px, -2px);
+
+  @each $position, $h-offset, $v-offset in $combinations {
+    &.bs-tooltip-#{$position} {
+      .arrow {
+        filter: drop-shadow($h-offset $v-offset 1px rgba(0, 0, 0, 0.125));
+      }
+
+      .arrow::before {
+        border-#{$position}-color: $gray-bg;
+      }
+    }
+  }
+}
+
 .tab-block {
   width: 100%;
   padding: 0 0 75px;
@@ -12,7 +38,7 @@
     left: 0;
     top: 40px;
     right: 0;
-    content: '';
+    content: "";
     height: 360px;
     background: linear-gradient(to top, $gray-85, $tile-background);
   }
@@ -35,7 +61,7 @@
     text-align: center;
     border: none;
     display: block;
-    letter-spacing: -.32em;
+    letter-spacing: -0.32em;
     position: relative;
     z-index: 2;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#466 

#### What's this PR do?
Adds a hover popover to catalog tabs for programs and courses.

#### How should this be manually tested?
On catalog page, hover on the programs tab and courses tab. Respective tooltip should be visible.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-13 08-08-21](https://user-images.githubusercontent.com/45350418/59400984-a2690f00-8db2-11e9-8749-41a217943cd0.png)
![Screenshot from 2019-06-13 08-07-56](https://user-images.githubusercontent.com/45350418/59400992-a72dc300-8db2-11e9-9bdf-4ccb2b2e3caa.png)
