### PR TITLE
Add enrollment emails

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -29,6 +29,7 @@ from courses.models import (
     Program,
 )
 from courseware.api import enroll_in_edx_course_runs
+from ecommerce import mail_api
 from ecommerce.exceptions import EcommerceException, ParseException
 from ecommerce.models import (
     Basket,
@@ -537,6 +538,9 @@ def enroll_user_in_order_items(order):
         if voucher_target == run:
             voucher.enrollment = enrollment
             voucher.save()
+        if enrollment.edx_enrolled:
+            mail_api.send_course_run_enrollment_email(enrollment)
+
     for program in programs:
         try:
             enrollment, created = ProgramEnrollment.all_objects.get_or_create(

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -824,6 +824,9 @@ def test_enroll_user_in_order_items(mocker, user, has_redemption):
     in course runs and programs
     """
     patched_enroll = mocker.patch("ecommerce.api.enroll_in_edx_course_runs")
+    patched_send_email = mocker.patch(
+        "ecommerce.mail_api.send_course_run_enrollment_email"
+    )
     order = OrderFactory.create(purchaser=user, status=Order.FULFILLED)
     if has_redemption:
         redemption = CouponRedemptionFactory.create(order=order)
@@ -859,6 +862,9 @@ def test_enroll_user_in_order_items(mocker, user, has_redemption):
     enroll_args = patched_enroll.call_args[0]
     assert enroll_args[0] == user
     assert set(enroll_args[1]) == set(course_runs)
+    assert patched_send_email.call_count == len(created_course_run_enrollments)
+    for enrollment in created_course_run_enrollments:
+        patched_send_email.assert_any_call(enrollment)
 
 
 def test_enroll_user_in_order_items_with_voucher(mocker, user):

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -1,26 +1,27 @@
 """Ecommerce mail API tests"""
 import pytest
 
+from courses.factories import CourseRunEnrollmentFactory
 from ecommerce.factories import (
     CouponPaymentVersionFactory,
     CouponEligibilityFactory,
     ProductVersionFactory,
     CompanyFactory,
 )
-from ecommerce.mail_api import send_bulk_enroll_emails
-from mail.constants import EMAIL_BULK_ENROLL
+from ecommerce.mail_api import send_bulk_enroll_emails, send_course_run_enrollment_email
+from mail.constants import EMAIL_BULK_ENROLL, EMAIL_COURSE_RUN_ENROLLMENT
 
 lazy = pytest.lazy_fixture
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db
+
 @pytest.fixture()
 def company():
     """Company object fixture"""
     return CompanyFactory.create(name="MIT")
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize("test_company", [lazy("company"), None])
 def test_send_bulk_enroll_emails(mocker, settings, test_company):
     """
@@ -58,4 +59,38 @@ def test_send_bulk_enroll_emails(mocker, settings, test_company):
 
     patched_mail_api.send_messages.assert_called_once_with(
         patched_mail_api.build_user_specific_messages.return_value
+    )
+
+
+def test_send_course_run_enrollment_email(mocker):
+    """send_course_run_enrollment_email should send an email for the given enrollment"""
+    patched_mail_api = mocker.patch("ecommerce.mail_api.api")
+    enrollment = CourseRunEnrollmentFactory.create()
+
+    send_course_run_enrollment_email(enrollment)
+
+    patched_mail_api.context_for_user.assert_called_once_with(
+        user=enrollment.user, extra_context={"enrollment": enrollment}
+    )
+    patched_mail_api.message_for_recipient.assert_called_once_with(
+        enrollment.user.email,
+        patched_mail_api.context_for_user.return_value,
+        EMAIL_COURSE_RUN_ENROLLMENT,
+    )
+    patched_mail_api.send_message.assert_called_once_with(
+        patched_mail_api.message_for_recipient.return_value
+    )
+
+
+def test_send_course_run_enrollment_email_error(mocker):
+    """send_course_run_enrollment_email handle and log errors"""
+    patched_mail_api = mocker.patch("ecommerce.mail_api.api")
+    patched_log = mocker.patch("ecommerce.mail_api.log")
+    patched_mail_api.send_message.side_effect = Exception("error")
+    enrollment = CourseRunEnrollmentFactory.create()
+
+    send_course_run_enrollment_email(enrollment)
+
+    patched_log.exception.assert_called_once_with(
+        "Error sending enrollment success email"
     )

--- a/mail/api.py
+++ b/mail/api.py
@@ -40,7 +40,7 @@ def safe_format_recipients(recipients):
         recipients (iterable of User): recipient users
 
     Returns:
-        list of (str, User): list of recipient emails to send to
+        list of User: list of users to send to
     """
     if not recipients:
         return []
@@ -156,6 +156,21 @@ def messages_for_recipients(recipients_and_contexts, template_name):
             )
 
 
+def message_for_recipient(recipient, context, template_name):
+    """
+    Creates message object for a recipient with user-specific context in the message.
+
+    Args:
+        recipient (User): recipient user
+        context (dict): context dictionary for the email
+        template_name (str): name of the template, this should match a directory in mail/templates
+
+    Returns:
+        django.core.mail.EmailMultiAlternatives: email message with rendered content
+    """
+    return list(messages_for_recipients([(recipient, context)], template_name))[0]
+
+
 def build_messages(template_name, recipients, extra_context):
     """
     Creates message objects for a set of recipients with the same context in each message.
@@ -239,3 +254,13 @@ def send_messages(messages):
             msg.send()
         except:  # pylint: disable=bare-except
             log.exception("Error sending email '%s' to %s", msg.subject, msg.to)
+
+
+def send_message(message):
+    """
+    Convenience method for sending one message
+
+    Args:
+        message (django.core.mail.EmailMultiAlternatives): message to send
+    """
+    send_messages([message])

--- a/mail/constants.py
+++ b/mail/constants.py
@@ -3,9 +3,11 @@
 EMAIL_VERIFICATION = "verification"
 EMAIL_PW_RESET = "password_reset"
 EMAIL_BULK_ENROLL = "bulk_enroll"
+EMAIL_COURSE_RUN_ENROLLMENT = "course_run_enrollment"
 
 EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_VERIFICATION: "Verify Email",
     EMAIL_PW_RESET: "Password Reset",
     EMAIL_BULK_ENROLL: "Bulk Enrollment",
+    EMAIL_COURSE_RUN_ENROLLMENT: "Course Run Enrollment",
 }

--- a/mail/templates/course_run_enrollment/body.html
+++ b/mail/templates/course_run_enrollment/body.html
@@ -1,0 +1,21 @@
+{% extends "email_base.html" %}
+
+{% block content %}
+<!-- 1 Column Text + Button : BEGIN -->
+  <tr>
+      <td style="background-color: #ffffff;">
+          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>
+                  <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                      <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
+                      <p style="margin: 0 0 10px;">
+                        You have been enrolled in {{ enrollment.run.course.title }}. The course should now appear on your <a href="{{ base_url }}{% url 'user-dashboard' %}">{{ site_name }} dashboard</a>.
+                      </p>
+                  </td>
+              </tr>
+
+          </table>
+      </td>
+  </tr>
+<!-- 1 Column Text + Button : END -->
+{% endblock %}

--- a/mail/templates/course_run_enrollment/subject.txt
+++ b/mail/templates/course_run_enrollment/subject.txt
@@ -1,0 +1,1 @@
+You have been enrolled in {{ enrollment.run.course.title }}

--- a/mail/verification_api.py
+++ b/mail/verification_api.py
@@ -25,16 +25,10 @@ def send_verification_email(
         quote_plus(partial_token),
     )
 
-    api.send_messages(
-        list(
-            api.messages_for_recipients(
-                [
-                    (
-                        code.email,
-                        api.context_for_user(extra_context={"confirmation_url": url}),
-                    )
-                ],
-                EMAIL_VERIFICATION,
-            )
+    api.send_message(
+        api.message_for_recipient(
+            code.email,
+            api.context_for_user(extra_context={"confirmation_url": url}),
+            EMAIL_VERIFICATION,
         )
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #567 

#### What's this PR do?
Adds a per-courserun confirmation email when/if enrollment succeeds. 

#### How should this be manually tested?

- Sign up for a program and verify you receive an email for each course run
- Sign up for a course run and verify that you receive an email for that course run

#### Any background context you want to provide?

Note: a known issue we're not fixing in this PR is that a failure to enroll in any course in a program causes no emails to get send because that matches the current state behavior of `CourseRunEnrollment.edx_enrolled`.

This code also handles any errors from sending the email and logs them so that they do not cause a checkout to fail.

#### Screenshots (if appropriate)

<details>
<summary>Individual email</summary>

![Screenshot_2019-06-25](https://user-images.githubusercontent.com/28598/60112554-0211d380-973e-11e9-989b-91d0b6983aee.png)
</details>

<details>
<summary>Set of emails for a program</summary>

![Screenshot_2019-06-25](https://user-images.githubusercontent.com/28598/60112587-10f88600-973e-11e9-87fd-89d7d70d8ea8.png)
</details>