### PR TITLE
Ensure order of runs is always the same to avoid test flakiness

### DIFF
--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -746,6 +746,7 @@ def test_enroll_user_in_order_items(mocker, user, has_redemption):
     Test that enroll_user_in_order_items creates objects that represent a user's enrollment
     in course runs and programs
     """
+
     def sort_func(obj):
         """Helper function to sort by id"""
         return obj.id
@@ -776,11 +777,14 @@ def test_enroll_user_in_order_items(mocker, user, has_redemption):
             == redemption.coupon_version.payment_version.company
         )
     created_course_run_enrollments = CourseRunEnrollment.objects.order_by("pk").all()
-    course_runs = sorted([
-        run_enrollment.run for run_enrollment in created_course_run_enrollments
-    ], key=sort_func)
+    course_runs = sorted(
+        [run_enrollment.run for run_enrollment in created_course_run_enrollments],
+        key=sort_func,
+    )
     assert len(created_course_run_enrollments) == len(run_selections)
-    assert course_runs == sorted([selection.run for selection in run_selections], key=sort_func)
+    assert course_runs == sorted(
+        [selection.run for selection in run_selections], key=sort_func
+    )
     enroll_args = patched_enroll.call_args[0]
     assert enroll_args[0] == user
     assert set(enroll_args[1]) == set(course_runs)

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -746,6 +746,10 @@ def test_enroll_user_in_order_items(mocker, user, has_redemption):
     Test that enroll_user_in_order_items creates objects that represent a user's enrollment
     in course runs and programs
     """
+    def sort_func(obj):
+        """Helper function to sort by id"""
+        return obj.id
+
     patched_enroll = mocker.patch("ecommerce.api.enroll_in_edx_course_runs")
     order = OrderFactory.create(purchaser=user, status=Order.FULFILLED)
     if has_redemption:
@@ -772,11 +776,11 @@ def test_enroll_user_in_order_items(mocker, user, has_redemption):
             == redemption.coupon_version.payment_version.company
         )
     created_course_run_enrollments = CourseRunEnrollment.objects.order_by("pk").all()
-    course_runs = [
+    course_runs = sorted([
         run_enrollment.run for run_enrollment in created_course_run_enrollments
-    ]
+    ], key=sort_func)
     assert len(created_course_run_enrollments) == len(run_selections)
-    assert course_runs == [selection.run for selection in run_selections]
+    assert course_runs == sorted([selection.run for selection in run_selections], key=sort_func)
     enroll_args = patched_enroll.call_args[0]
     assert enroll_args[0] == user
     assert set(enroll_args[1]) == set(course_runs)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Hopefully fix a test that occasionally fails

#### How should this be manually tested?
Run `docker-compose run web pytest ecommerce/api_test.py` a few times, it should pass consistently.  It should also pass on travis consistently.
