### PR TITLE
#610 TemplateDoesNotExist should raise a 404

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -80,6 +80,13 @@ class CourseObjectIndexPage(Page):
             return subpage.specific.route(request, remaining_components)
         return super().route(request, path_components)
 
+    def serve(self, request, *args, **kwargs):
+        """
+        For index pages we raise a 404 because these pages do not have a template
+        of their own and we do not expect a page to available at their slug.
+        """
+        raise Http404
+
 
 class CourseIndexPage(CourseObjectIndexPage):
     """
@@ -191,6 +198,13 @@ class CourseProgramChildPage(Page):
             self.title = self.__class__._meta.verbose_name.title()
         self.slug = slugify("{}-{}".format(self.get_parent().id, self.title))
         super().save(*args, **kwargs)
+
+    def serve(self, request, *args, **kwargs):
+        """
+        As the name suggests these pages are going to be children of some other page. They are not
+        designed to be viewed on their own so we raise a 404 if someone tries to access their slug.
+        """
+        raise Http404
 
 
 # Cannot name TestimonialPage otherwise pytest will try to pick up as a test

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -3,8 +3,10 @@ import pytest
 
 from django.urls import reverse
 from wagtail.core.models import Site
+from rest_framework import status
 
-from cms.models import HomePage
+from cms.factories import TextSectionFactory
+from cms.models import HomePage, CourseIndexPage, ProgramIndexPage
 
 pytestmark = pytest.mark.django_db
 
@@ -25,3 +27,43 @@ def test_home_page_view(client):
     assert reverse("user-dashboard") not in content
     assert reverse("checkout-page") not in content
     assert "dropdown-menu" not in content
+
+
+def test_courses_index_view(client):
+    """
+    Test that the courses index page shows a 404
+    """
+    root = Site.objects.get(is_default_site=True).root_page
+    page, created = CourseIndexPage.objects.get_or_create()
+
+    if created:
+        root.add_child(instance=page)
+
+    resp = client.get(page.get_url())
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_programs_index_view(client):
+    """
+    Test that the programs index page shows a 404
+    """
+    root = Site.objects.get(is_default_site=True).root_page
+    page, created = ProgramIndexPage.objects.get_or_create()
+
+    if created:
+        root.add_child(instance=page)
+
+    resp = client.get(page.get_url())
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_course_program_child_view(client):
+    """
+    Test that course/program child pages show a 404
+    """
+    root = Site.objects.get(is_default_site=True).root_page
+
+    child_page = TextSectionFactory.create(parent=root)
+    child_page.save_revision().publish()
+    resp = client.get(child_page.get_url())
+    assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#610 

#### What's this PR do?
Overrides the `serve` method for page classes that are not to be viewed on their own, to raise a 404 rather than throwing a `TemplateNotFound` exception.

#### How should this be manually tested?
In the CMS, go to any course/program child page and click on the `live` link. It should show a 404 page. Alternatively you can also try going to `/courses/` and `/programs/` and it should show a 404 page.
