### PR TITLE
Catalog page sorting

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -25,7 +25,6 @@ from wagtail.images.models import Image
 from wagtail.snippets.models import register_snippet
 from wagtailmetadata.models import MetadataPageMixin
 
-
 from courses.constants import DEFAULT_COURSE_IMG_PATH
 from cms.blocks import (
     FacultyBlock,
@@ -34,6 +33,7 @@ from cms.blocks import (
     UserTestimonialBlock,
 )
 from cms.constants import COURSE_INDEX_SLUG, PROGRAM_INDEX_SLUG
+from cms.utils import sort_and_filter_pages
 from mitxpro.views import get_js_settings_context
 
 
@@ -161,8 +161,9 @@ class CatalogPage(Page):
         return dict(
             **super().get_context(request),
             **get_js_settings_context(request),
-            program_pages=program_pages,
-            course_pages=course_pages,
+            all_pages=sort_and_filter_pages(list(program_pages) + list(course_pages)),
+            program_pages=sort_and_filter_pages(program_pages),
+            course_pages=sort_and_filter_pages(course_pages),
             default_image_path=DEFAULT_COURSE_IMG_PATH,
             hubspot_portal_id=settings.HUBSPOT_CONFIG.get("HUBSPOT_PORTAL_ID"),
             hubspot_new_courses_form_guid=settings.HUBSPOT_CONFIG.get(
@@ -812,6 +813,11 @@ class ProductPage(MetadataPageMixin, Page):
     def propel_career(self):
         """Gets the propel your career section child page"""
         return self._get_child_page_of_type(TextSection)
+
+    @property
+    def is_course_page(self):
+        """Gets the product page type, this is used for sorting product pages."""
+        return isinstance(self, CoursePage)
 
 
 class ProgramPage(ProductPage):

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -621,3 +621,12 @@ def test_program_page_propel_career():
     assert propel_career_page.action_title == "Action Title"
     assert propel_career_page.content == "<p>content</p>"
     assert propel_career_page.dark_theme
+
+
+def test_is_course_page():
+    """Returns True if object is type of CoursePage"""
+    program_page = ProgramPageFactory.create()
+    course_page = CoursePageFactory.create()
+
+    assert not program_page.is_course_page
+    assert course_page.is_course_page

--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -40,11 +40,13 @@
             <div class="tab-content">
               <div class="tab-pane catalog-body fade in show active" id="all" role="tabpanel" aria-labelledby="all-tab">
                 <h1>FEATURED</h1>
-                {% for program_page in program_pages %}
-                    {% include "partials/catalog-card.html" with courseware_page=program_page object_type="program" tab="all" %}
-                {% endfor %}
-                {% for course_page in course_pages %}
-                    {% include "partials/catalog-card.html" with courseware_page=course_page object_type="course" tab="all"%}
+                {% for page in all_pages %}
+                  {% if page.program %}
+                      {% include "partials/catalog-card.html" with courseware_page=page object_type="program" tab="all" %}
+                  {% endif %}
+                  {% if page.course %}
+                      {% include "partials/catalog-card.html" with courseware_page=page object_type="course" tab="all"%}
+                  {% endif %}
                 {% endfor %}
               </div>
               <div class="tab-pane catalog-body fade" id="programs" role="tabpanel" aria-labelledby="programs-tab">

--- a/cms/utils.py
+++ b/cms/utils.py
@@ -1,0 +1,18 @@
+"""utils for cms"""
+
+
+def get_sort_keys(page):
+    """Key function for returning keys for sorting."""
+
+    return page.product.next_run_date, page.is_course_page, page.title
+
+
+def sort_and_filter_pages(pages):
+    """
+    Get list of pages and return sorted and filtered list. It will sort page
+    based on start_date, type and title.
+    """
+
+    return sorted(
+        [page for page in pages if page.product.next_run_date], key=get_sort_keys
+    )

--- a/cms/utils_test.py
+++ b/cms/utils_test.py
@@ -1,0 +1,67 @@
+"""Tests for CMS views"""
+from datetime import timedelta
+
+import pytest
+
+from cms.factories import CoursePageFactory, ProgramPageFactory
+from cms.utils import sort_and_filter_pages
+from courses.factories import CourseFactory, CourseRunFactory, ProgramFactory
+from mitxpro.utils import now_in_utc
+
+pytestmark = pytest.mark.django_db
+
+
+def test_sort_and_filter_pages():
+    """
+    Test that method exclude pages where start_date is not available.
+    """
+    first_program = ProgramFactory(title="first program")
+    second_program = ProgramFactory(title="second program")
+
+    expired_course = CourseFactory.create(title="expired course")
+    CourseRunFactory.create_batch(2, course=expired_course, past_start=True, live=True)
+
+    now = now_in_utc()
+    first_course = CourseFactory.create(title="first course", program=first_program)
+    CourseRunFactory.create(
+        course=first_course, start_date=(now + timedelta(hours=1)), live=True
+    )
+
+    second_course = CourseFactory.create(title="second course", program=second_program)
+    CourseRunFactory.create(
+        course=second_course, start_date=(now + timedelta(hours=2)), live=True
+    )
+
+    expired_course_page = CoursePageFactory.create(course=expired_course)
+    first_course_page = CoursePageFactory.create(course=first_course)
+    second_course_page = CoursePageFactory.create(course=second_course)
+    first_program_page = ProgramPageFactory.create(program=first_program)
+    second_program_page = ProgramPageFactory.create(program=second_program)
+
+    sorted_pages = sort_and_filter_pages(
+        [
+            expired_course_page,
+            first_course_page,
+            second_course_page,
+            second_program_page,
+            first_program_page,
+        ]
+    )
+
+    # assert expired_course_pages are filtered out
+    assert expired_course_page not in sorted_pages
+
+    # assert program should appear before course with same start date
+    assert sorted_pages.index(first_program_page) < sorted_pages.index(
+        first_course_page
+    )
+
+    # assert pages are sorted on start_date
+    assert sorted_pages.index(first_course_page) < sorted_pages.index(
+        second_course_page
+    )
+
+    # assert if stat_date is same, pages should be sorted by title.
+    assert sorted_pages.index(first_program_page) < sorted_pages.index(
+        second_program_page
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #568 

#### What's this PR do?
- [x] The start date for a course is the start date of it's soonest courserun , after courseruns with start dates in the past are excluded. 
- [x] The start date for a program is the start date of it's soonest courserun (for any course, not just the first one) , after courseruns with start dates in the past are excluded.
- [x] any courses or programs without a start date should appear at the end of the list (or they can be omitted, if that's significantly easier)
- [x] If a course and a program have the same start date, the program should come first 
- [x] if two courses or two programs have the same start date, they can be sorted alphabetically

#### How should this be manually tested?

- Add courses and program pages, with different start dates. 
- Card should sort based on above criteria.
