### PR TITLE
Convert signout MixedLink to regular <a> tag

### DIFF
--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -47,14 +47,10 @@ const UserMenu = ({ currentUser }: Props) => {
           Dashboard
         </MixedLink>
         <div className="dropdown-divider" />
-        <MixedLink
-          className="dropdown-item"
-          dest={routes.logout}
-          aria-label="Sign Out"
-        >
+        <a className="dropdown-item" href={routes.logout} aria-label="Sign Out">
           <div className="dropdown-icon icon-logout" />
           Sign Out
-        </MixedLink>
+        </a>
       </div>
     </div>
   )

--- a/static/js/components/UserMenu_test.js
+++ b/static/js/components/UserMenu_test.js
@@ -33,9 +33,9 @@ describe("UserMenu component", () => {
   it("has a link to logout", () => {
     assert.equal(
       shallow(<UserMenu currentUser={user} />)
-        .find("MixedLink")
-        .at(2)
-        .prop("dest"),
+        .find("a")
+        .at(0)
+        .prop("href"),
       routes.logout
     )
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #620 

#### What's this PR do?
Changes the logout button from a `MixedLink` to a vanilla `a` tag.

#### How should this be manually tested?
Click `Sign out` from a CMS page and a non-CMS page.  In both cases you should get logged out.

