### PR TITLE
Fixed margin issue with site-wide notifications

### DIFF
--- a/mitxpro/templates/partials/notifications.html
+++ b/mitxpro/templates/partials/notifications.html
@@ -1,4 +1,4 @@
-<div class="notifications d-none">
+<div class="notifications site-wide d-none">
   {% if notification %}
     <div class="notification" data-notification-id="{{ notification.id }}">
       <a href="#" class="close-notification"></a>

--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -2,6 +2,15 @@
   position: relative;
   z-index: 1;
 
+  // HACK: Using this rule to get around styling issues with <p> elements in the
+  //       notification content (notification content in Wagtail is configured to be HTML,
+  //       and Wagtail wraps content in a <p> tag by default when you use the editor).
+  &.site-wide {
+    p {
+      margin: 0;
+    }
+  }
+
   .alert {
     margin-bottom: 0;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket (I think)

#### What's this PR do?
See title

#### How should this be manually tested?
Make sure the spacing issue with site-wide notifications is gone (best to test it on the home page with a video enabled like RC)

#### Screenshots (if appropriate)
![ss 2019-06-27 at 16 37 34 ](https://user-images.githubusercontent.com/14932219/60299312-6e393680-98fa-11e9-8637-1348fe49baf1.png)

