### PR TITLE
Set checkout page to be accessible only to logged-in users

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -85,7 +85,7 @@ export class App extends React.Component<Props, void> {
             path={urljoin(match.url, String(routes.register))}
             component={RegisterPages}
           />
-          <Route
+          <PrivateRoute
             path={urljoin(match.url, routes.checkout)}
             component={CheckoutPage}
           />


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #419

#### What's this PR do?
See title

#### How should this be manually tested?
Try to access the checkout page as a logged-out and logged-in user. The former should redirect you to the login page with the checkout page as the "next" path

#### Screenshots (if appropriate)
<img width="796" alt="ss 2019-06-13 at 14 20 20 " src="https://user-images.githubusercontent.com/14932219/59457552-a2830200-8de6-11e9-9f97-9ea4bca11f61.png">
