### PR TITLE
Fix header CSS for video on home page

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -13,23 +13,6 @@
 {% render_bundle 'header' %}
 {% endblock %}
 
-{% block extrahead %}
-  {{ block.super }}
-  <style>
-    .header-block {
-      {% image page.background_image fill-1024x768 as background_image %}
-      background-image: url('{{ background_image.url }}');
-    }
-
-    @media screen and (min-width: 1024px) {
-      .header-block {
-        {% image page.background_image fill-1920x1080 as background_image %}
-        background-image: url('{{ background_image.url }}');
-      }
-    }
-  </style>
-{% endblock %}
-
 {% block scripts %}
   {{ block.super }}
   <script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -1,4 +1,22 @@
-{% load wagtailembeds_tags %}
+{% load wagtailembeds_tags wagtailimages_tags %}
+
+{% block extrahead %}
+  {% if page.background_image %}
+  <style>
+    .header-block {
+      {% image page.background_image fill-1024x768 as background_image %}
+      background-image: url('{{ background_image.url }}');
+    }
+
+    @media screen and (min-width: 1024px) {
+      .header-block {
+        {% image page.background_image fill-1920x1080 as background_image %}
+        background-image: url('{{ background_image.url }}');
+      }
+    }
+  </style>
+  {% endif %}
+{% endblock %}
 
 <div class="header-block">
   <div class="container header-container">

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -4,11 +4,11 @@
   {% if page.background_image %}
   <style>
     .header-block {
-      {% image page.background_image fill-1024x768 as background_image %}
+      {% image page.background_image fill-768x576 as background_image %}
       background-image: url('{{ background_image.url }}');
     }
 
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 768px) {
       .header-block {
         {% image page.background_image fill-1920x1080 as background_image %}
         background-image: url('{{ background_image.url }}');

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -1,8 +1,8 @@
 {% load wagtailembeds_tags wagtailimages_tags %}
 
 {% block extrahead %}
-  {% if page.background_image %}
   <style>
+  {% if page.background_image %}
     .header-block {
       {% image page.background_image fill-768x576 as background_image %}
       background-image: url('{{ background_image.url }}');
@@ -13,9 +13,14 @@
         {% image page.background_image fill-1920x1080 as background_image %}
         background-image: url('{{ background_image.url }}');
       }
+      {% if page.background_video_url %}
+        .header-block {
+          background-image: none;
+        }
+      {% endif %}
     }
-  </style>
   {% endif %}
+  </style>
 {% endblock %}
 
 <div class="header-block">

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -13,23 +13,6 @@
   {% render_bundle 'header' %}
 {% endblock %}
 
-{% block extrahead %}
-  {{ block.super }}
-  <style>
-    .header-block {
-      {% image page.background_image fill-1024x768 as background_image %}
-      background-image: url('{{ background_image.url }}');
-    }
-
-    @media screen and (min-width: 1024px) {
-      .header-block {
-        {% image page.background_image fill-1920x1080 as background_image %}
-        background-image: url('{{ background_image.url }}');
-      }
-    }
-  </style>
-{% endblock %}
-
 {% block scripts %}
   {{ block.super }}
   <script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -17,7 +17,7 @@
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
 
-    @include media-breakpoint-down (lg) {
+    @include media-breakpoint-down (md) {
       display: none;
     }
   }

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -17,7 +17,7 @@
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
 
-    @include media-breakpoint-down (md) {
+    @include media-breakpoint-down (sm) {
       display: none;
     }
   }

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -13,9 +13,9 @@
   .background-video {
     position: absolute;
     width: 100%;
-    top: 50%;
+    bottom: 0;
     left: 50%;
-    transform: translateX(-50%) translateY(-50%);
+    transform: translateX(-50%) translateY(0%);
 
     @include media-breakpoint-down (sm) {
       display: none;

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -1,6 +1,8 @@
 // sass-lint:disable mixins-before-declarations
 #header {
   background-color: white;
+  position: relative;
+  z-index: 1;
 }
 
 .header-block {
@@ -10,14 +12,14 @@
 
   .background-video {
     position: absolute;
+    width: 100%;
     top: 50%;
     left: 50%;
-    min-width: 100%;
-    min-height: 100%;
-    width: auto;
-    height: auto;
-    z-index: -10;
     transform: translateX(-50%) translateY(-50%);
+
+    @include media-breakpoint-down (lg) {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #602 

#### What's this PR do?
Fixes video CSS to show video over background image but under any text or other elements in the header block. Video is 100% of width which should mean videos that change resolution will be shown correctly.

The video should not be visible at mobile resolutions. 

#### How should this be manually tested?
View the video on the homepage. At mobile resolutions you should see only the background image. Additionally you should be able to go to a program or course page as an anonymous user, click the 'Enroll now' link and see a tooltip which shows correctly. 

#### Screenshots

Desktop
![Screenshot from 2019-06-20 12-45-09](https://user-images.githubusercontent.com/863262/59866338-56414000-9359-11e9-9351-c4efb304a040.png)


Mobile
![Screenshot from 2019-06-20 12-45-25](https://user-images.githubusercontent.com/863262/59866343-59d4c700-9359-11e9-89e9-95e6e495bcf5.png)
