### PR TITLE
Fixed race condition with AccessToken

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -43,10 +43,8 @@ def create_edx_user(user):
     """Makes a request to create an equivalent user in Open edX"""
     application = Application.objects.get(name=settings.OPENEDX_OAUTH_APP_NAME)
     expiry_date = now_in_utc() + timedelta(hours=settings.OPENEDX_TOKEN_EXPIRES_HOURS)
-    access_token, _ = AccessToken.objects.update_or_create(
-        user=user,
-        application=application,
-        defaults=dict(token=generate_token(), expires=expiry_date),
+    access_token = AccessToken.objects.create(
+        user=user, application=application, token=generate_token(), expires=expiry_date
     )
 
     with transaction.atomic():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
Fixes #579 

#### What's this PR do?
This makes `create_edx_user` resilient against multiple access tokens already existing. It can handle 0 or 1 but more that that causes django to raise an error.

#### How should this be manually tested?
- Run the app
- Run `docker-compose stop celery` so the task doesn't get run immediately
- Register a new user
- Go into django admin and create at least 2 `AccessToken` records for your user
- `docker-compose start celery`
- Verify `CoursewareUser` and `OpenEdxApiAuth` records were created for your user

#### What GIF best describes this PR or how it makes you feel?
![race condition](https://media.giphy.com/media/tKmh1OtYxsB68/giphy.gif)
