### PR TITLE
#203 Product Page: fix right margin at 768px

### DIFF
--- a/cms/templates/partials/learning-outcomes.html
+++ b/cms/templates/partials/learning-outcomes.html
@@ -4,7 +4,7 @@
       <h1>{{ page.heading | safe }}</h1>
       <h2>{{ page.sub_heading | safe }}</h2>
     </div>
-    <ul class="learning-outcomes-list">
+    <ul class="learning-outcomes-list d-flex flex-wrap justify-content-between">
       {% for outcome in page.outcome_items %}
         <li>{{ outcome }}</li>
       {% endfor %}

--- a/static/scss/detail/learning-outcomes.scss
+++ b/static/scss/detail/learning-outcomes.scss
@@ -26,9 +26,6 @@
     list-style: none;
     letter-spacing: -.32em;
     overflow: hidden;
-    @include media-breakpoint-up(md) {
-      margin: 0 -45px;
-    }
 
     li {
       letter-spacing: normal;
@@ -41,13 +38,12 @@
       font-weight: 600;
 
       @include media-breakpoint-up(md) {
-        width: calc(50% - 90px);
+        width: calc(50% - 45px);
         display: inline-block;
         vertical-align: top;
-        margin: -1px 45px 0;
       }
       @include media-breakpoint-up(lg) {
-        width: calc(33.33% - 90px);
+        width: calc(33.33% - 45px);
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #203 

#### What's this PR do?
Fixes display of learning outcomes section (What You Will Learn) on product pages to not go out of its container at table width (768px).

#### How should this be manually tested?
Go to any product page which has the learning outcomes section. Resize viewport to 768px width. There should be no empty space to either sides of the page.
