### PR TITLE
Change basket PATCH to use product_id instead of id

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -283,7 +283,7 @@ class BasketSerializer(serializers.ModelSerializer):
         if items:
             # Item updated
             item = items[0]
-            product_id = item.get("id")
+            product_id = item.get("product_id")
             run_ids = item.get("run_ids")
             product = models.Product.objects.get(id=product_id)
             if run_ids is not None:
@@ -413,7 +413,7 @@ class BasketSerializer(serializers.ModelSerializer):
             if len(items) > 1:
                 raise ValidationError("Basket cannot contain more than one item")
             item = items[0]
-            product_id = item.get("id")
+            product_id = item.get("product_id")
 
             if product_id is None:
                 raise ValidationError("Invalid request")

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -369,7 +369,7 @@ def test_patch_basket_new_user(basket_and_coupons, user, user_drf_client):
 
 def test_patch_basket_new_item(basket_client, basket_and_coupons, mock_context):
     """Test that a user can add an item to their basket"""
-    data = {"items": [{"id": basket_and_coupons.product_version.product.id}]}
+    data = {"items": [{"product_id": basket_and_coupons.product_version.product.id}]}
     BasketItem.objects.all().delete()  # clear the basket first
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
@@ -380,7 +380,7 @@ def test_patch_basket_new_item(basket_client, basket_and_coupons, mock_context):
 
 def test_patch_basket_multiple_products(basket_client, basket_and_coupons):
     """ Test that an update with multiple products is rejected """
-    data = {"items": [{"id": 10}, {"id": 11}]}
+    data = {"items": [{"product_id": 10}, {"product_id": 11}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     resp_data = resp.json()
@@ -493,7 +493,7 @@ def test_patch_basket_update_valid_product_valid_coupon(
     product_version = ProductVersionFactory()
     CouponEligibilityFactory(product=product_version.product, coupon=best_coupon)
 
-    data = {"items": [{"id": product_version.product.id}]}
+    data = {"items": [{"product_id": product_version.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     resp_data = resp.json()
@@ -512,7 +512,7 @@ def test_patch_basket_update_valid_product_invalid_coupon_auto(
     product_version = ProductVersionFactory()
     CouponEligibilityFactory(product=product_version.product, coupon=auto_coupon)
 
-    data = {"items": [{"id": product_version.product.id}]}
+    data = {"items": [{"product_id": product_version.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     resp_data = resp.json()
@@ -533,7 +533,7 @@ def test_patch_basket_update_valid_product_invalid_coupon_no_auto(
         basket.couponselection_set.all().delete()
     else:
         assert basket.couponselection_set.first() is not None
-    data = {"items": [{"id": product_version.product.id}]}
+    data = {"items": [{"product_id": product_version.product.id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_200_OK
     resp_data = resp.json()
@@ -545,7 +545,7 @@ def test_patch_basket_update_valid_product_invalid_coupon_no_auto(
 def test_patch_basket_update_invalid_product(basket_client, basket_and_coupons):
     """ Test that invalid product id is rejected with no changes to basket """
     bad_id = 9999
-    data = {"items": [{"id": bad_id}]}
+    data = {"items": [{"product_id": bad_id}]}
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     resp_data = resp.json()
@@ -599,7 +599,7 @@ def test_patch_basket_update_runs(basket_client, basket_and_coupons, add_new_run
         data={
             "items": [
                 {
-                    "id": product.id,
+                    "product_id": product.id,
                     "run_ids": [run1.id, run2.id] if add_new_runs else [],
                 }
             ]
@@ -637,7 +637,7 @@ def test_patch_basket_invalid_run(
     resp = basket_client.patch(
         reverse("basket_api"),
         type="json",
-        data={"items": [{"id": product.id, "run_ids": [other_run_id]}]},
+        data={"items": [{"product_id": product.id, "run_ids": [other_run_id]}]},
     )
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.json()["errors"] == {
@@ -671,7 +671,7 @@ def test_patch_basket_multiple_runs(
     resp = basket_client.patch(
         reverse("basket_api"),
         type="json",
-        data={"items": [{"id": product.id, "run_ids": [run1.id, run2.id]}]},
+        data={"items": [{"product_id": product.id, "run_ids": [run1.id, run2.id]}]},
     )
     if multiple_for_program:
         assert resp.status_code == status.HTTP_200_OK
@@ -699,7 +699,7 @@ def test_patch_basket_already_enrolled(basket_client, basket_and_coupons):
         data={
             "items": [
                 {
-                    "id": basket_and_coupons.product_version.product.id,
+                    "product_id": basket_and_coupons.product_version.product.id,
                     "run_ids": [run.id],
                 }
             ]
@@ -721,7 +721,7 @@ def test_patch_basket__another_user_enrolled(basket_client, basket_and_coupons):
         data={
             "items": [
                 {
-                    "id": basket_and_coupons.product_version.product.id,
+                    "product_id": basket_and_coupons.product_version.product.id,
                     "run_ids": [run.id],
                 }
             ]

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -86,7 +86,9 @@ export class CheckoutPage extends React.Component<Props, State> {
       return
     }
 
-    const basketResponse = await updateBasket({ items: [{ id: productId }] })
+    const basketResponse = await updateBasket({
+      items: [{ product_id: productId }]
+    })
     if (basketResponse.status !== 200) {
       if (basketResponse.body.errors) {
         this.setState({
@@ -107,9 +109,9 @@ export class CheckoutPage extends React.Component<Props, State> {
     // update basket with selected runs
     const basketPayload = {
       items: basket.items.map(item => ({
-        id:      item.product_id,
+        product_id: item.product_id,
         // $FlowFixMe: flow doesn't understand that Object.values will return an array of number here
-        run_ids: Object.values(values.runs).map(runId => parseInt(runId))
+        run_ids:    Object.values(values.runs).map(runId => parseInt(runId))
       })),
       coupons:       values.couponCode ? [{ code: values.couponCode }] : [],
       data_consents: values.dataConsent ? [basket.data_consents[0].id] : []
@@ -169,7 +171,7 @@ export class CheckoutPage extends React.Component<Props, State> {
   ) => {
     const { updateBasket } = this.props
     const response = await updateBasket({
-      items: [{ id: productId, run_ids: runId ? [runId] : [] }]
+      items: [{ product_id: productId, run_ids: runId ? [runId] : [] }]
     })
     setFieldError(
       "runs",

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -65,7 +65,7 @@ describe("CheckoutPage", () => {
         "/api/basket/",
         "PATCH",
         {
-          body:        { items: [{ id: productId }] },
+          body:        { items: [{ product_id: productId }] },
           credentials: undefined,
           headers:     {
             "X-CSRFTOKEN": null
@@ -175,8 +175,8 @@ describe("CheckoutPage", () => {
           body: {
             items: [
               {
-                id:      basketItem.product_id,
-                run_ids: []
+                product_id: basketItem.product_id,
+                run_ids:    []
               }
             ],
             coupons:       [],
@@ -222,8 +222,8 @@ describe("CheckoutPage", () => {
       body: {
         items: [
           {
-            id:      basketItem.product_id,
-            run_ids: []
+            product_id: basketItem.product_id,
+            run_ids:    []
           }
         ],
         coupons:       [],
@@ -271,7 +271,7 @@ describe("CheckoutPage", () => {
     sinon.assert.notCalled(submitStub)
     sinon.assert.calledWith(helper.handleRequestStub, "/api/basket/", "PATCH", {
       body: {
-        items:         [{ id: basket.items[0].product_id, run_ids: [runId] }],
+        items:         [{ product_id: basket.items[0].product_id, run_ids: [runId] }],
         coupons:       [],
         data_consents: []
       },
@@ -321,7 +321,9 @@ describe("CheckoutPage", () => {
         "PATCH",
         {
           body: {
-            items:         [{ id: basket.items[0].product_id, run_ids: [runId] }],
+            items: [
+              { product_id: basket.items[0].product_id, run_ids: [runId] }
+            ],
             coupons:       hasCoupon ? [{ code: code }] : [],
             data_consents: []
           },

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -59,7 +59,7 @@ export type BasketResponse = {
 }
 
 type BasketItemPayload = {
-  id: number,
+  product_id: number,
   run_ids?: Array<number>,
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #565 
Related to #418 

#### What's this PR do?
Changes the valid patch key from `id` to `product_id`. This makes it so `id` always means `ProductVersion.id` and `product_id` always means `Product.id`.

#### How should this be manually tested?
Nothing should break

