### PR TITLE
Clear runs from basket when selected item changes

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -290,17 +290,19 @@ class BasketSerializer(serializers.ModelSerializer):
                 basketitem__basket=basket
             ).first()
 
-            if run_ids is not None:
-                runs = cls._get_runs_for_product(
-                    product=product, run_ids=run_ids, user=basket.user
-                )
-            elif previous_product is not None and product_id == previous_product.id:
+            if (
+                run_ids is None
+                and previous_product is not None
+                and product_id == previous_product.id
+            ):
                 # User is updating basket item to the same item as before
                 run_ids = list(
                     models.CourseRunSelection.objects.filter(basket=basket).values_list(
                         "run", flat=True
                     )
                 )
+
+            if run_ids is not None:
                 runs = cls._get_runs_for_product(
                     product=product, run_ids=run_ids, user=basket.user
                 )

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -396,12 +396,10 @@ class BasketSerializer(serializers.ModelSerializer):
                     product=product, quantity=1, basket=basket
                 )
 
+                models.CourseRunSelection.objects.filter(basket=basket).delete()
                 if runs is not None:
-                    models.CourseRunSelection.objects.filter(basket=basket).delete()
                     for run in runs:
                         models.CourseRunSelection.objects.create(basket=basket, run=run)
-                else:
-                    models.CourseRunSelection.objects.filter(basket=basket).delete()
 
                 if coupon_version:
                     models.CouponSelection.objects.update_or_create(

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -157,28 +157,30 @@ def test_serialize_basket_data_consents(basket_and_agreement, mock_context):
         "company": CompanySerializer(
             instance=basket_and_agreement.agreement.company
         ).data,
-        "consent_date": None,
+        "consent_date": data_consent_user.consent_date.strftime(datetime_millis_format),
         "consent_text": basket_and_agreement.agreement.content,
     }
 
 
-def test_serialize_basket(basket_and_coupons, mock_context):
+def test_serialize_basket(basket_and_agreement, mock_context):
     """Test Basket serialization"""
-    basket = basket_and_coupons.basket
+    basket = basket_and_agreement.basket
     selection = CouponSelection.objects.get(basket=basket)
     run = CourseRunSelection.objects.get(basket=basket).run
+    data_consent = DataConsentUser.objects.get(user=basket.user)
     data = BasketSerializer(instance=basket, context=mock_context).data
     assert data == {
         "items": [
             {
                 **ProductVersionSerializer(
-                    instance=basket_and_coupons.product_version, context=mock_context
+                    instance=basket_and_agreement.product.latest_version,
+                    context=mock_context,
                 ).data,
                 "run_ids": [run.id],
             }
         ],
         "coupons": [CouponSelectionSerializer(selection).data],
-        "data_consents": [],
+        "data_consents": [DataConsentUserSerializer(data_consent).data],
     }
 
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -383,7 +383,7 @@ def test_patch_basket_new_item(basket_client, basket_and_coupons, mock_context):
 def test_patch_basket_replace_item(basket_client, basket_and_agreement):
     """If a user changes the item in the basket it should clear away old selected runs and coupons"""
     new_product = ProductVersionFactory.create().product
-    data = {"items": [{"id": new_product.id}]}
+    data = {"items": [{"product_id": new_product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     items = resp.json()["items"]
@@ -402,7 +402,7 @@ def test_patch_basket_replace_item_with_same(basket_client, basket_and_agreement
     If a user changes the item in the basket but it's the same as the old product,
     the same runs and coupons should be selected as before
     """
-    data = {"items": [{"id": basket_and_agreement.product.id}]}
+    data = {"items": [{"product_id": basket_and_agreement.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     items = resp.json()["items"]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #539 

#### What's this PR do?
If the basket item changes, the selected runs are deleted. Previously this was only done when the runs were specified explicitly. Leaving the old runs selected caused subtle errors in checkout.

#### How should this be manually tested?

 -   Go to /checkout/?product=xxx where xxx is the id number for a course run product. Change the selected run to be "Select a course run", then change it back to some valid run.
 -   Go to /checkout/?product=yyy where yyy is the id number for a program product. Look at CourseRunSelection for your user. You should see no `CourseRunSelection` objects anymore.

