### PR TITLE
#659 Catalog: prices are not displayed for some courses/programs

### DIFF
--- a/cms/templates/partials/catalog-card.html
+++ b/cms/templates/partials/catalog-card.html
@@ -17,10 +17,11 @@
                     </a>
             </h3>
             <ul>
-                {% if courseware_page.product.current_price %}
+                {% firstof courseware_page.product.current_price courseware_page.product.first_unexpired_run.current_price as price %}
+                {% if price %}
                     <li>
                         <strong>Price:</strong>
-                        ${{ courseware_page.product.current_price|floatformat:"0"|intcomma }}
+                        ${{ price|floatformat:"0"|intcomma }}
                     </li>
                 {% endif %}
                 {% if object_type == "program" %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #659 

#### What's this PR do?
Previously metadata tiles were fixed by updating the current price methods for courseware. This PR updates the same for the catalog cards.

#### How should this be manually tested?
Add products for programs and courses and visit the catalog page. All cards with products linked should display the price. 