### PR TITLE
Move sync_hubspot_deal call out of atomic transaction

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -536,7 +536,9 @@ def create_unfulfilled_order(user):
         for basket_item in basket.basketitems.all():
             product_version = latest_product_version(basket_item.product)
             Line.objects.create(
-                order=order, product_version=product_version, quantity=basket_item.quantity
+                order=order,
+                product_version=product_version,
+                quantity=basket_item.quantity,
             )
 
         for coupon_selection in basket.couponselection_set.all():


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #566

#### What's this PR do?
In `ecommerce.api.create_unfulfilled_order`, moves the `sync_hubspot_deal` call out of an atomic transaction.

#### How should this be manually tested?
Log in as a new user and sign up for every course run available.  You should never see an exception in the log caused by `sync_hubspot_deal` being called for a non-existent `Order` object.
