### PR TITLE
Fixed and refactored enrollment commands 

### DIFF
--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -67,22 +67,13 @@ class Command(EnrollmentChangeCommand):
                 )
             )
 
-        to_enrollment = CourseRunEnrollment.objects.create(
-            user=user, run=to_run, company=from_enrollment.company
+        to_enrollment = self.move_course_run_enrollment(
+            from_enrollment, change_status=ENROLL_CHANGE_STATUS_DEFERRED, to_run=to_run
         )
-        from_enrollment.active = False
-        from_enrollment.change_status = ENROLL_CHANGE_STATUS_DEFERRED
-        from_enrollment.save_and_log(None)
-
-        self.stdout.write(
-            "Current enrollment deactivated and new enrollment record created. "
-            "Attempting to enroll the user on edX..."
-        )
-        self.enroll_in_edx(user, [to_run])
 
         self.stdout.write(
             self.style.SUCCESS(
-                "Deferred enrollment – 'from' run id: {}, 'to' run id: {}\nUser – {} ({})".format(
+                "Deferred enrollment – 'from' run id: {}, 'to' run id: {}\nUser: {} ({})".format(
                     from_enrollment.run.id,
                     to_enrollment.run.id,
                     user.username,

--- a/courses/management/commands/refund_enrollment.py
+++ b/courses/management/commands/refund_enrollment.py
@@ -33,12 +33,10 @@ class Command(EnrollmentChangeCommand):
         """Handle command execution"""
         user = fetch_user(options["user"])
         enrollment, enrolled_obj = self.fetch_enrollment(user, options)
-        enrollment.active = False
-        enrollment.change_status = ENROLL_CHANGE_STATUS_REFUNDED
-        enrollment.save_and_log(None)
+        enrollment.deactivate_and_save(ENROLL_CHANGE_STATUS_REFUNDED, no_user=True)
         self.stdout.write(
             self.style.SUCCESS(
-                "Refunded enrollment – id: {}, object: {}\nUser – {} ({})".format(
+                "Refunded enrollment – id: {}, object: {}\nUser: {} ({})".format(
                     enrollment.id,
                     enrolled_obj.title,
                     enrollment.user.username,

--- a/courses/models.py
+++ b/courses/models.py
@@ -382,11 +382,17 @@ class EnrollmentModel(TimestampedModel, AuditableModel):
     def to_dict(self):
         return serialize_model_object(self)
 
-    def reactivate_and_save(self):
-        """Sets an enrollment to be active again and saves it"""
+    def deactivate_and_save(self, change_status, no_user=False):
+        """Sets an enrollment to inactive, sets the status, and saves"""
+        self.active = False
+        self.change_status = change_status
+        return self.save_and_log(None if no_user else self.user)
+
+    def reactivate_and_save(self, no_user=False):
+        """Sets an enrollment to be active again and saves"""
         self.active = True
         self.change_status = None
-        return self.save_and_log(self.user)
+        return self.save_and_log(None if no_user else self.user)
 
 
 class CourseRunEnrollment(EnrollmentModel):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #671 

#### What's this PR do?
- Fixes edX API client error handling so that the actual error response body is shown in the command output
- Refactors some common functionality to make these commands a less susceptible to bugs

#### How should this be manually tested?
- Enroll a user in some program ("SysEngX"/"Systems Engineering" for example), then transfer that enrollment to a different user via the `transfer_enrollment` command. If you weren't previously enrolled, and if the course runs in that program aren't set up in your local edX instance, you should see (a) the program enrollment and associated course run enrollments transfer over to the new user, (b) the existing program enrollment and associated course run enrollments deactivated for your 'from' user, and (c) a bunch of warning output from the command indicating the error response from edX (e.g.: `edX enrollment request failed (400). Response: {"message":"No course 'course-v1:TestX+SysEngxB2+1T2019' found for enrollment"}`)
- Enroll a user in some course run, then defer that enrollment to some other course run that you're not enrolled in (use `-f` if you want to defer to a run from a different course). You should see similar output and results to the above command

#### Any background context you want to provide?
The edX API client does not have unenrolling capability yet, so don't expect any changes to existing enrollments on edX. This can be added later, and it was actually that shortfall that made me realize that the enrollment logic needed to be cleaned up and streamlined.

#### Screenshots (if appropriate)
![ss 2019-06-25 at 17 03 36 ](https://user-images.githubusercontent.com/14932219/60134629-ecb49d80-976d-11e9-9380-92f5a307ce68.png)


