### PR TITLE
#704 Watch Now button support for Youtube videos

### DIFF
--- a/cms/embeds.py
+++ b/cms/embeds.py
@@ -1,0 +1,49 @@
+"""
+Custom wagtail embed providers and finders
+"""
+
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from django.core.exceptions import ImproperlyConfigured
+
+from bs4 import BeautifulSoup
+from wagtail.embeds.finders.oembed import OEmbedFinder
+from wagtail.embeds.oembed_providers import youtube
+
+
+class YouTubeEmbedFinder(OEmbedFinder):
+    """
+    OEmbed finder which injects rel=0 and enablejsapi=1 parameters on YouTube URLs.
+
+    This finder operates on the youtube provider only, and sets the
+    source URL's rel=0  and enablejsapi=1. By default Youtube strips these out.
+    """
+
+    def __init__(self, providers=None, options=None):
+        if providers is None:
+            providers = [youtube]
+
+        if providers != [youtube]:
+            raise ImproperlyConfigured(
+                "The YouTubeEmbedFinder only operates on the youtube provider"
+            )
+
+        super().__init__(providers=providers, options=options)
+
+    def find_embed(self, url, max_width=None):
+        embed = super().find_embed(url, max_width)
+
+        embed_tag = BeautifulSoup(embed["html"], "html.parser")
+        iframe_url = embed_tag.find("iframe").attrs["src"]
+        scheme, netloc, path, params, query, fragment = urlparse(iframe_url)
+
+        querydict = parse_qs(query)
+        querydict["rel"] = "0"
+        querydict["enablejsapi"] = "1"
+
+        query = urlencode(querydict, doseq=1)
+        iframe_url = urlunparse((scheme, netloc, path, params, query, fragment))
+        embed_tag.find("iframe").attrs["src"] = iframe_url
+        embed["html"] = str(embed_tag)
+
+        return embed

--- a/cms/embeds_test.py
+++ b/cms/embeds_test.py
@@ -1,0 +1,56 @@
+"""Tests for custom embed providers and finders"""
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from bs4 import BeautifulSoup
+from django.core.exceptions import ImproperlyConfigured
+from wagtail.embeds.embeds import get_embed
+from wagtail.embeds.exceptions import EmbedNotFoundException
+from wagtail.embeds.oembed_providers import vimeo
+
+from cms.embeds import YouTubeEmbedFinder
+
+pytestmark = pytest.mark.django_db
+
+
+def test_youtube_finder_invalid_config():
+    """
+    Test that the Youtube embed finder throws in invalid configuration exception
+    if used apart from the Youtube provider
+    """
+    with pytest.raises(ImproperlyConfigured):
+        assert YouTubeEmbedFinder(providers=[vimeo])
+
+
+def test_youtube_embed():
+    """
+    Test that the Youtube embed works with a Youtube link.
+    """
+    embed = get_embed("https://www.youtube.com/watch?v=C0DPdy98e4c")
+    assert embed
+    assert embed.html
+
+
+def test_youtube_embed_parameters():
+    """
+    Test that the Youtube embed works with a Youtube link.
+    """
+    embed = get_embed("https://www.youtube.com/watch?v=C0DPdy98e4c")
+    assert embed
+    assert embed.html
+
+    embed_tag = BeautifulSoup(embed.html, "html.parser")
+    iframe_url = embed_tag.find("iframe").attrs["src"]
+    _, _, _, _, query, _ = urlparse(iframe_url)
+
+    querydict = parse_qs(query)
+    assert querydict["rel"] == ["0"]
+    assert querydict["enablejsapi"] == ["1"]
+
+
+def test_youtube_embed_invalid_link():
+    """
+    Test that the Youtube embed throws an exception on an invalid link
+    """
+    with pytest.raises(EmbedNotFoundException):
+        assert get_embed("https://www.youtube.com/watch?v=DUMMY")

--- a/cms/templates/partials/text-video-section.html
+++ b/cms/templates/partials/text-video-section.html
@@ -15,7 +15,7 @@
           <div class="video-holder">
               {% embed page.video_url as youtube_video %}
               {% if youtube_video %}
-                <div class="tv-video youtube-video">{{ youtube_video }}</div>
+                <div class="tv-video youtube-video" id="tv-yt-video">{{ youtube_video }}</div>
               {% else %}
                 <video class="tv-video" id="tv-video" controls data-source="{{ page.video_url }}"></video>
               {% endif %}

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -637,3 +637,9 @@ VOUCHER_COMPANY_ID = get_int("VOUCHER_COMPANY_ID", None)
 # Hubspot sync settings
 HUBSPOT_API_KEY = get_string("HUBSPOT_API_KEY", None)
 HUBSPOT_ID_PREFIX = get_string("HUBSPOT_ID_PREFIX", "xpronew")
+
+
+WAGTAILEMBEDS_FINDERS = [
+    {"class": "cms.embeds.YouTubeEmbedFinder"},
+    {"class": "wagtail.embeds.finders.oembed"},
+]

--- a/static/js/hero.js
+++ b/static/js/hero.js
@@ -47,6 +47,9 @@ $(document).ready(function() {
     event.preventDefault();
 
     const aboutVideo = $("#tv-video").get(0);
+    const aboutVideoYoutube = $("#tv-yt-video")
+      .find("iframe")
+      .get(0);
 
     if (aboutVideo) {
       aboutVideo.scrollIntoView({
@@ -54,6 +57,20 @@ $(document).ready(function() {
         block:    "center"
       });
       aboutVideo.play();
+    } else if (aboutVideoYoutube) {
+      aboutVideoYoutube.scrollIntoView({
+        behavior: "smooth",
+        block:    "center"
+      });
+      aboutVideoYoutube.contentWindow.postMessage(
+        JSON.stringify({
+          event: "command",
+          func:  "playVideo"
+        }),
+        "https://www.youtube.com"
+      );
+    } else {
+      console.error("We do not have any supported video elements available."); // eslint-disable-line no-console
     }
   });
 });


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #704

#### What's this PR do?
Adds support for Youtube videos to the "Watch Now" button in hero section on the home page.

#### How should this be manually tested?
Configure a Youtube video within the "Text Video" section on home page (typically titled "About MIT"). Click on the "Watch Now" button, the screen should scroll to bring the section in view and the video should start playing.
**Note:** While testing make sure your browser isn't trying to use a stale version of the JS file.
