### PR TITLE
#615 Add `live` filter to unexpired course runs

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -200,7 +200,7 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             (
                 course_run.start_date
                 for course_run in self.courseruns.all()
-                if course_run.start_date > now
+                if course_run.live and course_run.start_date > now
             ),
             default=None,
         )
@@ -214,7 +214,7 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             CourseRun or None: An unexpired course run
         """
         return first_matching_item(
-            self.courseruns.all().order_by("start_date"),
+            self.courseruns.filter(live=True).order_by("start_date"),
             lambda course_run: course_run.is_unexpired,
         )
 
@@ -226,7 +226,7 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         return list(
             filter(
                 op.attrgetter("is_unexpired"),
-                self.courseruns.all().order_by("start_date"),
+                self.courseruns.filter(live=True).order_by("start_date"),
             )
         )
 

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -58,7 +58,7 @@ def test_program_next_run_date():
     now = now_in_utc()
     future_dates = [now + timedelta(hours=1), now + timedelta(hours=2)]
     CourseRunFactory.create_batch(
-        2, course__program=program, start_date=factory.Iterator(future_dates)
+        2, course__program=program, start_date=factory.Iterator(future_dates), live=True
     )
     assert program.next_run_date == future_dates[0]
 
@@ -183,7 +183,11 @@ def test_course_first_unexpired_run():
     end_date = now + timedelta(days=100)
     enr_end_date = now + timedelta(days=100)
     first_run = CourseRunFactory.create(
-        start_date=now, course=course, end_date=end_date, enrollment_end=enr_end_date
+        start_date=now,
+        course=course,
+        end_date=end_date,
+        enrollment_end=enr_end_date,
+        live=True,
     )
     CourseRunFactory.create(
         start_date=now + timedelta(days=50),
@@ -204,7 +208,11 @@ def test_program_first_unexpired_run():
     end_date = now + timedelta(days=100)
     enr_end_date = now + timedelta(days=100)
     first_run = CourseRunFactory.create(
-        start_date=now, course=course, end_date=end_date, enrollment_end=enr_end_date
+        start_date=now,
+        course=course,
+        end_date=end_date,
+        enrollment_end=enr_end_date,
+        live=True,
     )
 
     # create another course and course run in program
@@ -231,7 +239,7 @@ def test_course_next_run_date():
     now = now_in_utc()
     future_dates = [now + timedelta(hours=1), now + timedelta(hours=2)]
     CourseRunFactory.create_batch(
-        2, course=course, start_date=factory.Iterator(future_dates)
+        2, course=course, start_date=factory.Iterator(future_dates), live=True
     )
     assert course.next_run_date == future_dates[0]
 
@@ -257,7 +265,14 @@ def test_course_unexpired_runs():
         course=course,
         start_date=factory.Iterator(start_dates),
         end_date=factory.Iterator(end_dates),
+        live=True,
     )
+
+    # Add a run that is not live and shouldn't show up in unexpired list
+    CourseRunFactory.create(
+        course=course, start_date=start_dates[0], end_date=end_dates[0], live=False
+    )
+
     assert len(course.unexpired_runs) == 1
     course_run = course.unexpired_runs[0]
     assert course_run.start_date == start_dates[0]
@@ -268,7 +283,7 @@ def test_course_available_runs():
     """enrolled runs for a user should not be in the list of available runs"""
     user = UserFactory.create()
     course = CourseFactory.create()
-    runs = CourseRunFactory.create_batch(2, course=course)
+    runs = CourseRunFactory.create_batch(2, course=course, live=True)
     runs.sort(key=lambda run: run.start_date)
     CourseRunEnrollmentFactory.create(run=runs[0], user=user)
     assert course.available_runs(user) == [runs[1]]

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -81,7 +81,7 @@ def test_base_course_serializer():
 def test_serialize_course(mock_context, with_runs):
     """Test Course serialization"""
     user = mock_context["request"].user
-    course_run = CourseRunFactory.create(course__no_program=True)
+    course_run = CourseRunFactory.create(course__no_program=True, live=True)
     course = course_run.course
 
     # Create expired, enrollment_ended, future, and enrolled course runs

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -235,7 +235,7 @@ def test_course_view(
     CoursePageFactory.create(course=course, parent=home_page)
 
     if has_unexpired_run:
-        run = CourseRunFactory.create(course=course)
+        run = CourseRunFactory.create(course=course, live=True)
     else:
         run = None
     if has_product and has_unexpired_run:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#615 

#### What's this PR do?
Adds a filter to unexpired course runs for `live=True`.

#### How should this be manually tested?
Add multiple course runs to a course. Have some of them `live=True` and others `live=False`. Only the course runs that are live should show up in the metadata tiles and through the "More Dates" popup.
