### PR TITLE
Styling of youtube video of different aspect ratio

### DIFF
--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -164,7 +164,7 @@
       height: 260px;
 
       iframe {
-        height: 250px;
+        height: 100%;
         width: 100%;
       }
     }

--- a/static/scss/detail/text-video-section.scss
+++ b/static/scss/detail/text-video-section.scss
@@ -26,6 +26,11 @@
 
       &.youtube-video {
         height: 280px;
+
+        iframe {
+          width: 100%;
+          height: 100%;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #619 

#### What's this PR do?
Fix styling of youtube video of home and product page.

#### How should this be manually tested?

- Add youtube video in home or product page with different aspect ratio.
- It should render within parent container.

#### Any background context you want to provide?
Introduce in #590 

#### Screenshots (if appropriate)
**Youtube video**
<img width="609" alt="Screen Shot 2019-06-21 at 11 37 20 AM" src="https://user-images.githubusercontent.com/4245618/59903242-e941af00-9419-11e9-8e06-5440216cc6f7.png">

**Rendered:**
<img width="680" alt="Screen Shot 2019-06-21 at 11 37 08 AM" src="https://user-images.githubusercontent.com/4245618/59903240-e8a91880-9419-11e9-843b-6f57f63dfb6a.png">
