### PR TITLE
Create 'Coupons' group and additional properties for Hubspot deals

### DIFF
--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -288,8 +288,9 @@ def sync_object_property(object_type, property_dict):
     missing_fields = required_fields.difference(property_dict.keys())
     if missing_fields:
         raise KeyError(
-            f"The following property attributes are required: %s",
-            ",".join(missing_fields),
+            "The following property attributes are required: {}".format(
+                ",".join(missing_fields)
+            )
         )
 
     for key in property_dict.keys():

--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -8,6 +8,7 @@ import re
 from urllib.parse import urljoin, urlencode
 import requests
 from django.conf import settings
+from requests import HTTPError
 
 from mitxpro.utils import now_in_utc
 
@@ -87,6 +88,8 @@ def send_hubspot_request(
         return requests.put(url=url, json=body, **kwargs)
     if method == "POST":
         return requests.post(url=url, json=body, **kwargs)
+    if method == "DELETE":
+        return requests.delete(url=url, **kwargs)
 
 
 def make_sync_message(object_id, properties):
@@ -266,3 +269,198 @@ def make_product_sync_message(product_id):
     product = Product.objects.get(id=product_id)
     properties = ProductSerializer(product).data
     return [make_sync_message(product_id, properties)]
+
+
+def sync_object_property(object_type, property_dict):
+    """
+    Create or update a new object property
+
+
+    Args:
+        object_type (str): The object type of the property (ie "deals")
+        property_dict (dict): The attributes of the property
+
+    Returns:
+        dict:  The new/updated property attributes
+    """
+    required_fields = {"name", "label", "groupName"}
+
+    missing_fields = required_fields.difference(property_dict.keys())
+    if missing_fields:
+        raise KeyError(
+            f"The following property attributes are required: %s", ",".join(missing_fields)
+        )
+
+    for key in property_dict.keys():
+        if property_dict[key] is None:
+            property_dict[key] = ""
+
+    exists = object_property_exists(object_type, property_dict["name"])
+
+    if exists:
+        method = "PUT"
+        endpoint = f"named/{property_dict['name']}"
+    else:
+        method = "POST"
+        endpoint = ""
+
+    response = send_hubspot_request(
+        endpoint,
+        f"/properties/v1/{object_type}/properties",
+        method,
+        body=property_dict,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_object_property(object_type, property_name):
+    """
+    Get a Hubspot object property.
+
+    Args:
+        object_type (str): The object type of the property (ie "deals")
+        property_name (str): The property name
+
+    Returns:
+        dict:  the property attributes
+    """
+    response = send_hubspot_request(
+        property_name,
+        f"/properties/v1/{object_type}/properties/named"
+        "GET",
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def object_property_exists(object_type, property_name):
+    """
+    Return True if the specified property exists, False otherwise
+
+    Args:
+        object_type (str): The object type of the property (ie "deals")
+        property_name (str): The property name
+
+    Returns:
+        boolean:  True if the property exists otherwise False
+    """
+    try:
+        get_object_property(object_type, property_name)
+        return True
+    except HTTPError:
+        return False
+
+
+def delete_object_property(object_type, property_name):
+    """
+    Delete a property from Hubspot
+
+    Args:
+        object_type (str): The object type of the property (ie "deals")
+        property_name (str): The property name
+
+    Returns:
+        dict:  the result of the delete request in JSON format
+    """
+    response = send_hubspot_request(
+        "",
+        "/properties/v1/{}/properties/named/{}".format(
+            object_type.lower(), property_name
+        ),
+        "DELETE",
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_property_group(object_type, group_name):
+    """
+    Get a Hubspot property group.
+
+    Args:
+        object_type (str): The object type of the group (ie "deals")
+        group_name (str): The group name
+
+    Returns:
+        dict:  The group attributes
+    """
+    response = send_hubspot_request(
+        group_name,
+        f"/properties/v1/{object_type}/groups/named",
+        "GET",
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def property_group_exists(object_type, group_name):
+    """
+    Return True if the specified group exists (status=200), False otherwise
+
+    Args:
+        object_type (str): The object type of the group (ie "deals")
+        group_name (str): The group name
+
+    Returns:
+        boolean:  True if the group exists otherwise False
+    """
+    try:
+        get_property_group(object_type, group_name)
+        return True
+    except HTTPError:
+        return False
+
+
+def sync_property_group(object_type, name, label):
+    """
+    Create or update a property group for an object type
+
+    Args:
+        object_type (str): The object type of the group (ie "deals")
+        name (str): The group name
+        label (str): The group label
+
+    Returns:
+        dict:  the new/updated group attributes
+
+    """
+    body = {"name": name, "displayName": label}
+
+    exists = property_group_exists(object_type, name)
+
+    if exists:
+        method = "PUT"
+        endpoint = f"named/{name}"
+    else:
+        method = "POST"
+        endpoint = ""
+
+    response = send_hubspot_request(
+        endpoint,
+        f"/properties/v1/{object_type}/groups",
+        method,
+        body=body,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def delete_property_group(object_type, group_name):
+    """
+    Delete a group from Hubspot
+
+    Args:
+        object_type (str): The object type of the group (ie "deals")
+        group_name (str): The group name
+
+    Returns:
+        dict:  The result of the delete command in JSON format
+    """
+    response = send_hubspot_request(
+        "",
+        "/properties/v1/{}/groups/named/{}".format(object_type.lower(), group_name),
+        "DELETE",
+    )
+    response.raise_for_status()
+    return response.json()

--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -6,9 +6,9 @@ https://developers.hubspot.com/docs/methods/ecomm-bridge/ecomm-bridge-overview
 import logging
 import re
 from urllib.parse import urljoin, urlencode
+
 import requests
 from django.conf import settings
-from requests import HTTPError
 
 from mitxpro.utils import now_in_utc
 
@@ -288,7 +288,8 @@ def sync_object_property(object_type, property_dict):
     missing_fields = required_fields.difference(property_dict.keys())
     if missing_fields:
         raise KeyError(
-            f"The following property attributes are required: %s", ",".join(missing_fields)
+            f"The following property attributes are required: %s",
+            ",".join(missing_fields),
         )
 
     for key in property_dict.keys():
@@ -305,10 +306,7 @@ def sync_object_property(object_type, property_dict):
         endpoint = ""
 
     response = send_hubspot_request(
-        endpoint,
-        f"/properties/v1/{object_type}/properties",
-        method,
-        body=property_dict,
+        endpoint, f"/properties/v1/{object_type}/properties", method, body=property_dict
     )
     response.raise_for_status()
     return response.json()
@@ -326,9 +324,7 @@ def get_object_property(object_type, property_name):
         dict:  the property attributes
     """
     response = send_hubspot_request(
-        property_name,
-        f"/properties/v1/{object_type}/properties/named"
-        "GET",
+        property_name, f"/properties/v1/{object_type}/properties/named", "GET"
     )
     response.raise_for_status()
     return response.json()
@@ -348,7 +344,7 @@ def object_property_exists(object_type, property_name):
     try:
         get_object_property(object_type, property_name)
         return True
-    except HTTPError:
+    except requests.HTTPError:
         return False
 
 
@@ -386,9 +382,7 @@ def get_property_group(object_type, group_name):
         dict:  The group attributes
     """
     response = send_hubspot_request(
-        group_name,
-        f"/properties/v1/{object_type}/groups/named",
-        "GET",
+        group_name, f"/properties/v1/{object_type}/groups/named", "GET"
     )
     response.raise_for_status()
     return response.json()
@@ -408,7 +402,7 @@ def property_group_exists(object_type, group_name):
     try:
         get_property_group(object_type, group_name)
         return True
-    except HTTPError:
+    except requests.HTTPError:
         return False
 
 
@@ -437,10 +431,7 @@ def sync_property_group(object_type, name, label):
         endpoint = ""
 
     response = send_hubspot_request(
-        endpoint,
-        f"/properties/v1/{object_type}/groups",
-        method,
-        body=body,
+        endpoint, f"/properties/v1/{object_type}/groups", method, body=body
     )
     response.raise_for_status()
     return response.json()

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -24,10 +24,7 @@ test_object_type = "deals"
 @pytest.fixture
 def property_group():
     """ Return sample group JSON """
-    return {
-        "name": "grpup_name",
-        "label": "Group Label"
-    }
+    return {"name": "grpup_name", "label": "Group Label"}
 
 
 @pytest.mark.parametrize("request_method", ["GET", "PUT", "POST"])
@@ -275,12 +272,17 @@ def test_sync_object_property(
             )
         else:
             assert mock_hubspot_api_request.called_with(
-                "", f"/properties/v1/{test_object_type}/properties", "POST", mock_property
+                "",
+                f"/properties/v1/{test_object_type}/properties",
+                "POST",
+                mock_property,
             )
 
 
 @pytest.mark.parametrize("object_exists", [True, False])
-def test_sync_property_group(mocker, mock_hubspot_api_request, object_exists, property_group):
+def test_sync_property_group(
+    mocker, mock_hubspot_api_request, object_exists, property_group
+):
     """sync_object_property should call send_hubspot_request with the correct arguments"""
     mocker.patch("hubspot.api.object_property_exists", return_value=object_exists)
     group_name = property_group["name"]
@@ -303,7 +305,9 @@ def test_delete_property_group(mock_hubspot_api_request, property_group):
     """ delete_property_group should call send_hubspot_request with the correct arguments"""
     api.delete_object_property(test_object_type, property_group["name"])
     assert mock_hubspot_api_request.called_with(
-        f"named/{property_group['name']}", f"/properties/v1/{test_object_type}/groups", "DELETE"
+        f"named/{property_group['name']}",
+        f"/properties/v1/{test_object_type}/groups",
+        "DELETE",
     )
 
 
@@ -311,5 +315,7 @@ def test_delete_object_property(mock_hubspot_api_request, property_group):
     """ delete_object_property should call send_hubspot_request with the correct arguments"""
     api.delete_object_property(test_object_type, property_group["name"])
     assert mock_hubspot_api_request.called_with(
-        f"named/{ property_group['name']}", f"/properties/v1/{test_object_type}/groups", "DELETE"
+        f"named/{ property_group['name']}",
+        f"/properties/v1/{test_object_type}/groups",
+        "DELETE",
     )

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -11,22 +11,23 @@ from faker import Faker
 from requests import HTTPError
 
 from ecommerce.factories import LineFactory, ProductFactory
-from hubspot.api import (
-    send_hubspot_request,
-    HUBSPOT_API_BASE_URL,
-    make_sync_message,
-    make_contact_sync_message,
-    make_deal_sync_message,
-    make_line_item_sync_message,
-    make_product_sync_message,
-    get_sync_errors,
-    exists_in_hubspot,
-)
+from hubspot import api
 from hubspot.serializers import OrderToDealSerializer, LineSerializer, ProductSerializer
 from mitxpro.test_utils import any_instance_of
 from users.serializers import UserSerializer
 
 fake = Faker()
+
+test_object_type = "deals"
+
+
+@pytest.fixture
+def property_group():
+    """ Return sample group JSON """
+    return {
+        "name": "grpup_name",
+        "label": "Group Label"
+    }
 
 
 @pytest.mark.parametrize("request_method", ["GET", "PUT", "POST"])
@@ -36,17 +37,17 @@ fake = Faker()
         [
             "sync-errors",
             "/extensions/ecomm/v1",
-            f"{HUBSPOT_API_BASE_URL}/extensions/ecomm/v1/sync-errors",
+            f"{api.HUBSPOT_API_BASE_URL}/extensions/ecomm/v1/sync-errors",
         ],
         [
             "",
             "/extensions/ecomm/v1/installs",
-            f"{HUBSPOT_API_BASE_URL}/extensions/ecomm/v1/installs",
+            f"{api.HUBSPOT_API_BASE_URL}/extensions/ecomm/v1/installs",
         ],
         [
             "CONTACT",
             "/extensions/ecomm/v1/sync-messages",
-            f"{HUBSPOT_API_BASE_URL}/extensions/ecomm/v1/sync-messages/CONTACT",
+            f"{api.HUBSPOT_API_BASE_URL}/extensions/ecomm/v1/sync-messages/CONTACT",
         ],
     ],
 )
@@ -61,13 +62,13 @@ def test_send_hubspot_request(mocker, request_method, endpoint, api_url, expecte
     url_params = urlencode(full_query_params)
     url = f"{expected_url}?{url_params}"
     if request_method == "GET":
-        send_hubspot_request(
+        api.send_hubspot_request(
             endpoint, api_url, request_method, query_params=query_params
         )
         mock_request.assert_called_once_with(url=url)
     else:
         body = fake.pydict()
-        send_hubspot_request(
+        api.send_hubspot_request(
             endpoint, api_url, request_method, query_params=query_params, body=body
         )
         mock_request.assert_called_once_with(url=url, json=body)
@@ -78,7 +79,7 @@ def test_make_sync_message():
     object_id = fake.pyint()
     value = fake.word()
     properties = {"prop": value, "blank": None}
-    sync_message = make_sync_message(object_id, properties)
+    sync_message = api.make_sync_message(object_id, properties)
     assert sync_message == (
         {
             "integratorObjectId": "{}-{}".format(settings.HUBSPOT_ID_PREFIX, object_id),
@@ -91,7 +92,7 @@ def test_make_sync_message():
 
 def test_make_contact_sync_message(user):
     """Test make_contact_sync_message serializes a user and returns a properly formatted sync message"""
-    contact_sync_message = make_contact_sync_message(user.id)
+    contact_sync_message = api.make_contact_sync_message(user.id)
 
     serialized_user = UserSerializer(user).data
     serialized_user.update(serialized_user.pop("legal_address") or {})
@@ -111,7 +112,7 @@ def test_make_contact_sync_message(user):
 def test_get_sync_errors(mock_hubspot_errors, offset):
     """Test that paging works for get_sync_errors"""
     limit = 2
-    errors = list(get_sync_errors(limit, offset))
+    errors = list(api.get_sync_errors(limit, offset))
     assert len(errors) == 4
     mock_hubspot_errors.assert_any_call(limit, offset)
     mock_hubspot_errors.assert_any_call(limit, offset + limit)
@@ -131,19 +132,20 @@ def test_exists_in_hubspot(mocker, sync_status, exists):
     mock_get_sync_status = mocker.patch(
         "hubspot.api.get_sync_status", side_effect=sync_status
     )
-    assert exists_in_hubspot("OBJECT", 1) == exists
+    assert api.exists_in_hubspot("OBJECT", 1) == exists
     mock_get_sync_status.assert_called_once_with("OBJECT", 1)
 
 
 @pytest.mark.django_db
 def test_make_deal_sync_message(hubspot_order):
     """Test make_deal_sync_message serializes a deal and returns a properly formatted sync message"""
-    deal_sync_message = make_deal_sync_message(hubspot_order.id)
+    deal_sync_message = api.make_deal_sync_message(hubspot_order.id)
 
     serialized_order = OrderToDealSerializer(hubspot_order).data
     serialized_order.pop("lines")
-    if serialized_order["close_date"] is None:
-        serialized_order["close_date"] = ""
+    for key in serialized_order.keys():
+        if serialized_order[key] is None:
+            serialized_order[key] = ""
     assert deal_sync_message == [
         {
             "integratorObjectId": "{}-{}".format(
@@ -160,7 +162,7 @@ def test_make_deal_sync_message(hubspot_order):
 def test_make_line_item_sync_message():
     """Test make_line_item_sync_message serializes a line_item and returns a properly formatted sync message"""
     line = LineFactory()
-    line_item_sync_message = make_line_item_sync_message(line.id)
+    line_item_sync_message = api.make_line_item_sync_message(line.id)
 
     serialized_line = LineSerializer(line).data
     assert line_item_sync_message == [
@@ -177,7 +179,7 @@ def test_make_line_item_sync_message():
 def test_make_product_sync_message():
     """Test make_deal_sync_message serializes a deal and returns a properly formatted sync message"""
     product = ProductFactory()
-    contact_sync_message = make_product_sync_message(product.id)
+    contact_sync_message = api.make_product_sync_message(product.id)
 
     serialized_product = ProductSerializer(product).data
     assert contact_sync_message == [
@@ -190,3 +192,124 @@ def test_make_product_sync_message():
             "propertyNameToValues": serialized_product,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "property_status, exists",
+    [
+        [HTTPError(response=HttpResponse(status=400)), False],
+        [HttpResponse(status=200), True],
+    ],
+)
+def test_object_property_exists(mocker, property_status, exists):
+    """Test that object_property_exists returns True if the property exists and False otherwise"""
+    mock_get_object_property = mocker.patch(
+        "hubspot.api.get_object_property", side_effect=property_status
+    )
+    assert api.object_property_exists("deals", "my_property") == exists
+    mock_get_object_property.assert_called_once_with("deals", "my_property")
+
+
+@pytest.mark.parametrize(
+    "group_status, exists",
+    [
+        [HTTPError(response=HttpResponse(status=400)), False],
+        [HttpResponse(status=200), True],
+    ],
+)
+def test_property_group_exists(mocker, group_status, exists):
+    """Test that property_group_exists returns True if the group exists and False otherwise"""
+    mock_get_property_group = mocker.patch(
+        "hubspot.api.get_property_group", side_effect=group_status
+    )
+    assert api.property_group_exists("deals", "my_group") == exists
+    mock_get_property_group.assert_called_once_with("deals", "my_group")
+
+
+def test_get_property_group(mock_hubspot_api_request, property_group):
+    """ get_property_group should call send_hubspot_request with the correct arguments"""
+    group_name = property_group["name"]
+    api.get_property_group(test_object_type, group_name)
+    assert mock_hubspot_api_request.called_with(
+        group_name, f"/properties/v1/{test_object_type}/groups/named", "GET"
+    )
+
+
+def test_get_object_property(mock_hubspot_api_request):
+    """ get_object_property should call send_hubspot_request with the correct arguments"""
+    property_name = "y"
+    api.get_object_property(test_object_type, property_name)
+    assert mock_hubspot_api_request.called_with(
+        f"named/{property_name}", f"/properties/v1/{test_object_type}/properties", "GET"
+    )
+
+
+@pytest.mark.parametrize("is_valid", [True, False])
+@pytest.mark.parametrize("object_exists", [True, False])
+def test_sync_object_property(
+    mocker, mock_hubspot_api_request, object_exists, is_valid
+):
+    """sync_object_property should call send_hubspot_request with the correct arguments"""
+    mocker.patch("hubspot.api.object_property_exists", return_value=object_exists)
+    mock_property = {
+        "name": "property_name",
+        "label": "Property Label",
+        "groupName": "Property Group",
+        "description": "Property description",
+        "field_type": "text",
+        "type": "string",
+    }
+
+    if not is_valid:
+        mock_property.pop("name")
+        with pytest.raises(KeyError):
+            api.sync_object_property(test_object_type, mock_property)
+    else:
+        api.sync_object_property(test_object_type, mock_property)
+        if object_exists:
+            assert mock_hubspot_api_request.called_with(
+                f"named/{mock_property['name']}",
+                f"/properties/v1/{test_object_type}/properties",
+                "PUT",
+                mock_property,
+            )
+        else:
+            assert mock_hubspot_api_request.called_with(
+                "", f"/properties/v1/{test_object_type}/properties", "POST", mock_property
+            )
+
+
+@pytest.mark.parametrize("object_exists", [True, False])
+def test_sync_property_group(mocker, mock_hubspot_api_request, object_exists, property_group):
+    """sync_object_property should call send_hubspot_request with the correct arguments"""
+    mocker.patch("hubspot.api.object_property_exists", return_value=object_exists)
+    group_name = property_group["name"]
+    group_label = property_group["label"]
+    api.sync_property_group(test_object_type, group_name, group_label)
+    if object_exists:
+        assert mock_hubspot_api_request.called_with(
+            f"named/{group_name}",
+            f"/properties/v1/{test_object_type}/groups",
+            "PUT",
+            property_group,
+        )
+    else:
+        assert mock_hubspot_api_request.called_with(
+            "", f"/properties/v1/{test_object_type}/groups", "POST", property_group
+        )
+
+
+def test_delete_property_group(mock_hubspot_api_request, property_group):
+    """ delete_property_group should call send_hubspot_request with the correct arguments"""
+    api.delete_object_property(test_object_type, property_group["name"])
+    assert mock_hubspot_api_request.called_with(
+        f"named/{property_group['name']}", f"/properties/v1/{test_object_type}/groups", "DELETE"
+    )
+
+
+def test_delete_object_property(mock_hubspot_api_request, property_group):
+    """ delete_object_property should call send_hubspot_request with the correct arguments"""
+    api.delete_object_property(test_object_type, property_group["name"])
+    assert mock_hubspot_api_request.called_with(
+        f"named/{ property_group['name']}", f"/properties/v1/{test_object_type}/groups", "DELETE"
+    )

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -24,7 +24,7 @@ test_object_type = "deals"
 @pytest.fixture
 def property_group():
     """ Return sample group JSON """
-    return {"name": "grpup_name", "label": "Group Label"}
+    return {"name": "group_name", "label": "Group Label"}
 
 
 @pytest.mark.parametrize("request_method", ["GET", "PUT", "POST"])

--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -163,6 +163,12 @@ def mock_hubspot_request(mocker):
 
 
 @pytest.fixture
+def mock_hubspot_api_request(mocker):
+    """Mock the send hubspot request method"""
+    yield mocker.patch("hubspot.api.send_hubspot_request")
+
+
+@pytest.fixture
 def hubspot_order():
     """ Return an order for testing with hubspot"""
     order = factories.OrderFactory()

--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -44,7 +44,7 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                         "displayOrder": 1,
                         "hidden": False,
                     },
-                ]
+                ],
             },
             {
                 "name": "discount_percent",
@@ -325,25 +325,23 @@ def configure_hubspot_settings():
 
 
 def install_custom_properties():
-    for object_type in CUSTOM_ECOMMERCE_PROPERTIES.keys():
+    """Create or update all custom properties and groups"""
+    for object_type in CUSTOM_ECOMMERCE_PROPERTIES:
         for group in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["groups"]:
-            sync_property_group(
-                object_type, group["name"], group["label"]
-            )
+            sync_property_group(object_type, group["name"], group["label"])
         for obj_property in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["properties"]:
             sync_object_property(object_type, obj_property)
 
 
-
 def uninstall_custom_properties():
-    for object_type in CUSTOM_ECOMMERCE_PROPERTIES.keys():
+    """Delete all custom properties and groups"""
+    for object_type in CUSTOM_ECOMMERCE_PROPERTIES:
         for obj_property in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["properties"]:
             if object_property_exists(object_type, obj_property):
                 delete_object_property(object_type, obj_property)
         for group in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["groups"]:
             if property_group_exists(object_type, group):
                 delete_property_group(object_type, group)
-
 
 
 def get_hubspot_settings():

--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -5,11 +5,91 @@ and Line Items
 import json
 from django.core.management import BaseCommand
 
-from hubspot.api import send_hubspot_request
+from hubspot.api import (
+    send_hubspot_request,
+    property_group_exists,
+    sync_property_group,
+    sync_object_property,
+    delete_object_property,
+    delete_property_group,
+    object_property_exists,
+)
 
 # Hubspot ecommerce settings define which hubspot properties are mapped with which
 # local properties when objects are synced.
 # See https://developers.hubspot.com/docs/methods/ecomm-bridge/ecomm-bridge-overview for more details
+from hubspot.serializers import ORDER_TYPE_B2B, ORDER_TYPE_B2C
+
+CUSTOM_ECOMMERCE_PROPERTIES = {
+    "deals": {
+        "groups": [{"name": "coupon", "label": "Coupon"}],
+        "properties": [
+            {
+                "name": "order_type",
+                "label": "Order Type",
+                "description": "B2B or B2C",
+                "groupName": "dealinformation",
+                "type": "enumeration",
+                "fieldType": "select",
+                "options": [
+                    {
+                        "value": ORDER_TYPE_B2B,
+                        "label": ORDER_TYPE_B2B,
+                        "displayOrder": 0,
+                        "hidden": False,
+                    },
+                    {
+                        "value": ORDER_TYPE_B2C,
+                        "label": ORDER_TYPE_B2C,
+                        "displayOrder": 1,
+                        "hidden": False,
+                    },
+                ]
+            },
+            {
+                "name": "discount_percent",
+                "label": "Percent Discount",
+                "description": "Percentage off regular price",
+                "groupName": "coupon",
+                "type": "number",
+                "fieldType": "text",
+            },
+            {
+                "name": "payment_transaction",
+                "label": "Payment Transaction ID",
+                "description": "ID of payment transaction",
+                "groupName": "coupon",
+                "type": "string",
+                "fieldType": "text",
+            },
+            {
+                "name": "payment_type",
+                "label": "Payment Type",
+                "description": "type of payment transaction",
+                "groupName": "coupon",
+                "type": "string",
+                "fieldType": "text",
+            },
+            {
+                "name": "coupon_code",
+                "label": "Coupon Code",
+                "description": "The coupon code used for the purchase",
+                "groupName": "coupon",
+                "type": "string",
+                "fieldType": "text",
+            },
+            {
+                "name": "company",
+                "label": "Company",
+                "description": "The company associated with the coupon",
+                "groupName": "coupon",
+                "type": "string",
+                "fieldType": "text",
+            },
+        ],
+    }
+}
+
 HUBSPOT_ECOMMERCE_SETTINGS = {
     "enabled": True,
     "productSyncSettings": {
@@ -150,7 +230,7 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
             {
                 "propertyName": "coupon_code",
                 "targetHubspotProperty": "coupon_code",
-                "dataType": "NUMBER",
+                "dataType": "STRING",
             },
             {
                 "propertyName": "purchaser",
@@ -165,6 +245,26 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
             {
                 "propertyName": "company",
                 "targetHubspotProperty": "company",
+                "dataType": "STRING",
+            },
+            {
+                "propertyName": "payment_type",
+                "targetHubspotProperty": "payment_type",
+                "dataType": "STRING",
+            },
+            {
+                "propertyName": "payment_transaction",
+                "targetHubspotProperty": "payment_transaction",
+                "dataType": "STRING",
+            },
+            {
+                "propertyName": "discount_percent",
+                "targetHubspotProperty": "discount_percent",
+                "dataType": "NUMBER",
+            },
+            {
+                "propertyName": "order_type",
+                "targetHubspotProperty": "order_type",
                 "dataType": "STRING",
             },
         ]
@@ -224,6 +324,28 @@ def configure_hubspot_settings():
     return response
 
 
+def install_custom_properties():
+    for object_type in CUSTOM_ECOMMERCE_PROPERTIES.keys():
+        for group in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["groups"]:
+            sync_property_group(
+                object_type, group["name"], group["label"]
+            )
+        for obj_property in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["properties"]:
+            sync_object_property(object_type, obj_property)
+
+
+
+def uninstall_custom_properties():
+    for object_type in CUSTOM_ECOMMERCE_PROPERTIES.keys():
+        for obj_property in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["properties"]:
+            if object_property_exists(object_type, obj_property):
+                delete_object_property(object_type, obj_property)
+        for group in CUSTOM_ECOMMERCE_PROPERTIES[object_type]["groups"]:
+            if property_group_exists(object_type, group):
+                delete_property_group(object_type, group)
+
+
+
 def get_hubspot_settings():
     """Get the current Hubspot ecommerce bridge settings for the api key specified in settings"""
     response = send_hubspot_request("", HUBSPOT_SETTINGS_PATH, "GET")
@@ -262,32 +384,26 @@ class Command(BaseCommand):
             f"Checking Hubspot Ecommerce Bridge installation for given Hubspot API Key..."
         )
         installation_status = json.loads(get_hubspot_installation_status().text)
+        print(installation_status)
         if options["status"]:
             print(f"Install completed: {installation_status['installCompleted']}")
             print(
                 f"Ecommerce Settings enabled: {installation_status['ecommSettingsEnabled']}"
             )
-        if options["uninstall"]:
+        elif options["uninstall"]:
             if installation_status["installCompleted"]:
                 print("Uninstalling Ecommerce Bridge...")
                 uninstall_hubspot_ecommerce_bridge()
+                print("Uninstalling cutsom groups and properties...")
+                uninstall_custom_properties()
                 print("Uninstall successful")
                 return
             else:
                 print("Ecommerce Bridge is not installed")
                 return
-        if not installation_status["installCompleted"]:
-            print(f"Installation not found. Installing now...")
-            install_hubspot_ecommerce_bridge()
-            print("Install successful")
-        else:
-            print(f"Installation found")
-        if options["status"]:
-            print("Getting settings...")
-            ecommerce_bridge_settings = json.loads(get_hubspot_settings().text)
-            print("Found settings:")
-            print(ecommerce_bridge_settings)
         else:
             print(f"Configuring settings...")
             configure_hubspot_settings()
-            print(f"Settings configured")
+            print(f"Configuring custom groups and properties...")
+            install_custom_properties()
+            print(f"Settings and custom properties configured")

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -19,6 +19,8 @@ from hubspot.serializers import (
     LineSerializer,
     OrderToDealSerializer,
     ORDER_STATUS_MAPPING,
+    ORDER_TYPE_B2C,
+    ORDER_TYPE_B2B,
 )
 
 pytestmark = [pytest.mark.django_db]
@@ -69,7 +71,10 @@ def test_serialize_order(status):
         ),
         "coupon_code": None,
         "company": None,
-        "b2b": False,
+        "payment_type": None,
+        "payment_transaction": None,
+        "discount_percent": "0",
+        "order_type": ORDER_TYPE_B2C,
         "lines": [LineSerializer(instance=line).data],
     }
 
@@ -98,6 +103,11 @@ def test_serialize_order_with_coupon():
         ),
         "coupon_code": coupon_redemption.coupon_version.coupon.coupon_code,
         "company": coupon_redemption.coupon_version.payment_version.company.name,
-        "b2b": True,
+        "order_type": ORDER_TYPE_B2B,
+        "payment_type": coupon_redemption.coupon_version.payment_version.payment_type,
+        "payment_transaction": coupon_redemption.coupon_version.payment_version.payment_transaction,
+        "discount_percent": (
+            coupon_redemption.coupon_version.payment_version.amount * 100
+        ).to_eng_string(),
         "lines": [LineSerializer(instance=line).data],
     }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #497 
Closes #498

#### What's this PR do?
- Modifies the `configure_hubspot_bridge` command to create/update new properties (`payment_type`, `payment_transaction`, `discount_percent`, `order_type`) and a new group `coupons` to contain most of these (along with some other existing properties - `company`, `coupon_code`).

#### How should this be manually tested?
`docker-compose run web python manage.py configure_hubspot_bridge`
`docker-compose run web python manage.py sync_hubspot`

You can also manually purchase something: use a single-use coupon with an affiliated company, payment type, and payment transaction.

Log into Hubspot and verify that the order(s) have the new fields, they are correctly populated, and assigned to the correct group.
