### PR TITLE
Fixed and refactored enrollment commands

### DIFF
--- a/courses/management/commands/transfer_enrollment.py
+++ b/courses/management/commands/transfer_enrollment.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 
 from courses.management.utils import EnrollmentChangeCommand, fetch_user
 from courses.constants import ENROLL_CHANGE_STATUS_TRANSFERRED
-from courses.models import CourseRunEnrollment, ProgramEnrollment
+from courses.models import CourseRunEnrollment
 
 User = get_user_model()
 
@@ -44,65 +44,42 @@ class Command(EnrollmentChangeCommand):
         enrollment, enrolled_obj = self.fetch_enrollment(from_user, options)
 
         if options["program"]:
-            to_user_existing_enrolled_run_ids = CourseRunEnrollment.all_objects.filter(
-                user=to_user, run__course__program=enrolled_obj
-            ).values_list("run__courseware_id", flat=True)
+            to_user_existing_enrolled_run_ids = CourseRunEnrollment.get_program_run_enrollments(
+                user=to_user, program=enrolled_obj
+            ).values_list(
+                "run__courseware_id", flat=True
+            )
             if len(to_user_existing_enrolled_run_ids) > 0:
                 raise CommandError(
                     "'to' user is already enrolled in program runs ({})".format(
-                        str(to_user_existing_enrolled_run_ids)
+                        list(to_user_existing_enrolled_run_ids)
                     )
                 )
-            # Create the program enrollment
-            ProgramEnrollment.objects.create(
-                user=to_user,
-                program=enrolled_obj,
-                company=enrollment.company,
-                order=enrollment.order,
+
+            new_program_enrollment, new_run_enrollments = self.create_program_enrollment(
+                enrollment, to_user=to_user
             )
-            associated_run_enrollments = CourseRunEnrollment.objects.filter(
-                user=from_user, run__course__program=enrolled_obj
+            self.deactivate_program_enrollment(
+                enrollment, change_status=ENROLL_CHANGE_STATUS_TRANSFERRED
             )
-            # Create enrollments in all of the same program course runs that the 'from' user
-            # was enrolled in
-            for run_enrollment in associated_run_enrollments:
-                CourseRunEnrollment.objects.create(
-                    user=to_user,
-                    run=run_enrollment.run,
-                    company=enrollment.company,
-                    order=enrollment.order,
-                )
-            enrollments_to_deactivate = [enrollment] + list(associated_run_enrollments)
-            runs_to_enroll = [e.run for e in associated_run_enrollments]
         else:
-            CourseRunEnrollment.objects.create(
-                user=to_user,
-                run=enrolled_obj,
-                company=enrollment.company,
-                order=enrollment.order,
+            new_program_enrollment = None
+            new_run_enrollments = [
+                self.create_run_enrollment(enrollment, to_user=to_user)
+            ]
+            self.deactivate_run_enrollment(
+                enrollment, change_status=ENROLL_CHANGE_STATUS_TRANSFERRED
             )
-            enrollments_to_deactivate = [enrollment]
-            runs_to_enroll = [enrolled_obj]
-
-        for enrollment_to_deactivate in enrollments_to_deactivate:
-            enrollment_to_deactivate.active = False
-            enrollment_to_deactivate.change_status = ENROLL_CHANGE_STATUS_TRANSFERRED
-            enrollment_to_deactivate.save_and_log(None)
-
-        self.stdout.write(
-            "New enrollment record(s) created. Attempting to enroll the user on edX..."
-        )
-        self.enroll_in_edx(to_user, runs_to_enroll)
 
         self.stdout.write(
             self.style.SUCCESS(
                 "Transferred enrollment – 'from' user: {} ({}), 'to' user: {} ({})\n"
-                "Enrollment in: {}".format(
+                "Enrollments created/updated: {}".format(
                     from_user.username,
                     from_user.email,
                     to_user.username,
                     to_user.email,
-                    enrolled_obj,
+                    list(filter(bool, [new_program_enrollment] + new_run_enrollments)),
                 )
             )
         )

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -127,6 +127,20 @@ def first_matching_item(iterable, predicate):
     return next(filter(predicate, iterable), None)
 
 
+def has_equal_properties(obj, property_dict):
+    """
+    Returns True if the given object has the properties indicated by the keys of the given dict, and the values
+    of those properties match the values of the dict
+    """
+    for field, value in property_dict.items():
+        try:
+            if getattr(obj, field) != value:
+                return False
+        except AttributeError:
+            return False
+    return True
+
+
 def partition(items, predicate=bool):
     """
     Partitions an iterable into two different iterables - the first does not match the given condition, and the second

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -1,5 +1,6 @@
 """Utils tests"""
 import datetime
+from types import SimpleNamespace
 
 import pytz
 
@@ -11,6 +12,7 @@ from mitxpro.utils import (
     dict_without_keys,
     filter_dict_by_key_set,
     partition,
+    has_equal_properties,
 )
 
 
@@ -63,6 +65,18 @@ def test_get_field_names():
         "created_on",
         "updated_on",
     }
+
+
+def test_has_equal_properties():
+    """
+    Assert that has_equal_properties returns True if an object has equivalent properties to a given dict
+    """
+    obj = SimpleNamespace(a=1, b=2, c=3)
+    assert has_equal_properties(obj, {}) is True
+    assert has_equal_properties(obj, dict(a=1, b=2)) is True
+    assert has_equal_properties(obj, dict(a=1, b=2, c=3)) is True
+    assert has_equal_properties(obj, dict(a=2)) is False
+    assert has_equal_properties(obj, dict(d=4)) is False
 
 
 def test_partition():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #671 
Fixes #669 

#### What's this PR do?
- Fixes bugs with the refund and defer enrollment management commands
- Fixes edX API client error handling so that the actual error response body is shown in the command output
- Refactors some common functionality to make these commands a less susceptible to bugs

#### How should this be manually tested?
- Enroll a user in some program ("SysEngX"/"Systems Engineering" for example), then transfer that enrollment to a different user via the `transfer_enrollment` command. If you weren't previously enrolled, and if the course runs in that program aren't set up in your local edX instance, you should see (a) the program enrollment and associated course run enrollments transfer over to the new user, (b) the existing program enrollment and associated course run enrollments deactivated for your 'from' user, and (c) a bunch of warning output from the command indicating the error response from edX (e.g.: `edX enrollment request failed (400). Response: {"message":"No course 'course-v1:TestX+SysEngxB2+1T2019' found for enrollment"}`)
- Enroll a user in some course run, then defer that enrollment to some other course run that you're not enrolled in (use `-f` if you want to defer to a run from a different course). You should see similar output and results to the above command
- Refund an existing program enrollment (e.g.: `manage.py refund_enrollment --user "myemail@example.com" --program "SysEngx"`) and make sure that the associated course run enrollments are also set to refunded

#### Any background context you want to provide?
The edX API client does not have unenrolling capability yet, so don't expect any changes to existing enrollments on edX. This can be added later (https://github.com/mitodl/edx-api-client/issues/60), and it was actually that shortfall that made me realize that the enrollment logic needed to be cleaned up and streamlined.

#### Screenshots (if appropriate)
![ss 2019-06-27 at 13 40 06 ](https://user-images.githubusercontent.com/14932219/60288894-2a870280-98e3-11e9-86f9-67f375099345.png)

