### PR TITLE
Added 'create account' link to sign in page

### DIFF
--- a/static/js/components/forms/EmailForm.js
+++ b/static/js/components/forms/EmailForm.js
@@ -13,14 +13,15 @@ const emailValidation = yup.object().shape({
 })
 
 type EmailFormProps = {
-  onSubmit: Function
+  onSubmit: Function,
+  children?: React$Element<*>
 }
 
 export type EmailFormValues = {
   email: string
 }
 
-const EmailForm = ({ onSubmit }: EmailFormProps) => (
+const EmailForm = ({ onSubmit, children }: EmailFormProps) => (
   <Formik
     onSubmit={onSubmit}
     validationSchema={emailValidation}
@@ -32,6 +33,7 @@ const EmailForm = ({ onSubmit }: EmailFormProps) => (
           <Field name="email" className="form-control" component={EmailInput} />
           <ErrorMessage name="email" component={FormError} />
         </div>
+        {children && <div className="form-group">{children}</div>}
         <div className="row submit-row no-gutters justify-content-end">
           <button
             type="submit"

--- a/static/js/components/forms/EmailForm_test.js
+++ b/static/js/components/forms/EmailForm_test.js
@@ -11,7 +11,13 @@ import { findFormikFieldByName } from "../../lib/test_utils"
 describe("EmailForm", () => {
   let sandbox, onSubmitStub
 
-  const renderForm = () => shallow(<EmailForm onSubmit={onSubmitStub} />)
+  const renderForm = children =>
+    shallow(
+      <EmailForm
+        onSubmit={onSubmitStub}
+        {...(children ? { children: children } : {})}
+      />
+    )
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -30,5 +36,15 @@ describe("EmailForm", () => {
     const form = wrapper.find("Formik").dive()
     assert.ok(findFormikFieldByName(form, "email").exists())
     assert.ok(form.find("button[type='submit']").exists())
+  })
+
+  it("renders child elements if they are passed in", () => {
+    const wrapper = renderForm(<div id="test-child">child element</div>)
+
+    const form = wrapper.find("Formik").dive()
+    const testChild = form.find("div#test-child")
+    assert.ok(testChild.exists())
+    assert.equal(testChild.at(0).text(), "child element")
+    assert.equal(testChild.parent().prop("className"), "form-group")
   })
 })

--- a/static/js/containers/pages/login/LoginEmailPage.js
+++ b/static/js/containers/pages/login/LoginEmailPage.js
@@ -13,6 +13,7 @@ import EmailForm from "../../../components/forms/EmailForm"
 import type { RouterHistory, Location } from "react-router"
 import type { Response } from "redux-query"
 import type { AuthResponse } from "../../../flow/authTypes"
+import { Link } from "react-router-dom"
 
 type Props = {
   location: Location,
@@ -51,7 +52,14 @@ class LoginEmailPage extends React.Component<Props> {
         </div>
         <div className="row auth-card card-shadow auth-form">
           <div className="col-12">
-            <EmailForm onSubmit={this.onSubmit.bind(this)} />
+            <EmailForm onSubmit={this.onSubmit.bind(this)}>
+              <React.Fragment>
+                <span>Don't have an account? </span>
+                <Link to={routes.register.begin} className="link-light-blue">
+                  Create Account
+                </Link>
+              </React.Fragment>
+            </EmailForm>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #680 

#### What's this PR do?
Adds a 'create account' link to sign in page

#### How should this be manually tested?
Go to the login page and use the "create account" link. Other email-only forms (e.g.: the forgot password page) should not have that link

#### Screenshots (if appropriate)
![ss 2019-06-27 at 15 29 54 ](https://user-images.githubusercontent.com/14932219/60297102-7c388880-98f5-11e9-9cad-1702b021acd4.png)

