### PR TITLE
redirect the wagtail login to the site login

### DIFF
--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -30,6 +30,7 @@ from mitxpro.views import (
     AppContextView,
     handler404 as not_found_handler,
     handler500 as server_error_handler,
+    cms_signin_redirect_to_site_signin,
 )
 
 
@@ -74,6 +75,9 @@ urlpatterns = [
     path("", include("social_django.urls", namespace="social")),
     re_path(r"^dashboard/", index, name="user-dashboard"),
     # Wagtail
+    re_path(
+        r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"
+    ),
     re_path(r"^cms/", include(wagtailadmin_urls)),
     re_path(r"^documents/", include(wagtaildocs_urls)),
     path("robots.txt", include("robots.urls")),

--- a/mitxpro/views.py
+++ b/mitxpro/views.py
@@ -4,8 +4,10 @@ mitxpro views
 import json
 
 from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseNotFound, HttpResponseServerError
+from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, redirect
 from django.template.loader import render_to_string
@@ -60,6 +62,11 @@ def handler500(request):
         "500.html", request=request, context=get_js_settings_context(request)
     )
     return HttpResponseServerError(response)
+
+
+def cms_signin_redirect_to_site_signin(request):
+    """Redirect wagtail admin signin to site signin page"""
+    return redirect_to_login(reverse("wagtailadmin_home"), login_url="/signin")
 
 
 def restricted(request):

--- a/mitxpro/views_test.py
+++ b/mitxpro/views_test.py
@@ -33,6 +33,14 @@ def test_restricted_view(client, admin_client):
     assert admin_client.get(reverse("ecommerce-admin")).status_code == 200
 
 
+def test_cms_signin_redirect_to_site_signin(client):
+    """
+    Test that the cms/login redirects users to site signin page.
+    """
+    response = client.get("/cms", follow=True)
+    assert response.request["PATH_INFO"] == "/signin/"
+
+
 def test_webpack_url(mocker, settings, client):
     """Verify that webpack bundle src shows up in production"""
     settings.GA_TRACKING_ID = "fake"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #554 

#### What's this PR do?
Add redirect view, which will redirect wagtail login to site login page.

#### How should this be manually tested?

- Logout of CMS.
- Hit `/cms`
- You will be redirected to `/signin/?next=/cms/`
 - After signing in you will be redirected back to CMS.
