### PR TITLE
Use site wide notifications for dashboard

### DIFF
--- a/static/js/components/NotificationContainer.js
+++ b/static/js/components/NotificationContainer.js
@@ -61,7 +61,7 @@ export class NotificationContainer extends React.Component<Props, State> {
           return (
             <Alert
               key={i}
-              color="info"
+              color={notification.color || "info"}
               className="rounded-0 border-0"
               isOpen={!hiddenNotifications.has(notificationKey)}
               toggle={dismiss}

--- a/static/js/components/NotificationContainer_test.js
+++ b/static/js/components/NotificationContainer_test.js
@@ -56,6 +56,28 @@ describe("NotificationContainer component", () => {
     assert.equal(alerts.at(1).prop("children").type, UnusedCouponNotification)
   })
 
+  //
+  ;[[undefined, "info"], ["danger", "danger"]].forEach(
+    ([color, expectedColor]) => {
+      it(`shows a ${expectedColor} color notification given a ${String(
+        color
+      )} color prop`, async () => {
+        const { inner } = await render({
+          ui: {
+            userNotifications: {
+              aMessage: {
+                type:  ALERT_TYPE_TEXT,
+                color: color,
+                props: { text: "derp" }
+              }
+            }
+          }
+        })
+        assert.equal(inner.find("Alert").prop("color"), expectedColor)
+      })
+    }
+  )
+
   it("hides a message when it's dismissed, then removes it from global state", async () => {
     const delayMs = 5
     const { inner, wrapper } = await render(

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -206,31 +206,13 @@ describe("DashboardPage", () => {
   })
 
   describe("cybersource redirect", () => {
-    it("shows an alert based on the toastMessage state value", async () => {
-      const { inner } = await renderPage()
-      assert.isFalse(inner.find("Alert").prop("isOpen"))
-      inner.setState({ toastMessage: "hello world", alertType: "info" })
-      assert.isTrue(inner.find("Alert").prop("isOpen"))
-      assert.equal(inner.find("Alert").prop("color"), "info")
-      assert.isTrue(
-        inner
-          .find("Alert")
-          .html()
-          .includes("hello world")
-      )
-      inner.find("Alert").prop("toggle")()
-      assert.isFalse(inner.find("Alert").prop("isOpen"))
-      assert.equal(inner.state().toastMessage, "")
-      assert.equal(inner.state().alertType, "")
-    })
-
     it("looks up a run or program using the query parameter, and displays the success message", async () => {
       const program = userEnrollments.program_enrollments[0].program
       const waitStub = helper.sandbox.stub(utilFuncs, "wait")
       const stub = helper.sandbox
         .stub(utilFuncs, "findItemWithTextId")
         .returns(program)
-      const { inner } = await renderPage(
+      const { store } = await renderPage(
         {},
         {
           location: {
@@ -238,11 +220,14 @@ describe("DashboardPage", () => {
           }
         }
       )
-      assert.equal(
-        inner.state().toastMessage,
-        `You are now enrolled in ${program.title}!`
-      )
-      assert.equal(inner.state().alertType, "info")
+      assert.deepEqual(store.getState().ui.userNotifications, {
+        "order-status": {
+          type:  "text",
+          props: {
+            text: `You are now enrolled in ${program.title}!`
+          }
+        }
+      })
       sinon.assert.calledWith(stub, userEnrollments, "a b c")
       assert.equal(waitStub.callCount, 0)
     })
@@ -264,7 +249,7 @@ describe("DashboardPage", () => {
           .stub(utilFuncs, "findItemWithTextId")
           .returns(null)
 
-        const { inner } = await renderPage(
+        const { store } = await renderPage(
           {},
           {
             location: {
@@ -282,12 +267,17 @@ describe("DashboardPage", () => {
         await waitPromise
 
         if (outOfTime) {
-          assert.equal(
-            inner.state().toastMessage,
-            `Something went wrong. Please contact support at ${
-              SETTINGS.support_email
-            }.`
-          )
+          assert.deepEqual(store.getState().ui.userNotifications, {
+            "order-status": {
+              color: "danger",
+              type:  "text",
+              props: {
+                text: `Something went wrong. Please contact support at ${
+                  SETTINGS.support_email
+                }.`
+              }
+            }
+          })
         } else {
           sinon.assert.calledWith(
             helper.handleRequestStub,

--- a/static/js/reducers/notifications.js
+++ b/static/js/reducers/notifications.js
@@ -15,10 +15,12 @@ export type UnusedCouponNotificationProps = {
 export type UserNotificationSpec =
   | {
       type: ALERT_TYPE_TEXT,
+      color: string,
       props: TextNotificationProps
     }
   | {
       type: ALERT_TYPE_UNUSED_COUPON,
+      color: string,
       props: UnusedCouponNotificationProps
     }
 

--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -14,8 +14,7 @@
   .alert {
     margin-bottom: 0;
 
-    &.alert-info {
-      background-color: #126f9a;
+    &.alert-info, &.alert-danger {
       color: white;
 
       a.alert-link, .close {
@@ -34,6 +33,14 @@
       .close {
         opacity: 1;
       }
+    }
+
+    &.alert-info {
+      background-color: #126f9a;
+    }
+
+    &.alert-danger {
+      background-color: $primary;
     }
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #698 

#### What's this PR do?
Removes the `<Alert />` component used on the dashboard page and uses the sitewide notifications instead

#### How should this be manually tested?
Go to `/dashboard/?purchased=abcde&status=purchased` where `abcde` is a readable id for a product you already have in the dashboard. You should see the URL change to remove the query parameter and a alert message pop up which looks like the screenshot below.

If you change the readable id to something else not in the dashboard, and go to `/dashboard?purchased=xyzzy&status=purchased` and wait for approx 2 minutes, you should see the other alert similar to the screenshot below.

#### Screenshots (if appropriate)
![Screenshot from 2019-06-27 16-12-29](https://user-images.githubusercontent.com/863262/60299067-d3d8f300-98f9-11e9-92c7-0ed4f504c139.png)

![Screenshot from 2019-06-27 16-12-16](https://user-images.githubusercontent.com/863262/60299092-dd625b00-98f9-11e9-9193-5a233da9aa35.png)
