### PR TITLE
Tweak notification CSS to prevent video from displaying over notifications

### DIFF
--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -1,4 +1,7 @@
 .notifications {
+  position: relative;
+  z-index: 1;
+
   .alert {
     margin-bottom: 0;
 


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #687 

#### What's this PR do?
Adds `position: relative` and `z-index: 1` to explicitly position the notifications above the window.

#### How should this be manually tested?
Add a `SiteNotification` and visit your home page. You should see a notification.
#### Screenshots (if appropriate)
Wide desktop
![Screenshot from 2019-06-26 17-20-35](https://user-images.githubusercontent.com/863262/60216069-1685c700-9837-11e9-96db-34848ef27ceb.png)


Narrow desktop
![Screenshot from 2019-06-26 17-19-39](https://user-images.githubusercontent.com/863262/60216082-1e456b80-9837-11e9-86b9-d19036a4b744.png)


Mobile
![Screenshot from 2019-06-26 17-21-07](https://user-images.githubusercontent.com/863262/60216086-22718900-9837-11e9-8cb0-73b4829aa25c.png)
