### PR TITLE
autoComplete attributes for form fields (Chrome)

### DIFF
--- a/static/js/components/forms/EmailForm.js
+++ b/static/js/components/forms/EmailForm.js
@@ -29,7 +29,12 @@ const EmailForm = ({ onSubmit }: EmailFormProps) => (
       <Form>
         <div className="form-group">
           <label htmlFor="email">Email</label>
-          <Field name="email" className="form-control" component={EmailInput} />
+          <Field
+            name="email"
+            className="form-control"
+            component={EmailInput}
+            autoComplete="email"
+          />
           <ErrorMessage name="email" component={FormError} />
         </div>
         <div className="row submit-row no-gutters justify-content-end">

--- a/static/js/components/forms/EmailForm_test.js
+++ b/static/js/components/forms/EmailForm_test.js
@@ -28,7 +28,9 @@ describe("EmailForm", () => {
     const wrapper = renderForm()
 
     const form = wrapper.find("Formik").dive()
-    assert.ok(findFormikFieldByName(form, "email").exists())
+    const emailField = findFormikFieldByName(form, "email")
+    assert.ok(emailField.exists())
+    assert.equal(emailField.prop("autoComplete"), "email")
     assert.ok(form.find("button[type='submit']").exists())
   })
 })

--- a/static/js/components/forms/ProfileFormFields.js
+++ b/static/js/components/forms/ProfileFormFields.js
@@ -254,7 +254,12 @@ export const LegalAddressFields = ({
     </div>
     {includes(values.legal_address.country, COUNTRIES_REQUIRING_STATE) ? (
       <div className="form-group">
-        <label className="font-weight-bold">State/Province*</label>
+        <label
+          htmlFor="legal_address.state_or_territory"
+          className="font-weight-bold"
+        >
+          State/Province*
+        </label>
         <Field
           component="select"
           name="legal_address.state_or_territory"

--- a/static/js/components/forms/ProfileFormFields.js
+++ b/static/js/components/forms/ProfileFormFields.js
@@ -138,6 +138,7 @@ export const LegalAddressFields = ({
         type="text"
         name="legal_address.first_name"
         className="form-control"
+        autoComplete="given-name"
       />
       <ErrorMessage name="legal_address.first_name" component={FormError} />
     </div>
@@ -149,15 +150,21 @@ export const LegalAddressFields = ({
         type="text"
         name="legal_address.last_name"
         className="form-control"
+        autoComplete="family-name"
       />
       <ErrorMessage name="legal_address.last_name" component={FormError} />
     </div>
     <div className="form-group">
-      <label htmlFor="legal_address.last_name" className="row">
+      <label htmlFor="legal_address.full_name" className="row">
         <div className="col-4 font-weight-bold">Full Name*</div>
         <div className="col-8">(As it will appear in your certificate)</div>
       </label>
-      <Field type="text" name="name" className="form-control" />
+      <Field
+        type="text"
+        name="name"
+        className="form-control"
+        autoComplete="name"
+      />
       <ErrorMessage name="name" component={FormError} />
     </div>
     {includePassword ? (
@@ -178,7 +185,10 @@ export const LegalAddressFields = ({
     ) : null}
     <div className="form-group">
       {/* LegalAddress fields */}
-      <label htmlFor="legal_address.last_name" className="font-weight-bold">
+      <label
+        htmlFor="legal_address.street_address"
+        className="font-weight-bold"
+      >
         Street Address*
       </label>
       <FieldArray
@@ -190,6 +200,7 @@ export const LegalAddressFields = ({
                 <Field
                   name={`legal_address.street_address[${index}]`}
                   className={`form-control ${index > 0 ? "row-inner" : ""}`}
+                  autoComplete={`address-line${index + 1}`}
                 />
                 {index === 0 ? (
                   <ErrorMessage
@@ -213,11 +224,14 @@ export const LegalAddressFields = ({
       />
     </div>
     <div className="form-group">
-      <label className="font-weight-bold">Country*</label>
+      <label htmlFor="legal_address.country" className="font-weight-bold">
+        Country*
+      </label>
       <Field
         component="select"
         name="legal_address.country"
         className="form-control"
+        autoComplete="country"
         onChange={e => {
           setFieldValue("legal_address.country", e.target.value)
           setFieldTouched("legal_address.country")
@@ -245,6 +259,7 @@ export const LegalAddressFields = ({
           component="select"
           name="legal_address.state_or_territory"
           className="form-control"
+          autoComplete="address-level1"
         >
           <option value="">-----</option>
           {find(
@@ -266,7 +281,12 @@ export const LegalAddressFields = ({
       <label htmlFor="legal_address.city" className="font-weight-bold">
         City*
       </label>
-      <Field type="text" name="legal_address.city" className="form-control" />
+      <Field
+        type="text"
+        name="legal_address.city"
+        className="form-control"
+        autoComplete="address-level2"
+      />
       <ErrorMessage name="legal_address.city" component={FormError} />
     </div>
     {includes(values.legal_address.country, COUNTRIES_REQUIRING_POSTAL_CODE) ? (
@@ -278,6 +298,7 @@ export const LegalAddressFields = ({
           type="text"
           name="legal_address.postal_code"
           className="form-control"
+          autoComplete="postal-code"
         />
         <ErrorMessage name="legal_address.postal_code" component={FormError} />
       </div>

--- a/static/js/components/forms/ProfileFormFields.js
+++ b/static/js/components/forms/ProfileFormFields.js
@@ -155,7 +155,7 @@ export const LegalAddressFields = ({
       <ErrorMessage name="legal_address.last_name" component={FormError} />
     </div>
     <div className="form-group">
-      <label htmlFor="legal_address.full_name" className="row">
+      <label htmlFor="name" className="row">
         <div className="col-4 font-weight-bold">Full Name*</div>
         <div className="col-8">(As it will appear in your certificate)</div>
       </label>

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -123,9 +123,6 @@ describe("RegisterDetailsForm", () => {
           : "Postal Code must be formatted as 'ANA NAN'"
       )
 
-      // Both postal code and state/territory fields should be visible
-      assert.isNotOk(wrapper.find(".hidden").exists())
-
       // Select country not requiring state and zipcode
       country.simulate("change", {
         persist: () => {},
@@ -134,21 +131,14 @@ describe("RegisterDetailsForm", () => {
       country.simulate("blur")
       await wait()
       wrapper.update()
-
-      // Both postal code and state/territory fields should not be visible
-      assert.equal(
-        wrapper
-          .find(`select[name="legal_address.state_or_territory"]`)
-          .parents("div")
-          .prop("className"),
-        "form-group hidden"
+      assert.isFalse(
+        findFormikErrorByName(
+          wrapper,
+          "legal_address.state_or_territory"
+        ).exists()
       )
-      assert.equal(
-        wrapper
-          .find(`input[name="legal_address.postal_code"]`)
-          .parents("div")
-          .prop("className"),
-        "form-group hidden"
+      assert.isFalse(
+        findFormikErrorByName(wrapper, "legal_address.postal_code").exists()
       )
     })
   })
@@ -187,5 +177,24 @@ describe("RegisterDetailsForm", () => {
       findFormikErrorByName(wrapper, "legal_address.street_address").text(),
       "Street address is a required field"
     )
+  })
+
+  //
+  ;[
+    ["name", "name"],
+    ["legal_address.first_name", "given-name"],
+    ["legal_address.last_name", "family-name"],
+    ["legal_address.street_address[0]", "address-line1"],
+    ["legal_address.country", "country"],
+    ["legal_address.city", "address-level2"]
+  ].forEach(([formFieldName, autoCompleteName]) => {
+    it(`validates that autoComplete=${autoCompleteName}  for field ${formFieldName}`, async () => {
+      const wrapper = renderForm()
+      const form = wrapper.find("Formik")
+      assert.equal(
+        findFormikFieldByName(form, formFieldName).prop("autoComplete"),
+        autoCompleteName
+      )
+    })
   })
 })

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -123,6 +123,9 @@ describe("RegisterDetailsForm", () => {
           : "Postal Code must be formatted as 'ANA NAN'"
       )
 
+      // Both postal code and state/territory fields should be visible
+      assert.isNotOk(wrapper.find(".hidden").exists())
+
       // Select country not requiring state and zipcode
       country.simulate("change", {
         persist: () => {},
@@ -131,14 +134,21 @@ describe("RegisterDetailsForm", () => {
       country.simulate("blur")
       await wait()
       wrapper.update()
-      assert.isFalse(
-        findFormikErrorByName(
-          wrapper,
-          "legal_address.state_or_territory"
-        ).exists()
+
+      // Both postal code and state/territory fields should not be visible
+      assert.equal(
+        wrapper
+          .find(`select[name="legal_address.state_or_territory"]`)
+          .parents("div")
+          .prop("className"),
+        "form-group hidden"
       )
-      assert.isFalse(
-        findFormikErrorByName(wrapper, "legal_address.postal_code").exists()
+      assert.equal(
+        wrapper
+          .find(`input[name="legal_address.postal_code"]`)
+          .parents("div")
+          .prop("className"),
+        "form-group hidden"
       )
     })
   })

--- a/static/js/components/forms/RegisterEmailForm.js
+++ b/static/js/components/forms/RegisterEmailForm.js
@@ -38,7 +38,12 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
       <Form>
         <div className="form-group">
           <label htmlFor="email">Email</label>
-          <Field name="email" className="form-control" component={EmailInput} />
+          <Field
+            name="email"
+            className="form-control"
+            autoComplete="email"
+            component={EmailInput}
+          />
           <ErrorMessage name="email" component={FormError} />
         </div>
         {SETTINGS.recaptchaKey ? (

--- a/static/js/components/forms/RegisterEmailForm_test.js
+++ b/static/js/components/forms/RegisterEmailForm_test.js
@@ -35,8 +35,10 @@ describe("Register forms", () => {
 
     it("renders the form", () => {
       const { form } = renderForm()
+      const emailField = findFormikFieldByName(form, "email")
 
-      assert.isOk(findFormikFieldByName(form, "email").exists())
+      assert.ok(emailField.exists())
+      assert.equal(emailField.prop("autoComplete"), "email")
       assert.isOk(form.find("button[type='submit']").exists())
     })
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Partially addresses #684

#### What's this PR do?
Adds `autoComplete` attributes to name/address profile fields and email form fields.

#### How should this be manually tested?
- With Chrome, try using autofill on the email form and the new user registration form.  The fields should be populated correctly based on your autofill selection.
- Repeat with Firefox, all fields should be populated correctly except state and postal code (see below).

#### Any background context you want to provide?
Autofill will only work partially in Firefox.  The browser seems unable to auto-populate state and zipcode fields because they are not on the form until either "US" or "Canada" is selected for country.  [There is a workaround](https://github.com/mitodl/mitxpro/issues/684#issuecomment-507355531) but it involves more substantial changes to the form so it will be handled in a separate PR later.
