### PR TITLE
Add popup for anonymous users to login when they want to enroll

### DIFF
--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -14,19 +14,50 @@
           <h2>{{ page.subhead }}</h2>
         </div>
         <div class="mt-5 mb-5">
-          {% if not user.is_anonymous %}
-            {% if not enrolled and product_id %}
-              <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_id }}">
-                Enroll Now
-              </a>
-            {% elif enrolled %}
-              <a class="enroll-button" href="{% url "user-dashboard" %}">
-                Enrolled
-              </a>
-            {% endif %}
-          {% endif %}
           {% if action_title and action_url %}
             <a id="actionButton" class="enroll-button" href="{{ action_url }}">{{ action_title }}</a>
+          {% else %}
+            {% if not user.is_anonymous %}
+              {% if not enrolled and product_id %}
+                <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_id }}">
+                  Enroll Now
+                </a>
+              {% elif enrolled %}
+                <a class="enroll-button" href="{% url "user-dashboard" %}">
+                  Enrolled
+                </a>
+              {% endif %}
+            {% else %}
+              <div class="enroll-dropdown">
+                <a class="enroll-button dropdown-toggle" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="true">
+                  Enroll Now
+                </a>
+                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                  <div class="login-popup">
+                    <div class="triangle"></div>
+                    <h4>
+                      <span>Attention</span>
+                      <a class="close-btn">
+                        ×
+                      </a>
+                    </h4>
+                    <div class="popup-text">
+                      Please Sign In to MITx PRO to enroll in a course
+                    </div>
+                    <div class="bottom-row">
+                      <div class="popup-buttons">
+                        <a class="sign-in-link link-button" href="/login">
+                          Sign In
+                        </a>
+                        <a class="create-account-link link-button" href="/signup">
+                          Create Account
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -46,10 +46,10 @@
                     </div>
                     <div class="bottom-row">
                       <div class="popup-buttons">
-                        <a class="sign-in-link link-button" href="/login">
+                        <a class="sign-in-link link-button" href="/signin">
                           Sign In
                         </a>
-                        <a class="create-account-link link-button" href="/signup">
+                        <a class="create-account-link link-button" href="/create-account">
                           Create Account
                         </a>
                       </div>

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -36,7 +36,7 @@
                   <div class="login-popup">
                     <div class="triangle"></div>
                     <h4>
-                      <span>Attention</span>
+                      <span>Sign In/Create Account</span>
                       <a class="close-btn">
                         ×
                       </a>

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -1,0 +1,27 @@
+"""Tests for CMS views"""
+import pytest
+
+from django.urls import reverse
+from wagtail.core.models import Site
+
+from cms.models import HomePage
+
+pytestmark = pytest.mark.django_db
+
+
+def test_home_page_view(client):
+    """
+    Test that the home page shows the right HTML for the watch now button
+    """
+    root = Site.objects.get(is_default_site=True).root_page
+    page = HomePage(title="Home Page", subhead="<p>subhead</p>")
+    root.add_child(instance=page)
+    resp = client.get(page.get_url())
+    content = resp.content.decode("utf-8")
+
+    assert (
+        f'<a id="actionButton" class="enroll-button" href="#">Watch Now</a>' in content
+    )
+    assert reverse("user-dashboard") not in content
+    assert reverse("checkout-page") not in content
+    assert "dropdown-menu" not in content

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -276,6 +276,10 @@ def test_course_view(
     assert (
         f'<a class="enroll-button" href="{url}">'.encode("utf-8") in resp.content
     ) is has_button
+    assert (
+        "Please Sign In to MITx PRO to enroll in a course".encode("utf-8")
+        in resp.content
+    ) is is_anonymous
 
 
 @pytest.mark.parametrize("is_enrolled", [True, False])
@@ -318,6 +322,10 @@ def test_program_view(client, user, home_page, is_enrolled, has_product, is_anon
     assert (
         f'<a class="enroll-button" href="{url}">'.encode("utf-8") in resp.content
     ) is has_button
+    assert (
+        "Please Sign In to MITx PRO to enroll in a course".encode("utf-8")
+        in resp.content
+    ) is is_anonymous
 
 
 def test_user_enrollments_view(mocker, client, user):

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -1,9 +1,12 @@
 // sass-lint:disable mixins-before-declarations
+#header {
+  background-color: white;
+}
+
 .header-block {
   background-size: cover;
   background-position: 50% 50%;
   position: relative;
-  overflow: hidden;
 
   .background-video {
     position: absolute;
@@ -13,7 +16,7 @@
     min-height: 100%;
     width: auto;
     height: auto;
-    z-index: 0;
+    z-index: -10;
     transform: translateX(-50%) translateY(-50%);
   }
 }
@@ -79,6 +82,75 @@
     color: white;
     padding: 20px 40px;
     text-transform: uppercase;
+    cursor: pointer;
+    font-weight: 700;
+  }
+
+  .enroll-dropdown {
+    .dropdown-toggle::after {
+      display: none;
+    }
+
+    .login-popup {
+      max-width: 350px;
+      margin-left: 20px;
+      margin-right: 20px;
+      padding: 20px;
+      font-weight: 600;
+      font-size: 20px;
+
+      .close-btn {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 5px;
+        margin: 20px 7px 0 0;
+        font-size: 72px;
+        font-weight: 300;
+        background-color: #fff !important;
+        color: #000;
+        min-width: unset;
+        height: unset;
+        cursor: pointer;
+      }
+
+      h4 {
+        font-weight: 700;
+        font-size: 22px;
+      }
+
+      .popup-buttons {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        margin-top: 20px;
+
+        .link-button {
+          border: 2px solid $light-blue;
+          border-radius: 10px;
+          font-weight: 600;
+          font-size: 24px;
+
+          &.sign-in-link {
+            color: white;
+            background-color: $light-blue;
+          }
+
+          &.create-account-link {
+            color: black;
+          }
+        }
+      }
+    }
+
+    .triangle {
+      width: 15px;
+      height: 15px;
+      position: absolute;
+      top: -7px;
+      background: white;
+      transform: rotate(45deg);
+    }
   }
 
   .promo-video {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #441 

#### What's this PR do?
Adds a popup which shows when anonymous users try to enroll informing them to sign up or sign in first.

#### How should this be manually tested?
As an anonymous user click the enroll button on a program or course page. You should also verify that a home page with a video playing looks the same as before. The overflow CSS was removed so that the popup could go over the boundary. I adjusted the z-index and set a background color of the header so everything should still look the same as before.

#### Screenshots

Desktop:
![Screenshot from 2019-06-18 11-44-34](https://user-images.githubusercontent.com/863262/59698824-80122f80-91be-11e9-97f9-cf941e467421.png)


Mobile:
![Screenshot from 2019-06-18 11-44-15](https://user-images.githubusercontent.com/863262/59698832-830d2000-91be-11e9-913a-a41eefa51cb4.png)
