### PR TITLE
User hubspot-formatted purchaser id in OrderToDealSerializer

### DIFF
--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -45,6 +45,7 @@ class OrderToDealSerializer(serializers.ModelSerializer):
     company = serializers.SerializerMethodField(allow_null=True)
     lines = LineSerializer(many=True)
     b2b = serializers.SerializerMethodField()
+    purchaser = serializers.SerializerMethodField()
 
     _coupon_version = None
     _product_version = None
@@ -129,6 +130,10 @@ class OrderToDealSerializer(serializers.ModelSerializer):
             if company or transaction_id:
                 return True
         return False
+
+    def get_purchaser(self, instance):
+        """ Get the Hubspot ID for the purchaser"""
+        return format_hubspot_id(instance.purchaser.id)
 
     class Meta:
         fields = (

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -58,7 +58,7 @@ def test_serialize_order(status):
     assert serialized_data == {
         "id": order.id,
         "name": f"XPRO-ORDER-{order.id}",
-        "purchaser": order.purchaser.id,
+        "purchaser": format_hubspot_id(order.purchaser.id),
         "status": ORDER_STATUS_MAPPING[status],
         "amount": line.product_version.price.to_eng_string(),
         "discount_amount": "0.00",
@@ -87,7 +87,7 @@ def test_serialize_order_with_coupon():
     assert serialized_data == {
         "id": order.id,
         "name": f"XPRO-ORDER-{order.id}",
-        "purchaser": order.purchaser.id,
+        "purchaser": format_hubspot_id(order.purchaser.id),
         "status": ORDER_STATUS_MAPPING[order.status],
         "amount": line.product_version.price.to_eng_string(),
         "discount_amount": discount.to_eng_string(),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #623 

#### What's this PR do?
- Uses a hubspot-formatted purchaser id in the `OrderToDealSerializer`

#### How should this be manually tested?
- Create a new user.
- Order a product as that user.
- Sign in to Hubspot and find the new order, it should be associated with the contact you just created.
