### PR TITLE
Use program.title and run.title instead of product.description

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -59,6 +59,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
     product_id = serializers.IntegerField(source="product.id", read_only=True)
     courses = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
+    content_title = serializers.SerializerMethodField()
 
     def get_type(self, instance):
         """ Return the product version type """
@@ -93,11 +94,16 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             raise ValueError(f"Unexpected product {content_object}")
         return catalog_image_url or static(DEFAULT_COURSE_IMG_PATH)
 
+    def get_content_title(self, instance):
+        """Return the title of the program or course run"""
+        return instance.product.content_object.title
+
     class Meta:
         fields = [
             "id",
             "price",
             "description",
+            "content_title",
             "type",
             "courses",
             "thumbnail_url",

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -61,6 +61,7 @@ def test_serialize_basket_product_version_courserun(mock_context):
     assert data == {
         "id": product_version.id,
         "description": product_version.description,
+        "content_title": product_version.product.content_object.title,
         "price": str(round_half_up(product_version.price)),
         "type": product_version.product.content_type.model,
         "courses": [
@@ -84,6 +85,7 @@ def test_serialize_basket_product_version_program(mock_context):
     assert data == {
         "id": product_version.id,
         "description": product_version.description,
+        "content_title": product_version.product.content_object.title,
         "price": str(round_half_up(product_version.price)),
         "type": product_version.product.content_type.model,
         "courses": [

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -126,10 +126,10 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
       return (
         <div className="flex-row item-row">
           <div className="flex-row item-column">
-            <img src={item.thumbnail_url} alt={item.description} />
+            <img src={item.thumbnail_url} alt={item.content_title} />
           </div>
           <div className="title-column">
-            <div className="title">{item.description}</div>
+            <div className="title">{item.content_title}</div>
             <Field
               component="select"
               name={`runs.${course.id}`}
@@ -213,7 +213,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
               </div>
               <hr />
               {item.type === "program" ? (
-                <span className="description">{item.description}</span>
+                <span className="description">{item.content_title}</span>
               ) : null}
             </div>
           </div>

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -70,7 +70,7 @@ describe("CheckoutForm", () => {
       assert.equal(inner.find(".item-type").text(), "Program")
       assert.equal(
         inner.find(".header .description").text(),
-        basketItem.description
+        basketItem.content_title
       )
       assert.equal(inner.find(".item-row").length, basketItem.courses.length)
       basketItem.courses.forEach((course, i) => {
@@ -110,8 +110,11 @@ describe("CheckoutForm", () => {
     assert.equal(inner.find(".item-type").text(), "Course")
     assert.equal(inner.find(".item-row").length, 1)
     assert.equal(inner.find("img").prop("src"), basketItem.thumbnail_url)
-    assert.equal(inner.find("img").prop("alt"), basketItem.description)
-    assert.equal(inner.find(".item-row .title").text(), basketItem.description)
+    assert.equal(inner.find("img").prop("alt"), basketItem.content_title)
+    assert.equal(
+      inner.find(".item-row .title").text(),
+      basketItem.content_title
+    )
   })
 
   //

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -46,6 +46,7 @@ export const makeItem = (itemType: ?string): BasketItem => {
     // $FlowFixMe: flow doesn't understand generators well
     id:            genBasketItemId.next().value,
     description:   casual.text,
+    content_title: casual.text,
     price:         String(casual.double(0, 100)),
     thumbnail_url: casual.url,
     run_ids:       runIds,

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -33,6 +33,7 @@ export type BasketItem = {
   thumbnail_url: string,
   price: string,
   description: string,
+  content_title: string,
   object_id: number,
   product_id: number,
   id: number,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #720 

#### What's this PR do?
Adds the program title to the API and uses it instead of the product description when displaying it on the checkout page

#### How should this be manually tested?
View a product in the checkout page and verify that the title matches the course run or program title, not necessarily the product description.
