### PR TITLE
Get unused coupons in UserSerializer, not CurrentUserRetrieveUpdateViewSet

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -7,7 +7,6 @@ from rest_framework.response import Response
 from mitxpro.permissions import UserIsOwnerPermission
 from users.models import User
 from users.serializers import PublicUserSerializer, UserSerializer, CountrySerializer
-from ecommerce.api import fetch_and_serialize_unused_coupons
 
 
 class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
@@ -32,18 +31,6 @@ class CurrentUserRetrieveUpdateViewSet(
         """Returns the current request user"""
         # NOTE: this may be a logged in or anonymous user
         return self.request.user
-
-    def retrieve(self, request, *args, **kwargs):
-        user = self.get_object()
-        serializer = self.get_serializer(user)
-        if user.is_anonymous:
-            return Response(serializer.data)
-        return Response(
-            {
-                **serializer.data,
-                "unused_coupons": fetch_and_serialize_unused_coupons(user),
-            }
-        )
 
 
 class CountriesStatesViewSet(viewsets.ViewSet):

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -44,7 +44,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous):
         client.force_login(user)
 
     patched_unused_coupon_api = mocker.patch(
-        "users.views.fetch_and_serialize_unused_coupons",
+        "users.serializers.fetch_and_serialize_unused_coupons",
         return_value=[{"serialized": "data"}],
     )
     resp = client.get(reverse("users_api-me"))
@@ -60,6 +60,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous):
             "is_anonymous": True,
             "is_authenticated": False,
             "profile": None,
+            "unused_coupons": [],
         }
         patched_unused_coupon_api.assert_not_called()
     else:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #635

#### What's this PR do?
Moves `unused_coupons` attribute to the `UserSerializer` instead of inserting it from `CurrentUserRetrieveUpdateViewSet`

#### How should this be manually tested?
- Edit your profile and click submit, the 'View Profile' page should load afterward.
- Use the bulk coupon enrollment tool (`http://xpro.odl.local:8053/ecommerce/admin/enroll/`) to associate a coupon with your user, you should see the `You have an unused coupon. Checkout now to redeem it.` banner near the top of each page, including the profile pages (view/edit).
