### PR TITLE
Added enrollment change management commands

### DIFF
--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -1,0 +1,92 @@
+"""Management command to change enrollment status"""
+from django.core.management.base import CommandError
+from django.contrib.auth import get_user_model
+
+from courses.management.utils import EnrollmentChangeCommand, fetch_user
+from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
+from courses.models import CourseRun, CourseRunEnrollment
+
+User = get_user_model()
+
+
+class Command(EnrollmentChangeCommand):
+    """Sets a user's enrollment to 'deferred' and creates an enrollment for a different course run"""
+
+    help = "Sets a user's enrollment to 'deferred' and creates an enrollment for a different course run"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user", type=str, help="The id, email, or username of the enrolled User"
+        )
+        parser.add_argument(
+            "--from-run",
+            type=str,
+            help="The 'courseware_id' value for an enrolled CourseRun",
+        )
+        parser.add_argument(
+            "--to-run",
+            type=str,
+            help="The 'courseware_id' value for the CourseRun that you are deferring to",
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        """Handle command execution"""
+        user = fetch_user(options["user"])
+        from_run = CourseRun.objects.filter(courseware_id=options["from_run"]).first()
+        to_run = CourseRun.objects.filter(courseware_id=options["to_run"]).first()
+        if not from_run:
+            raise CommandError(
+                "Could not find 'from' run with courseware_id={}".format(
+                    options["from_run"]
+                )
+            )
+        elif not to_run:
+            raise CommandError(
+                "Could not find 'to' run with courseware_id={}".format(
+                    options["to_run"]
+                )
+            )
+        elif from_run.course != to_run.course and not options["force"]:
+            raise CommandError(
+                "Enrollment deferral must occur between two runs of the same course "
+                "('from' run course: {}, 'to' run course: {})\n"
+                "Add the -f/--force flag if you want to complete this deferment anyway.".format(
+                    from_run.course.title, to_run.course.title
+                )
+            )
+        elif not to_run.is_unexpired:
+            raise CommandError("'To' run is expired")
+
+        from_enrollment = CourseRunEnrollment.all_objects.get(user=user, run=from_run)
+        if not from_enrollment.active and not options["force"]:
+            raise CommandError(
+                "The 'from' enrollment is not active ({}).\n"
+                "Add the -f/--force flag if you want to complete this deferment anyway.".format(
+                    from_enrollment.id
+                )
+            )
+
+        to_enrollment = CourseRunEnrollment.objects.create(
+            user=user, run=to_run, company=from_enrollment.company
+        )
+        from_enrollment.active = False
+        from_enrollment.change_status = ENROLL_CHANGE_STATUS_DEFERRED
+        from_enrollment.save_and_log(None)
+
+        self.stdout.write(
+            "Current enrollment deactivated and new enrollment record created. "
+            "Attempting to enroll the user on edX..."
+        )
+        self.enroll_in_edx(user, [to_run])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Deferred enrollment – 'from' run id: {}, 'to' run id: {}\nUser – {} ({})".format(
+                    from_enrollment.run.id,
+                    to_enrollment.run.id,
+                    user.username,
+                    user.email,
+                )
+            )
+        )

--- a/courses/management/commands/refund_enrollment.py
+++ b/courses/management/commands/refund_enrollment.py
@@ -1,0 +1,48 @@
+"""Management command to change enrollment status"""
+from django.contrib.auth import get_user_model
+
+from courses.management.utils import EnrollmentChangeCommand, fetch_user
+from courses.constants import ENROLL_CHANGE_STATUS_REFUNDED
+
+User = get_user_model()
+
+
+class Command(EnrollmentChangeCommand):
+    """Sets a user's enrollment to 'refunded' and deactivates it"""
+
+    help = "Sets a user's enrollment to 'refunded' and deactivates it"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user", type=str, help="The id, email, or username of the enrolled User"
+        )
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--program",
+            type=str,
+            help="The 'readable_id' value for an enrolled Program",
+        )
+        group.add_argument(
+            "--run",
+            type=str,
+            help="The 'courseware_id' value for an enrolled CourseRun",
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        """Handle command execution"""
+        user = fetch_user(options["user"])
+        enrollment, enrolled_obj = self.fetch_enrollment(user, options)
+        enrollment.active = False
+        enrollment.change_status = ENROLL_CHANGE_STATUS_REFUNDED
+        enrollment.save_and_log(None)
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Refunded enrollment – id: {}, object: {}\nUser – {} ({})".format(
+                    enrollment.id,
+                    enrolled_obj.title,
+                    enrollment.user.username,
+                    enrollment.user.email,
+                )
+            )
+        )

--- a/courses/management/commands/transfer_enrollment.py
+++ b/courses/management/commands/transfer_enrollment.py
@@ -1,0 +1,99 @@
+"""Management command to change enrollment status"""
+from django.core.management.base import CommandError
+from django.contrib.auth import get_user_model
+
+from courses.management.utils import EnrollmentChangeCommand, fetch_user
+from courses.constants import ENROLL_CHANGE_STATUS_TRANSFERRED
+from courses.models import CourseRunEnrollment, ProgramEnrollment
+
+User = get_user_model()
+
+
+class Command(EnrollmentChangeCommand):
+    """Sets a user's enrollment to 'transferred' and creates an enrollment for a different user"""
+
+    help = "Sets a user's enrollment to 'transferred' and creates an enrollment for a different user"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--from-user",
+            type=str,
+            help="The id, email, or username of the enrolled User",
+        )
+        parser.add_argument(
+            "--to-user",
+            type=str,
+            help="The id, email, or username of the User to whom the enrollment will be transferred",
+        )
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--program",
+            type=str,
+            help="The 'readable_id' value for an enrolled Program",
+        )
+        group.add_argument(
+            "--run",
+            type=str,
+            help="The 'courseware_id' value for an enrolled CourseRun",
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        from_user = fetch_user(options["from_user"])
+        to_user = fetch_user(options["to_user"])
+        enrollment, enrolled_obj = self.fetch_enrollment(from_user, options)
+
+        if options["program"]:
+            to_user_existing_enrolled_run_ids = CourseRunEnrollment.all_objects.filter(
+                user=to_user, run__course__program=enrolled_obj
+            ).values_list("run__courseware_id", flat=True)
+            if len(to_user_existing_enrolled_run_ids) > 0:
+                raise CommandError(
+                    "'to' user is already enrolled in program runs ({})".format(
+                        str(to_user_existing_enrolled_run_ids)
+                    )
+                )
+            # Create the program enrollment
+            ProgramEnrollment.objects.create(
+                user=to_user, program=enrolled_obj, company=enrollment.company
+            )
+            associated_run_enrollments = CourseRunEnrollment.objects.filter(
+                user=from_user, run__course__program=enrolled_obj
+            )
+            # Create enrollments in all of the same program course runs that the 'from' user
+            # was enrolled in
+            for run_enrollment in associated_run_enrollments:
+                CourseRunEnrollment.objects.create(
+                    user=to_user, run=run_enrollment.run, company=enrollment.company
+                )
+            enrollments_to_deactivate = [enrollment] + list(associated_run_enrollments)
+            runs_to_enroll = [e.run for e in associated_run_enrollments]
+        else:
+            CourseRunEnrollment.objects.create(
+                user=to_user, run=enrolled_obj, company=enrollment.company
+            )
+            enrollments_to_deactivate = [enrollment]
+            runs_to_enroll = [enrolled_obj]
+
+        for enrollment_to_deactivate in enrollments_to_deactivate:
+            enrollment_to_deactivate.active = False
+            enrollment_to_deactivate.change_status = ENROLL_CHANGE_STATUS_TRANSFERRED
+            enrollment_to_deactivate.save_and_log(None)
+
+        self.stdout.write(
+            "New enrollment record(s) created. Attempting to enroll the user on edX..."
+        )
+        self.enroll_in_edx(to_user, runs_to_enroll)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Transferred enrollment – 'from' user: {} ({}), 'to' user: {} ({})\n"
+                "Enrollment in: {}".format(
+                    from_user.username,
+                    from_user.email,
+                    to_user.username,
+                    to_user.email,
+                    enrolled_obj,
+                )
+            )
+        )

--- a/courses/management/utils.py
+++ b/courses/management/utils.py
@@ -1,0 +1,117 @@
+"""Utility functions/classes for course management commands"""
+from requests.exceptions import HTTPError
+from django.core.management.base import BaseCommand, CommandError
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.contrib.auth import get_user_model
+
+from courses.models import Program, ProgramEnrollment, CourseRun, CourseRunEnrollment
+from courseware.api import enroll_in_edx_course_runs
+
+User = get_user_model()
+
+
+def fetch_user(user_property):
+    """
+    Attempts to fetch a user based on several properties
+
+    Args:
+        user_property (str): The id, email, or username of some User
+    Returns:
+        User: A user that matches the given property
+    """
+    if user_property.isdigit():
+        return User.objects.get(id=int(user_property))
+    else:
+        try:
+            validate_email(user_property)
+            return User.objects.get(email=user_property)
+        except ValidationError:
+            return User.objects.get(username=user_property)
+
+
+class EnrollmentChangeCommand(BaseCommand):
+    """Base class for management commands that change enrollment status"""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            dest="force",
+            help="Ignores validation when performing the desired status change",
+        )
+
+    def handle(self, *args, **options):
+        pass
+
+    @staticmethod
+    def fetch_enrollment(user, command_options):
+        """
+        Fetches the appropriate enrollment model object paired with an object of the
+        Program/Course that the user is enrolled in.
+
+        Args:
+            user (User): An enrolled User
+            command_options (dict): A dict of command parameters
+        Returns:
+             tuple: (ProgramEnrollment, Program) or (CourseRunEnrollment, CourseRun)
+        """
+        program_property = command_options["program"]
+        run_property = command_options["run"]
+        force = command_options["force"]
+
+        if program_property and run_property:
+            raise CommandError(
+                "Either 'program' or 'run' should be provided, not both."
+            )
+        elif not program_property and not run_property:
+            raise CommandError("Either 'program' or 'run' must be provided.")
+
+        if program_property:
+            enrolled_obj = Program.objects.get(readable_id=program_property)
+            enrollment = ProgramEnrollment.all_objects.filter(
+                user=user, program=enrolled_obj
+            ).first()
+        else:
+            enrolled_obj = CourseRun.objects.get(courseware_id=run_property)
+            enrollment = CourseRunEnrollment.all_objects.filter(
+                user=user, run=enrolled_obj
+            ).first()
+
+        if not enrollment:
+            raise CommandError("Enrollment not found for: {}".format(enrolled_obj))
+        elif not enrollment.active and not force:
+            raise CommandError(
+                "The given enrollment is not active ({}).\n"
+                "Add the -f/--force flag if you want to change the status anyway.".format(
+                    enrollment.id
+                )
+            )
+
+        return enrollment, enrolled_obj
+
+    def enroll_in_edx(self, user, course_runs):
+        """
+        Try to perform edX enrollment, but print a message and continue if it fails
+
+        Args:
+            user (users.models.User): The user to enroll
+            course_runs (iterable of CourseRun): The course runs to enroll in
+        """
+        try:
+            enroll_in_edx_course_runs(user, course_runs)
+        except HTTPError as exc:
+            self.stdout.write(
+                self.style.WARNING(
+                    "edX enrollment request failed ({}).\nResponse: {}".format(
+                        exc.response.status_code, exc.response.body
+                    )
+                )
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            self.stdout.write(
+                self.style.WARNING(
+                    "Unexpected edX enrollment error.\n{}".format(str(exc))
+                )
+            )

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -272,7 +272,7 @@ def get_edx_api_client(user, ttl_in_seconds=OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS)
 
 def enroll_in_edx_course_runs(user, course_runs):
     """
-    Enrolls a user in an edx course run
+    Enrolls a user in edx course runs
 
     Args:
         user (users.models.User): The user to enroll


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #457
Closes #458
Closes #460

#### What's this PR do?
Adds management commands for setting an enrollment to refunded, deferring an enrollment to a different course run, and transferring an enrollment to a different user

#### How should this be manually tested?
To test refunds:
- Create or use an active course run or program enrollment
- `manage.py refund_enrollment --user <YOUR_USERNAME_OR_EMAIL> --run <COURSEWARE_ID>` (`--program <READABLE_ID>` instead of `--run` to test program enrollments)
- Check that the enrollment record now has active=False, change_status=refunded

To test deferrals:
- Create or use an active course run enrollment
- `manage.py defer_enrollment --user <YOUR_USERNAME_OR_EMAIL> --from-run <ENROLLED_COURSEWARE_ID> --to-run <DESIRED_COURSEWARE_ID>`
- Check that the enrollment record now has active=False, change_status=deferred; Also check that the new enrollment was created for the desired course run

To test transfers:
- Create or use an active course run or program enrollment
- `manage.py transfer_enrollment --from-user <YOUR_USERNAME_OR_EMAIL> --to-user <TARGET_USERNAME_OR_EMAIL> --run <COURSEWARE_ID>` (`--program <READABLE_ID>` instead of `--run` to test program enrollments)
- Check that the enrollment record now has active=False, change_status=transferred; Also check that the new enrollment was created for the target user
