### PR TITLE
Fixed catalog login/signup urls

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models import Prefetch
 from django.utils.text import slugify
 from django.http.response import Http404
+from django.shortcuts import reverse
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
     FieldPanel,
@@ -509,6 +510,9 @@ class ProgramPage(ProductPage):
             **super().get_context(request, **kwargs),
             **get_js_settings_context(request),
             "product_id": product.id if product else None,
+            "checkout_url": f"{reverse('checkout-page')}?product={ product.id }"
+            if product
+            else None,
             "enrolled": enrolled,
             "user": request.user,
         }
@@ -578,6 +582,9 @@ class CoursePage(ProductPage):
             **super().get_context(request, **kwargs),
             **get_js_settings_context(request),
             "product_id": product.id if product else None,
+            "checkout_url": f"{reverse('checkout-page')}?product={ product.id }"
+            if product
+            else None,
             "enrolled": enrolled,
             "user": request.user,
         }

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -44,7 +44,7 @@
           {% else %}
             {% if not user.is_anonymous %}
               {% if not enrolled and product_id %}
-                <a class="enroll-button" href="{% url "checkout-page" %}?product={{ product_id }}">
+                <a class="enroll-button" href="{{ checkout_url }}">
                   Enroll Now
                 </a>
               {% elif enrolled %}
@@ -71,10 +71,10 @@
                     </div>
                     <div class="bottom-row">
                       <div class="popup-buttons">
-                        <a class="sign-in-link link-button" href="/signin">
+                        <a class="sign-in-link link-button" href="{% url 'login' %}?next={{ checkout_url|urlencode:'' }}">
                           Sign In
                         </a>
-                        <a class="create-account-link link-button" href="/create-account">
+                        <a class="create-account-link link-button" href="{% url 'signup' %}?next={{ checkout_url|urlencode:'' }}">
                           Create Account
                         </a>
                       </div>

--- a/static/js/containers/pages/register/RegisterExtraDetailsPage.js
+++ b/static/js/containers/pages/register/RegisterExtraDetailsPage.js
@@ -17,7 +17,11 @@ import RegisterExtraDetailsForm from "../../../components/forms/RegisterExtraDet
 
 import type { RouterHistory, Location } from "react-router"
 import type { Response } from "redux-query"
-import type { AuthResponse, ProfileForm, User } from "../../../flow/authTypes"
+import type {
+  AuthResponseRaw,
+  ProfileForm,
+  User
+} from "../../../flow/authTypes"
 
 type RegisterProps = {|
   location: Location,
@@ -29,7 +33,7 @@ type DispatchProps = {|
   registerExtraDetails: (
     profileData: ProfileForm,
     partialToken: string
-  ) => Promise<Response<AuthResponse>>,
+  ) => Promise<Response<AuthResponseRaw>>,
   getCurrentUser: () => Promise<Response<User>>
 |}
 
@@ -45,16 +49,17 @@ class RegisterExtraDetailsPage extends React.Component<Props> {
       params: { partialToken }
     } = this.props
 
+    /* eslint-disable camelcase */
     try {
       const {
-        body: { state, errors }
-      }: { body: AuthResponse } = await registerExtraDetails(
+        body: { state, errors, redirect_url }
+      }: { body: AuthResponseRaw } = await registerExtraDetails(
         profileData,
         partialToken
       )
 
       if (state === STATE_SUCCESS) {
-        window.location.href = routes.root
+        window.location.href = redirect_url || routes.dashboard
       } else if (errors.length > 0) {
         setErrors({
           email: errors[0]

--- a/static/js/lib/selectors.js
+++ b/static/js/lib/selectors.js
@@ -19,5 +19,5 @@ export const qsPartialTokenSelector = createParamSelector("partial_token")
 export const qsVerificationCodeSelector = createParamSelector(
   "verification_code"
 )
-export const qsNextSelector = createParamSelector("next", "/")
+export const qsNextSelector = createParamSelector("next")
 export const qsErrorSelector = createParamSelector("error")

--- a/static/js/lib/selectors_test.js
+++ b/static/js/lib/selectors_test.js
@@ -64,8 +64,8 @@ describe("selector utils", () => {
     })
 
     it("should return '/' if no next param", () => {
-      assert.equal(qsNextSelector({}, makeSearchProps("abc=123")), "/")
-      assert.equal(qsNextSelector({}, makeSearchProps("")), "/")
+      assert.equal(qsNextSelector({}, makeSearchProps("abc=123")), null)
+      assert.equal(qsNextSelector({}, makeSearchProps("")), null)
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #697 

#### What's this PR do?
- Adds the `next=?` parameter to the catalog popup dialog
- Fixes `RegisterExtraDetailsPage.js` to support this on registration complete since it was missed previously

#### How should this be manually tested?
- As a logged in user, verify the enroll button on a product page still gives you a valid link to the checkout page for that product.
- As an anonymous user, verify both the sign in and create an account buttons in the popup result in you ending up on the checkout page after successfully completing either auth flow

#### Any background context you want to provide?
In the interest of delivery time, did not write tests for this change because `RegisterExtraDetailsPage.js` doesn't have any tests carved out for it anyway. See #312.