### PR TITLE
Remove enableReinitialize, call resetForm explicitly instead

### DIFF
--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -34,7 +34,8 @@ export type Actions = {
   setFieldError: SetFieldError,
   setErrors: (errors: Object) => void,
   setSubmitting: (submitting: boolean) => void,
-  setValues: (values: Values) => void
+  setValues: (values: Values) => void,
+  resetForm: () => void
 }
 type Errors = {
   runs?: string,
@@ -82,7 +83,14 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
   }
 
   renderBasketItem = () => {
-    const { item, values, setFieldError, setValues, updateProduct } = this.props
+    const {
+      item,
+      values,
+      setFieldError,
+      setValues,
+      resetForm,
+      updateProduct
+    } = this.props
 
     if (item.type === "program") {
       return (
@@ -126,7 +134,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
               component="select"
               name={`runs.${course.id}`}
               className="run-selector"
-              onChange={e => {
+              onChange={async e => {
                 setValues({
                   ...values,
                   runs: {
@@ -144,7 +152,8 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                   run => run.id === selectedRunId
                 )
                 if (run && run.product_id) {
-                  updateProduct(run.product_id, run.id, setFieldError)
+                  await updateProduct(run.product_id, run.id, setFieldError)
+                  resetForm()
                 }
               }}
             >
@@ -375,7 +384,6 @@ export class CheckoutForm extends React.Component<OuterProps> {
           dataConsent: false
         }}
         validate={this.validate}
-        enableReinitialize={true}
         render={props => (
           <InnerCheckoutForm
             {...props}

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -291,11 +291,28 @@ describe("CheckoutForm", () => {
     basketItem.type = PRODUCT_TYPE_COURSERUN
     basketItem.courses = [basketItem.courses[0]]
     const run = basketItem.courses[0].courseruns[1]
+    const resetFormStub = sandbox.stub()
 
-    const inner = await renderForm()
+    const inner = await shallow(
+      // $FlowFixMe
+      <InnerCheckoutForm
+        onSubmit={onSubmitStub}
+        basket={basket}
+        errors={{}}
+        item={basketItem}
+        onMount={sandbox.stub()}
+        setValues={sandbox.stub()}
+        resetForm={resetFormStub}
+        updateProduct={updateProductStub}
+        values={{}}
+      />
+    )
 
-    inner.find("select").prop("onChange")({ target: { value: String(run.id) } })
+    await inner
+      .find("FormikConnect(FieldInner)[component='select']")
+      .prop("onChange")({ target: { value: String(run.id) } })
     sinon.assert.calledWith(updateProductStub, run.product_id, run.id)
+    sinon.assert.calledWith(resetFormStub)
   })
 
   //


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #454 

#### What's this PR do?
Previously the form was reset whenever the `initialValues` changed, which would happen when the basket is updated. The intent was to have the form be reset if there was a significant change of content from some form update, so that the new content could fill in the form fields. This makes sense when switching the product but we don't want to do this when just switching the coupon code, and we don't need to do this when submitting the form since we will be redirected away from the form right after. For the `updateProduct` case we explicitly call `resetForm`.

#### How should this be manually tested?
On a program product start with no runs being selected. Choose some runs then apply a coupon code. Then selected runs will remain and the coupon will be applied with the update to the discount.

If you go to a course run product and switch course runs, you should see all fields be reset. For example if you had an automatic coupon, the coupon code should show up with the relevant course run. If there is no automatic coupon any text entered in the coupon field should be cleared when the course run is switched.

