### PR TITLE
Send email to support when enrollments fail

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -520,20 +520,19 @@ def format_enrollment_message(order, obj, details):
     Args:
         order (Order): the order with a failed enrollment
         obj (Program or CourseRun): the object that failed enrollment
+        details (str): Details of the error (typically a stack trace)
 
     Returns:
         str: The formatted error message
     """
-    return (
-        "{name}({email}): Order #{order_id}, {error_obj} #{obj_id} ({obj_title})\n\n{details}".format(
-            name=order.purchaser.username,
-            email=order.purchaser.email,
-            order_id=order.id,
-            error_obj=("Run" if isinstance(obj, CourseRun) else "Program"),
-            obj_id=obj.id,
-            obj_title=obj.title,
-            details=details,
-        ),
+    return "{name}({email}): Order #{order_id}, {error_obj} #{obj_id} ({obj_title})\n\n{details}".format(
+        name=order.purchaser.username,
+        email=order.purchaser.email,
+        order_id=order.id,
+        error_obj=("Run" if isinstance(obj, CourseRun) else "Program"),
+        obj_id=obj.id,
+        obj_title=obj.title,
+        details=details,
     )
 
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -501,7 +501,7 @@ def enroll_user_in_order_items(order):
     for program in programs:
         try:
             enrollment, created = ProgramEnrollment.all_objects.get_or_create(
-                user=order.purchaser, program=program, defaults=dict(company=order)
+                user=order.purchaser, program=program, defaults=dict(company=company)
             )
             if not created and not enrollment.active:
                 enrollment.reactivate_and_save()
@@ -526,7 +526,7 @@ def format_enrollment_message(order, obj, details):
     """
     return (
         "{name}({email}): Order #{order_id}, {error_obj} #{obj_id} ({obj_title})\n\n{details}".format(
-            name=order.purchaser.name,
+            name=order.purchaser.username,
             email=order.purchaser.email,
             order_id=order.id,
             error_obj=("Run" if isinstance(obj, CourseRun) else "Program"),

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -905,8 +905,7 @@ def test_enroll_user_in_order_items_api_fail(mocker, user):
 @pytest.mark.parametrize("enroll_type", ["CourseRun", "Program"])
 def test_enroll_user_in_order_exception(mocker, user, enroll_type):
     """
-    Test that enroll_user_in_order_items logs a message and still creates local enrollment records
-    when the edX API request fails
+    Test that enroll_user_in_order_items sends an email to support if an enrollment fails
     """
     patched_send_support_email = mocker.patch("ecommerce.api.send_support_email")
     mocker.patch("ecommerce.api.enroll_in_edx_course_runs")
@@ -931,7 +930,7 @@ def test_enroll_user_in_order_exception(mocker, user, enroll_type):
 
     patched_send_support_email.assert_called_once()
     assert patched_send_support_email.call_args[0][0] == ENROLL_ERROR_EMAIL_SUBJECT
-    for item in (user.name, user.email, f"Order #{order.id}"):
+    for item in (user.username, user.email, f"Order #{order.id}"):
         assert item in patched_send_support_email.call_args[0][1][0]
 
 

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -143,6 +143,13 @@ def partition(items, predicate=bool):
 
 
 def send_support_email(subject, message):
+    """
+    Send an email to support.
+
+    Args:
+        subject (str): The email subject.
+        message (str): The email message.
+    """
     try:
         with mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
             mail.send_mail(
@@ -152,7 +159,7 @@ def send_support_email(subject, message):
                 [settings.EMAIL_SUPPORT],
                 connection=connection,
             )
-    except Exception:  # pylint: disable=broad-except
+    except:  # pylint: disable=bare-except
         log.exception("Exception sending email to admins regarding enrollment failure")
 
 

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -6,6 +6,7 @@ import logging
 import itertools
 
 from django.conf import settings
+from django.core import mail
 from django.core.serializers import serialize
 from django.db import models
 import pytz
@@ -139,6 +140,20 @@ def partition(items, predicate=bool):
     """
     a, b = itertools.tee((predicate(item), item) for item in items)
     return ((item for pred, item in a if not pred), (item for pred, item in b if pred))
+
+
+def send_support_email(subject, message):
+    try:
+        with mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
+            mail.send_mail(
+                subject,
+                message,
+                settings.MAILGUN_FROM_EMAIL,
+                [settings.EMAIL_SUPPORT],
+                connection=connection,
+            )
+    except Exception:  # pylint: disable=broad-except
+        log.exception("Exception sending email to admins regarding enrollment failure")
 
 
 class ValidateOnSaveMixin(models.Model):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #626

#### What's this PR do?
Sends an email to customer support if an attempt to create or update an enrollment fails.

#### How should this be manually tested?
- Set `MITXPRO_SUPPORT_EMAIL` or `MAILGUN_RECIPIENT_OVERRIDE` to your email.
- Temporarily change `enroll_user_in_order_items` to throw an error when creating a `CourseRunEnrollment` or `ProgramEnrollment`, for instance `defaults=dict(company=order)`
- Try to purchase a course run or program, an error should be thrown
- Check your inbox, you should get an email with subject "MIT xPRO enrollment error" with a message including the username and email, order number, course run or program id and title, and the stacktrace.
