### PR TITLE
#448 Courseware: space between text/"view detail"

### DIFF
--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -10,7 +10,7 @@
       {% endif %}
       <a class="title" href="{% pageurl courseware_page %}">{{ courseware_page.title }}</a>
       <p>{{ courseware_page.subhead }}</p>
-      <a href="{% pageurl courseware_page %}" class="read-more text-uppercase mt-2 mb-2">view detail</a>
+      <a href="{% pageurl courseware_page %}" class="detail-link text-uppercase">view detail</a>
     </div>
   </div>
 {% endfor %}

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 <div id="faculty" class="faculty-block">
   <div class="container">
     <div class="head">
@@ -13,7 +13,7 @@
             <img src="{{ faculty_image.url }}" alt="{{ member.value.name }}">
             <h2>{{ member.value.name }}</h2>
             <div class="text-holder">
-              {{ member.value.description|safe }}
+              {{ member.value.description|richtext }}
             </div>
           </div>
         </div>

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -94,21 +94,22 @@
     font-weight: 500;
     margin: 0 0 20px;
     line-height: 30px;
-    color: black;
   }
 
   p {
     margin: 0 0 10px;
     min-height: 89px;
+    padding-bottom: 40px;
+    padding-top: 20px;
+    text-align: start;
   }
 
-  .read-more {
+  .detail-link {
     position: absolute;
-    bottom: 5px;
+    bottom: 20px;
+    left: 15px;
     font-size: 18px;
     line-height: 24px;
-    display: inline-block;
-    vertical-align: top;
     font-weight: 600;
     color: $primary;
 

--- a/static/scss/detail/faculty.scss
+++ b/static/scss/detail/faculty.scss
@@ -87,6 +87,7 @@
     overflow-y: auto;
     height: 78px;
     padding: 0 10px;
+    word-wrap: break-word;
   }
 
   p {


### PR DESCRIPTION
Continues on from #503 that was closed by mistake and can't be reopened because the branch was squashed meanwhile.