### PR TITLE
Fix login redirect regression

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -135,8 +135,8 @@ if DEBUG:
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
 LOGIN_REDIRECT_URL = "/"
-LOGIN_URL = "/login"
-LOGIN_ERROR_URL = "/login"
+LOGIN_URL = "/signin"
+LOGIN_ERROR_URL = "/signin"
 LOGOUT_REDIRECT_URL = get_string("LOGOUT_REDIRECT_URL", "/")
 
 ROOT_URLCONF = "mitxpro.urls"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #577 

#### What's this PR do?
Fixes the regression for @login_required protected redirects

#### How should this be manually tested?
Go to /dashboard and verify you get redirected to /signin with the `next` parameter populated
