### PR TITLE
replace aqua color to more darker color

### DIFF
--- a/static/scss/catalog/keep-me-posted.scss
+++ b/static/scss/catalog/keep-me-posted.scss
@@ -146,7 +146,7 @@
 
 .submitted-message {
   margin-left: 200px;
-  color: $blue;
+  color: white;
   font-family: Rajdhani;
   font-size: 24px;
   font-weight: 600;

--- a/static/scss/detail/for-teams.scss
+++ b/static/scss/detail/for-teams.scss
@@ -90,6 +90,6 @@
   color: white;
 
   h1 {
-    color: $blue;
+    color: white;
   }
 }

--- a/static/scss/detail/text-video-section.scss
+++ b/static/scss/detail/text-video-section.scss
@@ -50,7 +50,7 @@
   color: white;
 
   h1 {
-    color: $blue;
+    color: white;
   }
 
   .video-holder video {

--- a/static/scss/detail/who-should-enroll.scss
+++ b/static/scss/detail/who-should-enroll.scss
@@ -66,7 +66,7 @@
   }
 
   h1 {
-    color: $blue;
+    color: white;
     margin: 0 0 10px;
 
     @include media-breakpoint-up(lg) {

--- a/static/scss/resource.scss
+++ b/static/scss/resource.scss
@@ -44,6 +44,7 @@ html {
   h2 {
     color: $blue;
     margin-top: 50px;
+    font-weight: 600;
   }
 
   .resource-list {

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -6,7 +6,7 @@ $gray-85: #d9d9d9;
 
 $light-gray: #8a8b8c;
 $very-light-gray: #f5f5f5;
-$blue: #355B6B;
+$blue: #355b6b;
 $light-blue: #15729b;
 $navy-blue: #355b6b;
 $tile-background: #fff;

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -6,7 +6,7 @@ $gray-85: #d9d9d9;
 
 $light-gray: #8a8b8c;
 $very-light-gray: #f5f5f5;
-$blue: #3dbdbf;
+$blue: #355B6B;
 $light-blue: #15729b;
 $navy-blue: #355b6b;
 $tile-background: #fff;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #490 

#### What's this PR do?

- Replace aqua color to more darker color.
- Where we are using dark theme, replace it with white color.

#### How should this be manually tested?

- Visit any course, program page or resource page.
- Try switching between dark/light themes on course/program.
- Note that aqua color has changed to darker on light themes, and changed to white on light theme.

#### Any background context you want to provide?
Go through the designs provided at https://github.com/mitodl/mitxpro/issues/490#issuecomment-501434608

#### Screenshots (if appropriate)
**Product page**
![screencapture-xpro-odl-local-8053-courses-seed-analog-learning-300-2019-06-13-15_49_18](https://user-images.githubusercontent.com/4245618/59427308-ca2c9700-8df3-11e9-9577-f44fcb49e1e6.png)


**Resource page**
<img width="1228" alt="Screen Shot 2019-06-13 at 3 46 40 PM" src="https://user-images.githubusercontent.com/4245618/59426744-5b027300-8df2-11e9-9932-034fcda55aa8.png">

**Question @pdpinch **

After changing aqua to darker, `Thank You` becomes more darker, should I change this to white?
<img width="935" alt="Screen Shot 2019-06-13 at 3 52 13 PM" src="https://user-images.githubusercontent.com/4245618/59427017-1925fc80-8df3-11e9-809a-3c996c723d58.png">
