### PR TITLE
Validate data consent agreements have been signed

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -620,6 +620,7 @@ def get_available_bulk_product_coupons(coupon_payment_id, product_id):
     )
 
 
+# pylint: disable=too-many-branches
 def validate_basket_for_checkout(basket):
     """
     Validate basket for checkout

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -40,7 +40,7 @@ type Errors = {
   runs?: string,
   coupons?: string,
   items?: string,
-  dataConsent?: string
+  data_consents?: string
 }
 type CommonProps = {
   item: BasketItem,
@@ -241,7 +241,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                 {formatErrors(errors.coupons)}
               </div>
               {dataConsent ? (
-                <div>
+                <div className="data-consent">
                   <div className="data-consent-row">
                     <Field
                       type="checkbox"
@@ -260,7 +260,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                       .
                     </span>
                   </div>
-                  {formatErrors(errors.dataConsent)}
+                  {formatErrors(errors.data_consents)}
                 </div>
               ) : null}
             </div>
@@ -346,14 +346,9 @@ export class CheckoutForm extends React.Component<OuterProps> {
       errors.runs = `No run selected for ${missingCourses.join(", ")}`
     }
 
-    if (basket) {
-      const dataConsent = basket.data_consents[0]
-      if (dataConsent && !dataConsent.consent_date) {
-        if (!values.dataConsent) {
-          errors.dataConsent =
-            "User must consent to the Data Sharing Policy to use the coupon."
-        }
-      }
+    if (basket && basket.data_consents[0] && !values.dataConsent) {
+      errors.data_consents =
+        "User must consent to the Data Sharing Policy to use the coupon."
     }
 
     return errors

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -174,6 +174,7 @@ describe("CheckoutForm", () => {
   it("shows the data consent validation error", async () => {
     const errorMessage = "my custom error message"
     const inner = await shallow(
+      // $FlowFixMe
       <InnerCheckoutForm
         basket={basket}
         item={basketItem}

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -129,15 +129,13 @@ describe("CheckoutForm", () => {
       })
       const errors = inner.find(Formik).prop("validate")({ runs })
 
-      assert.deepEqual(
-        errors,
+      assert.equal(
+        errors.runs,
         hasRuns
-          ? {}
-          : {
-            runs: `No run selected for ${basketItem.courses
-              .map(course => course.title)
-              .join(", ")}`
-          }
+          ? undefined
+          : `No run selected for ${basketItem.courses
+            .map(course => course.title)
+            .join(", ")}`
       )
     })
   })

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -113,6 +113,8 @@ describe("CheckoutForm", () => {
     assert.equal(inner.find("img").prop("alt"), basketItem.description)
     assert.equal(inner.find(".item-row .title").text(), basketItem.description)
   })
+
+  //
   ;[true, false].forEach(hasRuns => {
     it(`validates ${hasRuns ? "existing" : "present"} runs`, async () => {
       basketItem.type = PRODUCT_TYPE_PROGRAM
@@ -138,6 +140,49 @@ describe("CheckoutForm", () => {
           }
       )
     })
+  })
+
+  //
+  ;[
+    [true, true, false],
+    [true, false, true],
+    [false, true, false],
+    [false, false, false]
+  ].forEach(([hasDataConsent, checkedDataConsent, shouldHaveError]) => {
+    it(`validates data consent ${
+      hasDataConsent ? "with" : "without"
+    } an agreement, when the user ${
+      checkedDataConsent ? "has" : "hasn't"
+    } checked the box`, async () => {
+      if (!hasDataConsent) {
+        basket.data_consents = []
+      }
+      const inner = await renderForm()
+      const errors = inner.find(Formik).prop("validate")({
+        dataConsent: checkedDataConsent,
+        runs:        {}
+      })
+      assert.equal(
+        errors.data_consents,
+        shouldHaveError
+          ? "User must consent to the Data Sharing Policy to use the coupon."
+          : undefined
+      )
+    })
+  })
+
+  it("shows the data consent validation error", async () => {
+    const errorMessage = "my custom error message"
+    const inner = await shallow(
+      <InnerCheckoutForm
+        basket={basket}
+        item={basketItem}
+        values={{ dataConsent: false }}
+        errors={{ data_consents: errorMessage }}
+        onMount={sandbox.stub()}
+      />
+    )
+    assert.equal(inner.find(".data-consent .error").text(), errorMessage)
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #518 

#### What's this PR do?
Adds validation of data consent agreements on the backend

#### How should this be manually tested?

- Generate a coupon which has a data consent agreement attached to it. Paste the code in the checkout text field and click 'Apply'. Click 'place your order' and note the error message saying that you have not clicked the checkbox yet.
-  Clear the code textbox and click 'Apply'. The checkbox goes away and the coupon is unapplied. Add the coupon code back and click 'Place your order' without clicking 'Apply' first. You should see a validation error message saying that the agreement is not yet signed

#### Screenshots (if appropriate)
![Screenshot from 2019-06-18 13-06-42](https://user-images.githubusercontent.com/863262/59704366-f1a3ab00-91c9-11e9-9e97-c3af10f8d8a7.png)
