### PR TITLE
Poll dashboard page for course run/program

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -93,7 +93,7 @@ def make_receipt_url(*, base_url, readable_id):
             The URL for the order receipt page
     """
     dashboard_url = urljoin(base_url, reverse("user-dashboard"))
-    return f"{dashboard_url}?status=purchased&readable_id={quote_plus(readable_id)}"
+    return f"{dashboard_url}?status=purchased&purchased={quote_plus(readable_id)}"
 
 
 def get_readable_id(run_or_program):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -93,7 +93,7 @@ def make_receipt_url(*, base_url, readable_id):
             The URL for the order receipt page
     """
     dashboard_url = urljoin(base_url, reverse("user-dashboard"))
-    return f"{dashboard_url}?status=receipt&readable_id={quote_plus(readable_id)}"
+    return f"{dashboard_url}?status=purchased&readable_id={quote_plus(readable_id)}"
 
 
 def get_readable_id(run_or_program):

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -123,7 +123,7 @@ def test_make_receipt_url():
     """make_receipt_url should generate a URL for use by users returning from a successful CyberSource payment"""
     assert (
         make_receipt_url(base_url="https://mit.edu/", readable_id="a readable id")
-        == "https://mit.edu/dashboard/?status=receipt&readable_id=a+readable+id"
+        == "https://mit.edu/dashboard/?status=purchased&readable_id=a+readable+id"
     )
 
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -123,7 +123,7 @@ def test_make_receipt_url():
     """make_receipt_url should generate a URL for use by users returning from a successful CyberSource payment"""
     assert (
         make_receipt_url(base_url="https://mit.edu/", readable_id="a readable id")
-        == "https://mit.edu/dashboard/?status=purchased&readable_id=a+readable+id"
+        == "https://mit.edu/dashboard/?status=purchased&purchased=a+readable+id"
     )
 
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -27,6 +27,7 @@ from ecommerce.api import (
     create_unfulfilled_order,
     generate_cybersource_sa_payload,
     generate_cybersource_sa_signature,
+    get_readable_id,
     ISO_8601_FORMAT,
     make_reference_id,
     redeem_coupon,
@@ -36,6 +37,7 @@ from ecommerce.api import (
     get_valid_coupon_versions,
     latest_product_version,
     latest_coupon_version,
+    make_receipt_url,
     get_product_courses,
     get_available_bulk_product_coupons,
     validate_basket_for_checkout,
@@ -117,6 +119,21 @@ def test_valid_signature():
     assert b64encode(digest).decode("utf-8") == signature
 
 
+def test_make_receipt_url():
+    """make_receipt_url should generate a URL for use by users returning from a successful CyberSource payment"""
+    assert (
+        make_receipt_url(base_url="https://mit.edu/", readable_id="a readable id")
+        == "https://mit.edu/dashboard/?status=receipt&readable_id=a+readable+id"
+    )
+
+
+def test_get_readable_id():
+    """get_readable_id should get the readable id for a CourseRun or a Program"""
+    run = CourseRunFactory.create()
+    assert get_readable_id(run) == run.courseware_id
+    assert get_readable_id(run.course.program) == run.course.program.readable_id
+
+
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize("has_coupon", [True, False])
 @pytest.mark.parametrize("has_company", [True, False])
@@ -188,6 +205,7 @@ def test_signed_payload(mocker, has_coupon, has_company, is_program_product):
         if has_coupon
         else {}
     )
+    readable_id = get_readable_id(line1.product_version.product.content_object)
 
     assert payload == {
         "access_key": CYBERSOURCE_ACCESS_KEY,
@@ -215,7 +233,9 @@ def test_signed_payload(mocker, has_coupon, has_company, is_program_product):
         "line_item_count": 3,
         "locale": "en-us",
         "reference_number": make_reference_id(order),
-        "override_custom_receipt_page": urljoin(base_url, "dashboard/"),
+        "override_custom_receipt_page": make_receipt_url(
+            base_url=base_url, readable_id=readable_id
+        ),
         "override_custom_cancel_page": urljoin(base_url, "checkout/"),
         "profile_id": CYBERSOURCE_PROFILE_ID,
         "signed_date_time": now.strftime(ISO_8601_FORMAT),

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -20,6 +20,8 @@ from ecommerce.api import (
     get_product_version_price_with_discount,
     get_full_price_coupon_product_set,
     get_available_bulk_product_coupons,
+    get_readable_id,
+    make_receipt_url,
     validate_basket_for_checkout,
     complete_order,
 )
@@ -94,6 +96,11 @@ class CheckoutView(APIView):
             for line in order.lines.all()
         )
 
+        # Should only have one line per order currently
+        line = order.lines.first()
+
+        readable_id = get_readable_id(line.product_version.product.content_object)
+
         if total_price == 0:
             # If price is $0, don't bother going to CyberSource, just mark as fulfilled
             order.status = Order.FULFILLED
@@ -104,7 +111,7 @@ class CheckoutView(APIView):
 
             # This redirects the user to our order success page
             payload = {}
-            url = base_url
+            url = make_receipt_url(base_url=base_url, readable_id=readable_id)
             method = "GET"
         else:
             # This generates a signed payload which is submitted as an HTML form to CyberSource

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -170,7 +170,7 @@ def test_zero_price_checkout(
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {
         "payload": {},
-        "url": f"http://testserver/dashboard/?status=receipt&readable_id={quote_plus(readable_id)}",
+        "url": f"http://testserver/dashboard/?status=purchased&readable_id={quote_plus(readable_id)}",
         "method": "GET",
     }
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -170,7 +170,7 @@ def test_zero_price_checkout(
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {
         "payload": {},
-        "url": f"http://testserver/dashboard/?status=purchased&readable_id={quote_plus(readable_id)}",
+        "url": f"http://testserver/dashboard/?status=purchased&purchased={quote_plus(readable_id)}",
         "method": "GET",
     }
 

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -68,7 +68,7 @@ export class DashboardPage extends React.Component<Props, State> {
     }
 
     const query = qs.parse(search)
-    if (query.status === "receipt") {
+    if (query.status === "purchased") {
       this.handleOrderPending(query.readable_id)
     }
   }

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -38,6 +38,9 @@ type State = {
   alertType: string
 }
 
+const NUM_MINUTES_TO_POLL = 2
+const NUM_MILLIS_PER_POLL = 3000
+
 export class DashboardPage extends React.Component<Props, State> {
   state = {
     collapseVisible: {},
@@ -94,10 +97,10 @@ export class DashboardPage extends React.Component<Props, State> {
     }
 
     this.setState({ timeoutActive: true })
-    await wait(3000)
+    await wait(NUM_MILLIS_PER_POLL)
     this.setState({ timeoutActive: false })
 
-    const deadline = moment(initialTime).add(2, "minutes")
+    const deadline = moment(initialTime).add(NUM_MINUTES_TO_POLL, "minutes")
     const now = moment()
     if (now.isBefore(deadline)) {
       await forceRequest()

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -34,7 +34,8 @@ type State = {
   collapseVisible: Object,
   now: Moment,
   timeoutActive: boolean,
-  toastMessage: string
+  toastMessage: string,
+  alertType: string
 }
 
 export class DashboardPage extends React.Component<Props, State> {
@@ -42,7 +43,8 @@ export class DashboardPage extends React.Component<Props, State> {
     collapseVisible: {},
     now:             moment(),
     timeoutActive:   false,
-    toastMessage:    ""
+    toastMessage:    "",
+    alertType:       ""
   }
 
   componentDidMount() {
@@ -85,7 +87,8 @@ export class DashboardPage extends React.Component<Props, State> {
     if (item) {
       history.push("/dashboard/")
       this.setState({
-        toastMessage: `You are now enrolled in ${item.title}!`
+        toastMessage: `You are now enrolled in ${item.title}!`,
+        alertType:    "info"
       })
       return
     }
@@ -102,7 +105,8 @@ export class DashboardPage extends React.Component<Props, State> {
       this.setState({
         toastMessage: `Something went wrong. Please contact support at ${
           SETTINGS.support_email
-        }.`
+        }.`,
+        alertType: "danger"
       })
     }
   }
@@ -249,7 +253,7 @@ export class DashboardPage extends React.Component<Props, State> {
 
   render() {
     const { enrollments } = this.props
-    const { toastMessage } = this.state
+    const { alertType, toastMessage } = this.state
 
     const enrollmentsExist = this.enrollmentsExist()
 
@@ -258,9 +262,14 @@ export class DashboardPage extends React.Component<Props, State> {
         <div className="user-dashboard container">
           <div className="row">
             <Alert
-              color="info"
+              color={alertType}
               isOpen={!!toastMessage}
-              toggle={() => this.setState({ toastMessage: "" })}
+              toggle={() =>
+                this.setState({
+                  alertType:    "",
+                  toastMessage: ""
+                })
+              }
             >
               {toastMessage}
             </Alert>

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -69,7 +69,7 @@ export class DashboardPage extends React.Component<Props, State> {
 
     const query = qs.parse(search)
     if (query.status === "purchased") {
-      this.handleOrderPending(query.readable_id)
+      this.handleOrderPending(query.purchased)
     }
   }
 

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -1,18 +1,22 @@
+/* global SETTINGS: false */
 // @flow
 import React from "react"
 import { compose } from "redux"
 import { connect } from "react-redux"
 import { connectRequest } from "redux-query"
-import moment from "moment"
 import { createStructuredSelector } from "reselect"
+import moment from "moment"
 import * as R from "ramda"
-import { Collapse, Button } from "reactstrap"
+import { Alert, Collapse, Button } from "reactstrap"
+import qs from "query-string"
 
 import { RibbonText } from "../../components/Ribbon"
 import queries from "../../lib/queries"
 import { getDateSummary, programDateRange } from "../../lib/courses"
-import { formatPrettyDate } from "../../lib/util"
+import { formatPrettyDate, findItemWithReadableId, wait } from "../../lib/util"
 
+import type Moment from "moment"
+import type { Location, RouterHistory } from "react-router"
 import type {
   ProgramEnrollment,
   CourseRunEnrollment,
@@ -20,20 +24,86 @@ import type {
 } from "../../flow/courseTypes"
 
 type Props = {
-  enrollments: UserEnrollments
+  enrollments: UserEnrollments,
+  forceRequest: () => Promise<*>,
+  history: RouterHistory,
+  location: Location
 }
 
 type State = {
   collapseVisible: Object,
-  now: moment
+  now: Moment,
+  timeoutActive: boolean,
+  toastMessage: string
 }
 
 export class DashboardPage extends React.Component<Props, State> {
-  constructor() {
-    super()
-    this.state = {
-      collapseVisible: {},
-      now:             moment()
+  state = {
+    collapseVisible: {},
+    now:             moment(),
+    timeoutActive:   false,
+    toastMessage:    ""
+  }
+
+  componentDidMount() {
+    this.handleOrderStatus()
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // This is meant to be an identity check, not a deep equality check. This shows whether we received an update
+    // for enrollments based on the forceReload
+    if (prevProps.enrollments !== this.props.enrollments) {
+      this.handleOrderStatus()
+    }
+  }
+
+  handleOrderStatus = () => {
+    const {
+      enrollments,
+      location: { search }
+    } = this.props
+    if (!enrollments) {
+      // wait until we have access to the dashboard
+      return
+    }
+
+    const query = qs.parse(search)
+    if (query.status === "receipt") {
+      this.handleOrderPending(query.readable_id)
+    }
+  }
+
+  handleOrderPending = async (readableId: ?string) => {
+    const { enrollments, forceRequest, history } = this.props
+    const { timeoutActive, now: initialTime } = this.state
+
+    if (timeoutActive) {
+      return
+    }
+
+    const item = findItemWithReadableId(enrollments, readableId)
+    if (item) {
+      history.push("/dashboard/")
+      this.setState({
+        toastMessage: `You are now enrolled in ${item.title}!`
+      })
+      return
+    }
+
+    this.setState({ timeoutActive: true })
+    await wait(3000)
+    this.setState({ timeoutActive: false })
+
+    const deadline = moment(initialTime).add(2, "minutes")
+    const now = moment()
+    if (now.isBefore(deadline)) {
+      await forceRequest()
+    } else {
+      this.setState({
+        toastMessage: `Something went wrong. Please contact support at ${
+          SETTINGS.support_email
+        }.`
+      })
     }
   }
 
@@ -179,39 +249,49 @@ export class DashboardPage extends React.Component<Props, State> {
 
   render() {
     const { enrollments } = this.props
+    const { toastMessage } = this.state
 
     const enrollmentsExist = this.enrollmentsExist()
 
     return (
-      <div className="user-dashboard container">
-        <div className="row">
-          <div className="header col-12">
-            <h1>Dashboard</h1>
-            {enrollments &&
-              (enrollmentsExist ? (
-                <h3>Courses and Programs</h3>
-              ) : (
-                <h2>You are not yet enrolled in any courses or programs.</h2>
-              ))}
+      <React.Fragment>
+        <div className="user-dashboard container">
+          <div className="row">
+            <Alert
+              color="info"
+              isOpen={!!toastMessage}
+              toggle={() => this.setState({ toastMessage: "" })}
+            >
+              {toastMessage}
+            </Alert>
+            <div className="header col-12">
+              <h1>Dashboard</h1>
+              {enrollments &&
+                (enrollmentsExist ? (
+                  <h3>Courses and Programs</h3>
+                ) : (
+                  <h2>You are not yet enrolled in any courses or programs.</h2>
+                ))}
+            </div>
           </div>
+          {enrollments ? (
+            <React.Fragment>
+              <div className="program-enrollments">
+                {enrollments.program_enrollments.map(
+                  this.renderProgramEnrollment
+                )}
+              </div>
+              <div className="non-program-course-enrollments">
+                {enrollments.course_run_enrollments.map(
+                  this.renderCourseEnrollment(false)
+                )}
+              </div>
+            </React.Fragment>
+          ) : (
+            <span>Loading...</span>
+          )}
         </div>
-        {enrollments ? (
-          <React.Fragment>
-            <div className="program-enrollments">
-              {enrollments.program_enrollments.map(
-                this.renderProgramEnrollment
-              )}
-            </div>
-            <div className="non-program-course-enrollments">
-              {enrollments.course_run_enrollments.map(
-                this.renderCourseEnrollment(false)
-              )}
-            </div>
-          </React.Fragment>
-        ) : (
-          <span>Loading...</span>
-        )}
-      </div>
+      </React.Fragment>
     )
   }
 }

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -13,7 +13,7 @@ import qs from "query-string"
 import { RibbonText } from "../../components/Ribbon"
 import queries from "../../lib/queries"
 import { getDateSummary, programDateRange } from "../../lib/courses"
-import { formatPrettyDate, findItemWithReadableId, wait } from "../../lib/util"
+import { formatPrettyDate, findItemWithTextId, wait } from "../../lib/util"
 
 import type Moment from "moment"
 import type { Location, RouterHistory } from "react-router"
@@ -83,7 +83,7 @@ export class DashboardPage extends React.Component<Props, State> {
       return
     }
 
-    const item = findItemWithReadableId(enrollments, readableId)
+    const item = findItemWithTextId(enrollments, readableId)
     if (item) {
       history.push("/dashboard/")
       this.setState({

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -1,7 +1,9 @@
+/* global SETTINGS: false */
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
-import moment from "moment"
+// $FlowFixMe: flow doesn't see fn
+import moment, { fn as momentProto } from "moment"
 import { mergeDeepRight } from "ramda"
 
 import DashboardPage, {
@@ -15,6 +17,7 @@ import {
   makeUserEnrollments
 } from "../../factories/course"
 import * as coursesApi from "../../lib/courses"
+import * as utilFuncs from "../../lib/util"
 
 describe("DashboardPage", () => {
   let helper,
@@ -43,7 +46,11 @@ describe("DashboardPage", () => {
           enrollments: userEnrollments
         }
       },
-      {}
+      {
+        location: {
+          search: ""
+        }
+      }
     )
   })
 
@@ -140,6 +147,8 @@ describe("DashboardPage", () => {
       [programEnrollmentId]: false
     })
   })
+
+  //
   ;[
     [
       moment()
@@ -193,6 +202,97 @@ describe("DashboardPage", () => {
           userRunEnrollment.run.course.title
         )
       }
+    })
+  })
+
+  describe("cybersource redirect", () => {
+    it("shows an alert based on the toastMessage state value", async () => {
+      const { inner } = await renderPage()
+      assert.isFalse(inner.find("Alert").prop("isOpen"))
+      inner.setState({ toastMessage: "hello world" })
+      assert.isTrue(inner.find("Alert").prop("isOpen"))
+      assert.isTrue(
+        inner
+          .find("Alert")
+          .html()
+          .includes("hello world")
+      )
+      inner.find("Alert").prop("toggle")()
+      assert.isFalse(inner.find("Alert").prop("isOpen"))
+      assert.equal(inner.state().toastMessage, "")
+    })
+
+    it("looks up a run or program using the query parameter, and displays the success message", async () => {
+      const program = userEnrollments.program_enrollments[0].program
+      const waitStub = helper.sandbox.stub(utilFuncs, "wait")
+      const stub = helper.sandbox
+        .stub(utilFuncs, "findItemWithReadableId")
+        .returns(program)
+      const { inner } = await renderPage(
+        {},
+        {
+          location: {
+            search: "readable_id=a+b+c&status=receipt"
+          }
+        }
+      )
+      assert.equal(
+        inner.state().toastMessage,
+        `You are now enrolled in ${program.title}!`
+      )
+      sinon.assert.calledWith(stub, userEnrollments, "a b c")
+      assert.equal(waitStub.callCount, 0)
+    })
+
+    //
+    ;[true, false].forEach(outOfTime => {
+      it(`if a run or program is not immediately found it waits 3 seconds and ${
+        outOfTime ? "errors" : "force reloads"
+      }`, async () => {
+        let waitResolve = null
+        const waitPromise = new Promise(resolve => {
+          waitResolve = resolve
+        })
+        const waitStub = helper.sandbox
+          .stub(utilFuncs, "wait")
+          .returns(waitPromise)
+        const run = userEnrollments.course_run_enrollments[0].run
+        const findStub = helper.sandbox
+          .stub(utilFuncs, "findItemWithReadableId")
+          .returns(null)
+
+        const { inner } = await renderPage(
+          {},
+          {
+            location: {
+              search: "readable_id=xyz&status=receipt"
+            }
+          }
+        )
+        helper.handleRequestStub.resetHistory()
+
+        sinon.assert.calledWith(waitStub, 3000)
+        helper.sandbox.stub(momentProto, "isBefore").returns(!outOfTime)
+        findStub.returns(run)
+        // $FlowFixMe
+        waitResolve()
+        await waitPromise
+
+        if (outOfTime) {
+          assert.equal(
+            inner.state().toastMessage,
+            `Something went wrong. Please contact support at ${
+              SETTINGS.support_email
+            }.`
+          )
+        } else {
+          sinon.assert.calledWith(
+            helper.handleRequestStub,
+            "/api/enrollments/",
+            "GET"
+          )
+        }
+      })
     })
   })
 })

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -209,8 +209,9 @@ describe("DashboardPage", () => {
     it("shows an alert based on the toastMessage state value", async () => {
       const { inner } = await renderPage()
       assert.isFalse(inner.find("Alert").prop("isOpen"))
-      inner.setState({ toastMessage: "hello world" })
+      inner.setState({ toastMessage: "hello world", alertType: "info" })
       assert.isTrue(inner.find("Alert").prop("isOpen"))
+      assert.equal(inner.find("Alert").prop("color"), "info")
       assert.isTrue(
         inner
           .find("Alert")
@@ -220,6 +221,7 @@ describe("DashboardPage", () => {
       inner.find("Alert").prop("toggle")()
       assert.isFalse(inner.find("Alert").prop("isOpen"))
       assert.equal(inner.state().toastMessage, "")
+      assert.equal(inner.state().alertType, "")
     })
 
     it("looks up a run or program using the query parameter, and displays the success message", async () => {
@@ -240,6 +242,7 @@ describe("DashboardPage", () => {
         inner.state().toastMessage,
         `You are now enrolled in ${program.title}!`
       )
+      assert.equal(inner.state().alertType, "info")
       sinon.assert.calledWith(stub, userEnrollments, "a b c")
       assert.equal(waitStub.callCount, 0)
     })

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -232,7 +232,7 @@ describe("DashboardPage", () => {
         {},
         {
           location: {
-            search: "readable_id=a+b+c&status=purchased"
+            search: "purchased=a+b+c&status=purchased"
           }
         }
       )
@@ -265,7 +265,7 @@ describe("DashboardPage", () => {
           {},
           {
             location: {
-              search: "readable_id=xyz&status=purchased"
+              search: "purchased=xyz&status=purchased"
             }
           }
         )

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -228,7 +228,7 @@ describe("DashboardPage", () => {
       const program = userEnrollments.program_enrollments[0].program
       const waitStub = helper.sandbox.stub(utilFuncs, "wait")
       const stub = helper.sandbox
-        .stub(utilFuncs, "findItemWithReadableId")
+        .stub(utilFuncs, "findItemWithTextId")
         .returns(program)
       const { inner } = await renderPage(
         {},
@@ -261,7 +261,7 @@ describe("DashboardPage", () => {
           .returns(waitPromise)
         const run = userEnrollments.course_run_enrollments[0].run
         const findStub = helper.sandbox
-          .stub(utilFuncs, "findItemWithReadableId")
+          .stub(utilFuncs, "findItemWithTextId")
           .returns(null)
 
         const { inner } = await renderPage(

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -232,7 +232,7 @@ describe("DashboardPage", () => {
         {},
         {
           location: {
-            search: "readable_id=a+b+c&status=receipt"
+            search: "readable_id=a+b+c&status=purchased"
           }
         }
       )
@@ -265,7 +265,7 @@ describe("DashboardPage", () => {
           {},
           {
             location: {
-              search: "readable_id=xyz&status=receipt"
+              search: "readable_id=xyz&status=purchased"
             }
           }
         )

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -20,6 +20,11 @@ import * as R from "ramda"
 import moment from "moment"
 
 import type Moment from "moment"
+import type {
+  CourseRunDetail,
+  Program,
+  UserEnrollments
+} from "../flow/courseTypes"
 
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed
@@ -184,4 +189,29 @@ export const timeoutPromise = (
       resolve()
     }, timeoutMs)
   )
+}
+
+export const findItemWithReadableId = (
+  enrollments: UserEnrollments,
+  readableId: ?string
+): Program | CourseRunDetail | null => {
+  for (const programEnrollment of enrollments.program_enrollments) {
+    if (readableId === programEnrollment.program.readable_id) {
+      return programEnrollment.program
+    }
+
+    for (const courseRunEnrollment of programEnrollment.course_run_enrollments) {
+      if (readableId === courseRunEnrollment.run.courseware_id) {
+        return courseRunEnrollment.run
+      }
+    }
+  }
+
+  for (const courseRunEnrollment of enrollments.course_run_enrollments) {
+    if (readableId === courseRunEnrollment.run.courseware_id) {
+      return courseRunEnrollment.run
+    }
+  }
+
+  return null
 }

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -191,24 +191,24 @@ export const timeoutPromise = (
   )
 }
 
-export const findItemWithReadableId = (
+export const findItemWithTextId = (
   enrollments: UserEnrollments,
-  readableId: ?string
+  textId: ?string
 ): Program | CourseRunDetail | null => {
   for (const programEnrollment of enrollments.program_enrollments) {
-    if (readableId === programEnrollment.program.readable_id) {
+    if (textId === programEnrollment.program.readable_id) {
       return programEnrollment.program
     }
 
     for (const courseRunEnrollment of programEnrollment.course_run_enrollments) {
-      if (readableId === courseRunEnrollment.run.courseware_id) {
+      if (textId === courseRunEnrollment.run.courseware_id) {
         return courseRunEnrollment.run
       }
     }
   }
 
   for (const courseRunEnrollment of enrollments.course_run_enrollments) {
-    if (readableId === courseRunEnrollment.run.courseware_id) {
+    if (textId === courseRunEnrollment.run.courseware_id) {
       return courseRunEnrollment.run
     }
   }

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -8,6 +8,7 @@ import {
   assertRaises,
   wait,
   enumerate,
+  findItemWithReadableId,
   isEmptyText,
   preventDefaultAndInvoke,
   notNil,
@@ -24,6 +25,7 @@ import {
   newSetWithout,
   timeoutPromise
 } from "./util"
+import { makeUserEnrollments } from "../factories/course"
 
 describe("utility functions", () => {
   it("waits some milliseconds", done => {
@@ -247,6 +249,41 @@ describe("utility functions", () => {
       assert.equal(getMaxDate(dates).toISOString(), futureDate.toISOString())
       dates = [null, undefined]
       assert.isNull(getMaxDate(dates))
+    })
+  })
+
+  describe("findItemWithReadableId", () => {
+    it("finds the readable id for a program", () => {
+      const enrollments = makeUserEnrollments()
+      const program = enrollments.program_enrollments[0].program
+      assert.deepEqual(
+        findItemWithReadableId(enrollments, program.readable_id),
+        program
+      )
+    })
+
+    it("finds the readable id for a course in a program", () => {
+      const enrollments = makeUserEnrollments()
+      const run =
+        enrollments.program_enrollments[0].course_run_enrollments[1].run
+      assert.deepEqual(
+        findItemWithReadableId(enrollments, run.courseware_id),
+        run
+      )
+    })
+
+    it("finds the readable id for a course outside a program", () => {
+      const enrollments = makeUserEnrollments()
+      const run = enrollments.course_run_enrollments[1].run
+      assert.deepEqual(
+        findItemWithReadableId(enrollments, run.courseware_id),
+        run
+      )
+    })
+
+    it("can't find the readable id so it returns null", () => {
+      const enrollments = makeUserEnrollments()
+      assert.isNull(findItemWithReadableId(enrollments, "missing"))
     })
   })
 })

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -8,7 +8,7 @@ import {
   assertRaises,
   wait,
   enumerate,
-  findItemWithReadableId,
+  findItemWithTextId,
   isEmptyText,
   preventDefaultAndInvoke,
   notNil,
@@ -252,12 +252,12 @@ describe("utility functions", () => {
     })
   })
 
-  describe("findItemWithReadableId", () => {
+  describe("findItemWithTextId", () => {
     it("finds the readable id for a program", () => {
       const enrollments = makeUserEnrollments()
       const program = enrollments.program_enrollments[0].program
       assert.deepEqual(
-        findItemWithReadableId(enrollments, program.readable_id),
+        findItemWithTextId(enrollments, program.readable_id),
         program
       )
     })
@@ -266,24 +266,18 @@ describe("utility functions", () => {
       const enrollments = makeUserEnrollments()
       const run =
         enrollments.program_enrollments[0].course_run_enrollments[1].run
-      assert.deepEqual(
-        findItemWithReadableId(enrollments, run.courseware_id),
-        run
-      )
+      assert.deepEqual(findItemWithTextId(enrollments, run.courseware_id), run)
     })
 
     it("finds the readable id for a course outside a program", () => {
       const enrollments = makeUserEnrollments()
       const run = enrollments.course_run_enrollments[1].run
-      assert.deepEqual(
-        findItemWithReadableId(enrollments, run.courseware_id),
-        run
-      )
+      assert.deepEqual(findItemWithTextId(enrollments, run.courseware_id), run)
     })
 
     it("can't find the readable id so it returns null", () => {
       const enrollments = makeUserEnrollments()
-      assert.isNull(findItemWithReadableId(enrollments, "missing"))
+      assert.isNull(findItemWithTextId(enrollments, "missing"))
     })
   })
 })

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -41,8 +41,7 @@
     font-weight: inherit;
   }
 
-  .alert-info {
-    background-color: $light-blue;
+  .alert {
     color: white;
     font-size: 24px;
     font-weight: 600;
@@ -57,6 +56,14 @@
       padding-bottom: 0;
       opacity: 1;
     }
+  }
+
+  .alert-info {
+    background-color: $light-blue;
+  }
+
+  .alert-danger {
+    background-color: $primary;
   }
 }
 

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -40,6 +40,24 @@
     font-size: inherit;
     font-weight: inherit;
   }
+
+  .alert-info {
+    background-color: $light-blue;
+    color: white;
+    font-size: 24px;
+    font-weight: 600;
+    width: 100%;
+    text-align: center;
+
+    button.close {
+      color: white;
+      font-size: 56px;
+      font-weight: 100;
+      padding-top: 0;
+      padding-bottom: 0;
+      opacity: 1;
+    }
+  }
 }
 
 .text-ribbon,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #598 
Fixes #663 

#### What's this PR do?
Adds query parameters to the redirect from CyberSource, then uses that information to direct the 

#### How should this be manually tested?
Go to `/dashboard/?readable_id=xyz&status=receipt`. You should see a request being made every 3 seconds. After 2 minutes the polling should stop and you should see "Something went wrong. Please contact support." in a alert message.

Find a readable id for an item you are already enrolled in (`Program.readable_id` or `CourseRun.courseware_id`). Encode it as a query parameter and put it in the `readable_id` query parameter in place of the `xyz` in the URL above. You should see the URL change to `/dashboard/` and a message saying that you are successfully enrolled in the course run or program.

Separately, go to `/checkout?product=?` for a product you can purchase. Have a 100% off coupon handy and apply it to the purchase, then checkout. You should be redirected to `/dashboard/?readable_id=...&status=receipt` and you should see a success message.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-27 13-41-36](https://user-images.githubusercontent.com/863262/60288884-278c1200-98e3-11e9-9460-1e25a61e55b8.png)

![Screenshot from 2019-06-27 13-54-30](https://user-images.githubusercontent.com/863262/60288893-29ee6c00-98e3-11e9-8cf5-a93e43e2accb.png)
