### PR TITLE
Disable submit button while processing

### DIFF
--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -47,6 +47,7 @@ type CommonProps = {
   item: BasketItem,
   basket: BasketResponse,
   coupon: ?CouponSelection,
+  mutationPending: boolean,
   onSubmit: (Values, Actions) => Promise<void>,
   submitCoupon: (
     couponCode: ?string,
@@ -185,6 +186,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
     const {
       basket,
       errors,
+      mutationPending,
       values,
       setFieldError,
       item,
@@ -240,6 +242,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                   <button
                     className="apply-button"
                     type="button"
+                    disabled={mutationPending}
                     onClick={() =>
                       submitCoupon(values.couponCode, setFieldError)
                     }
@@ -297,7 +300,11 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
           <div className="row">
             <div className="col-lg-7" />
             <div className="col-lg-5">
-              <button className="checkout-button" type="submit">
+              <button
+                className="checkout-button"
+                type="submit"
+                disabled={mutationPending}
+              >
                 Place your order
               </button>
               {formatErrors(errors.items)}
@@ -370,6 +377,7 @@ export class CheckoutForm extends React.Component<OuterProps> {
       coupon,
       couponCode,
       item,
+      mutationPending,
       selectedRuns,
       submitCoupon,
       updateProduct
@@ -390,6 +398,7 @@ export class CheckoutForm extends React.Component<OuterProps> {
             basket={basket}
             item={item}
             coupon={coupon}
+            mutationPending={mutationPending}
             onSubmit={onSubmit}
             submitCoupon={submitCoupon}
             updateProduct={updateProduct}

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -47,7 +47,7 @@ type CommonProps = {
   item: BasketItem,
   basket: BasketResponse,
   coupon: ?CouponSelection,
-  mutationPending: boolean,
+  requestPending: boolean,
   onSubmit: (Values, Actions) => Promise<void>,
   submitCoupon: (
     couponCode: ?string,
@@ -186,7 +186,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
     const {
       basket,
       errors,
-      mutationPending,
+      requestPending,
       values,
       setFieldError,
       item,
@@ -242,7 +242,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                   <button
                     className="apply-button"
                     type="button"
-                    disabled={mutationPending}
+                    disabled={requestPending}
                     onClick={() =>
                       submitCoupon(values.couponCode, setFieldError)
                     }
@@ -303,7 +303,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
               <button
                 className="checkout-button"
                 type="submit"
-                disabled={mutationPending}
+                disabled={requestPending}
               >
                 Place your order
               </button>
@@ -377,7 +377,7 @@ export class CheckoutForm extends React.Component<OuterProps> {
       coupon,
       couponCode,
       item,
-      mutationPending,
+      requestPending,
       selectedRuns,
       submitCoupon,
       updateProduct
@@ -398,7 +398,7 @@ export class CheckoutForm extends React.Component<OuterProps> {
             basket={basket}
             item={item}
             coupon={coupon}
-            mutationPending={mutationPending}
+            requestPending={requestPending}
             onSubmit={onSubmit}
             submitCoupon={submitCoupon}
             updateProduct={updateProduct}

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -51,7 +51,7 @@ describe("CheckoutForm", () => {
         coupon={coupon}
         couponCode={couponCode}
         basket={basket}
-        mutationPending={false}
+        requestPending={false}
         item={basketItem}
         submitCoupon={submitCouponStub}
         selectedRuns={{}}
@@ -446,20 +446,17 @@ describe("CheckoutForm", () => {
   })
 
   //
-  ;[true, false].forEach(mutationPending => {
+  ;[true, false].forEach(requestPending => {
     it("disables the apply coupon and checkout buttons while processing", async () => {
       const inner = await renderForm({
-        mutationPending
+        requestPending
       })
 
       assert.equal(
         inner.find(".checkout-button").prop("disabled"),
-        mutationPending
+        requestPending
       )
-      assert.equal(
-        inner.find(".apply-button").prop("disabled"),
-        mutationPending
-      )
+      assert.equal(inner.find(".apply-button").prop("disabled"), requestPending)
     })
   })
 })

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -18,6 +18,7 @@ import {
 } from "../../lib/ecommerce"
 import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants"
 import { calcSelectedRunIds } from "../../containers/pages/CheckoutPage"
+import { isIf, shouldIf } from "../../lib/test_utils"
 
 describe("CheckoutForm", () => {
   let sandbox,
@@ -447,7 +448,11 @@ describe("CheckoutForm", () => {
 
   //
   ;[true, false].forEach(requestPending => {
-    it("disables the apply coupon and checkout buttons while processing", async () => {
+    it(`${shouldIf(
+      requestPending
+    )} disable submit buttons while the request ${isIf(
+      requestPending
+    )} in progress`, async () => {
       const inner = await renderForm({
         requestPending
       })

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -51,6 +51,7 @@ describe("CheckoutForm", () => {
         coupon={coupon}
         couponCode={couponCode}
         basket={basket}
+        mutationPending={false}
         item={basketItem}
         submitCoupon={submitCouponStub}
         selectedRuns={{}}
@@ -441,6 +442,24 @@ describe("CheckoutForm", () => {
       const [text, url] = linkPairs[i]
       assert.equal(linkWrapper.text(), text)
       assert.equal(linkWrapper.prop("href"), url)
+    })
+  })
+
+  //
+  ;[true, false].forEach(mutationPending => {
+    it("disables the apply coupon and checkout buttons while processing", async () => {
+      const inner = await renderForm({
+        mutationPending
+      })
+
+      assert.equal(
+        inner.find(".checkout-button").prop("disabled"),
+        mutationPending
+      )
+      assert.equal(
+        inner.find(".apply-button").prop("disabled"),
+        mutationPending
+      )
     })
   })
 })

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -27,7 +27,7 @@ import type {
 
 type Props = {
   basket: ?BasketResponse,
-  mutationPending: boolean,
+  requestPending: boolean,
   checkout: () => Promise<Response<CheckoutResponse>>,
   fetchBasket: () => Promise<*>,
   location: Location,
@@ -182,7 +182,7 @@ export class CheckoutPage extends React.Component<Props, State> {
   }
 
   render() {
-    const { basket, mutationPending } = this.props
+    const { basket, requestPending } = this.props
     const { errors } = this.state
 
     const item = basket && basket.items[0]
@@ -211,15 +211,15 @@ export class CheckoutPage extends React.Component<Props, State> {
         submitCoupon={this.submitCoupon}
         onSubmit={this.submit}
         updateProduct={this.updateProduct}
-        mutationPending={mutationPending}
+        requestPending={requestPending}
       />
     )
   }
 }
 
 const mapStateToProps = state => ({
-  basket:          state.entities.basket,
-  mutationPending:
+  basket:         state.entities.basket,
+  requestPending:
     pathOr(false, ["queries", "basketMutation", "isPending"], state) ||
     pathOr(false, ["queries", "couponsMutation", "isPending"], state) ||
     pathOr(false, ["queries", "checkoutMutation", "isPending"], state)

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux"
 import { mutateAsync, requestAsync } from "redux-query"
 import { compose } from "redux"
 import queryString from "query-string"
+import { pathOr } from "ramda"
 
 import { CheckoutForm } from "../../components/forms/CheckoutForm"
 
@@ -26,6 +27,7 @@ import type {
 
 type Props = {
   basket: ?BasketResponse,
+  mutationPending: boolean,
   checkout: () => Promise<Response<CheckoutResponse>>,
   fetchBasket: () => Promise<*>,
   location: Location,
@@ -180,7 +182,7 @@ export class CheckoutPage extends React.Component<Props, State> {
   }
 
   render() {
-    const { basket } = this.props
+    const { basket, mutationPending } = this.props
     const { errors } = this.state
 
     const item = basket && basket.items[0]
@@ -209,13 +211,18 @@ export class CheckoutPage extends React.Component<Props, State> {
         submitCoupon={this.submitCoupon}
         onSubmit={this.submit}
         updateProduct={this.updateProduct}
+        mutationPending={mutationPending}
       />
     )
   }
 }
 
 const mapStateToProps = state => ({
-  basket: state.entities.basket
+  basket:          state.entities.basket,
+  mutationPending:
+    pathOr(false, ["queries", "basketMutation", "isPending"], state) ||
+    pathOr(false, ["queries", "couponsMutation", "isPending"], state) ||
+    pathOr(false, ["queries", "checkoutMutation", "isPending"], state)
 })
 const mapDispatchToProps = dispatch => ({
   checkout:     () => dispatch(mutateAsync(queries.ecommerce.checkoutMutation())),

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -371,7 +371,7 @@ describe("CheckoutPage", () => {
           }
         }
       })
-      assert.isTrue(inner.find("CheckoutForm").prop("mutationPending"))
+      assert.isTrue(inner.find("CheckoutForm").prop("requestPending"))
     })
   })
 })

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -360,4 +360,18 @@ describe("CheckoutPage", () => {
       assert.deepEqual(calcSelectedRunIds(item), expected)
     })
   })
+
+  //
+  ;["basketMutation", "couponsMutation", "checkoutMutation"].forEach(key => {
+    it(`notifies CheckoutForm that a request is ongoing for ${key}`, async () => {
+      const { inner } = await renderPage({
+        queries: {
+          [key]: {
+            isPending: true
+          }
+        }
+      })
+      assert.isTrue(inner.find("CheckoutForm").prop("mutationPending"))
+    })
+  })
 })

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -18,8 +18,9 @@ const DEFAULT_POST_OPTIONS = {
 
 export default {
   checkoutMutation: () => ({
-    url:    "/api/checkout/",
-    update: {
+    queryKey: "checkoutMutation",
+    url:      "/api/checkout/",
+    update:   {
       checkout: () => null
     },
     options: {
@@ -37,8 +38,9 @@ export default {
     }
   }),
   basketMutation: (payload: BasketResponse) => ({
-    url:    "/api/basket/",
-    update: {
+    queryKey: "basketMutation",
+    url:      "/api/basket/",
+    update:   {
       basket: (prev: BasketResponse, next: BasketResponse) => next
     },
     transform: (json: BasketResponse) => ({
@@ -73,6 +75,7 @@ export default {
   }),
   couponsSelector: pathOr(null, ["entities", "coupons"]),
   couponsMutation: (coupon: Object) => ({
+    queryKey:  "couponsMutation",
     url:       "/api/coupons/",
     body:      coupon,
     transform: (coupon: CouponPaymentVersion) => ({


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #711 

#### What's this PR do?
Disables coupon update and checkout buttons while mutating requests are processing

#### How should this be manually tested?
Throttle down your network activity in the browser console and click the button repeatedly. You should see only one request be initiated
