### PR TITLE
Fixed seed data bugs, added products, added deletion command

### DIFF
--- a/cms/utils.py
+++ b/cms/utils.py
@@ -1,4 +1,5 @@
 """utils for cms"""
+from wagtail.core.models import Site, Page
 
 
 def get_sort_keys(page):
@@ -16,3 +17,19 @@ def sort_and_filter_pages(pages):
     return sorted(
         [page for page in pages if page.product.next_run_date], key=get_sort_keys
     )
+
+
+def get_home_page():
+    """
+    Returns an instance of the home page (all of our Wagtail pages are expected to be descendants of this home page)
+    """
+    site = Site.objects.filter(is_default_site=True).first()
+    if not site:
+        raise Exception(
+            "A default site is not set up. Please setup a default site before running this migration"
+        )
+    if not site.root_page:
+        raise Exception(
+            "No root (home) page set up. Please setup a root (home) page for the default site before running this migration"
+        )
+    return Page.objects.get(id=site.root_page.id)

--- a/localdev/seed/api.py
+++ b/localdev/seed/api.py
@@ -1,33 +1,105 @@
 """Functions/classes for adding and removing seed data"""
 import os
 import json
-from collections import defaultdict
 from types import SimpleNamespace
-
+from collections import defaultdict, namedtuple
 from wagtail.core.models import Page
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 
-from courses.models import Program, Course, CourseRun
+from courses.models import (
+    Program,
+    Course,
+    CourseRun,
+    CourseRunEnrollment,
+    CourseRunEnrollmentAudit,
+    ProgramEnrollment,
+    ProgramEnrollmentAudit,
+)
 from localdev.seed.serializers import (
     ProgramSerializer,
     CourseSerializer,
     CourseRunSerializer,
 )
-from mitxpro.utils import dict_without_keys, filter_dict_by_key_set, get_field_names
-from cms.models import ProgramPage, CoursePage, ResourcePage
+from mitxpro.utils import (
+    dict_without_keys,
+    filter_dict_by_key_set,
+    get_field_names,
+    first_or_none,
+    has_equal_properties,
+)
+from cms.models import (
+    ProgramPage,
+    CoursePage,
+    ResourcePage,
+    CourseIndexPage,
+    ProgramIndexPage,
+)
+from cms.utils import get_home_page
+from ecommerce.models import (
+    Product,
+    ProductVersion,
+    CouponEligibility,
+    CouponSelection,
+    CouponRedemption,
+    Order,
+    OrderAudit,
+    Line,
+    Receipt,
+    Basket,
+    BasketItem,
+    CourseRunSelection,
+    ProductCouponAssignment,
+)
+
+# ROUGH EXPECTED FORMAT FOR SEED DATA FILE:
+# {
+#     "programs": [
+#         {
+#             ...mixed Program and ProgramPage properties...
+#             ...optional "_product" key pointing to dict of ProductVersion properties...
+#         }
+#     ],
+#     "courses": [
+#         {
+#             ...optional "program" key pointing to a parent Program title...
+#             ...mixed Course and CoursePage properties...
+#             "course_runs": [
+#                 ...CourseRun properties...
+#                 ...optional "_product" key pointing to dict of ProductVersion properties...
+#             ]
+#         }
+#     ],
+#     "resource_pages": [
+#         {
+#             ...ResourcePage properties...
+#         }
+#     ]
+# }
+
 
 SEED_DATA_FILE_PATH = os.path.join(
     settings.BASE_DIR, "localdev/seed/resources/seed_data.json"
 )
 
 
-def get_top_level_wagtail_page():
-    """
-    The Wagtail CMS (at least in our usage) has one root page at depth 1, and one page at depth 2. All pages that we
-    create in Wagtail are added as children to the page at depth 2.
-    """
-    return Page.objects.get(depth=2)
+def get_raw_seed_data_from_file():
+    """Loads raw seed data from our seed data file"""
+    with open(SEED_DATA_FILE_PATH) as f:
+        return json.loads(f.read())
+
+
+def get_courseware_page_parent(courseware_page_obj):
+    """Gets an instance of the parent index/listing page for a CoursePage/ProgramPage"""
+    if isinstance(courseware_page_obj, Course):
+        index_page_cls = CourseIndexPage
+    elif isinstance(courseware_page_obj, Program):
+        index_page_cls = ProgramIndexPage
+    else:
+        return None
+    page_specific = Page.objects.get(id=index_page_cls.objects.first().id).specific
+    return page_specific
 
 
 def delete_wagtail_pages(page_cls, filter_dict):
@@ -55,34 +127,55 @@ def filter_for_model_fields(model_cls, dict_to_filter):
     return filter_dict_by_key_set(dict_to_filter, model_field_names)
 
 
+def set_model_properties_from_dict(model_obj, property_dict):
+    """
+    Takes a model object and a dict property names mapped to desired values, then sets all of the relevant
+    property values on the model object and saves it
+    """
+    for field, value in property_dict.items():
+        setattr(model_obj, field, value)
+    model_obj.save()
+    return model_obj
+
+
+SeedDataSpec = namedtuple("SeedDataSpec", ["model_cls", "data", "parent"])
+
+
 class SeedResult:
     """Represents the results of seeding/unseeding"""
 
     def __init__(self):
         self.created = defaultdict(int)
-        self.existing = defaultdict(int)
+        self.updated = defaultdict(int)
         self.deleted = defaultdict(int)
+        self.ignored = defaultdict(int)
 
     def add_created(self, obj):
         """Adds to the count of created object types"""
         self.created[obj.__class__.__name__] += 1
 
-    def add_existing(self, obj):
-        """Adds to the count of existing object types"""
-        self.existing[obj.__class__.__name__] += 1
+    def add_updated(self, obj):
+        """Adds to the count of updated object types"""
+        self.updated[obj.__class__.__name__] += 1
+
+    def add_ignored(self, obj):
+        """Adds to the count of ignored object types"""
+        self.ignored[obj.__class__.__name__] += 1
 
     def add_deleted(self, deleted_type_dict):
         """Adds to the count of deleted object types"""
         for deleted_type, deleted_count in deleted_type_dict.items():
-            self.deleted[deleted_type] += deleted_count
+            if deleted_count:
+                self.deleted[deleted_type] += deleted_count
 
     @property
     def report(self):
         """Simple dict representing the seed result"""
         return {
             "Created": dict(self.created),
-            "Already Existed": dict(self.existing),
+            "Updated": dict(self.updated),
             "Deleted": dict(self.deleted),
+            "Ignored (Already Existed)": dict(self.ignored),
         }
 
     def __repr__(self):
@@ -90,13 +183,18 @@ class SeedResult:
 
 
 class SeedDataLoader:
-    """Handles creation/deletion of seed data based on raw data"""
+    """Handles creation/updating/deletion of seed data based on raw data"""
 
     # Our legacy course models did not enforce uniqueness on any fields. It's possible that
     # we'll want to change that, but for now this dict exists to indicate which field should
     # be used to (a) find an existing object for some data we're deserializing, and
     # (b) prepend a string indicating that the object is seed data.
     SEED_DATA_FIELD_MAP = {Program: "title", Course: "title", CourseRun: "title"}
+    SEED_DATA_DESERIALIZER = {
+        Program: ProgramSerializer,
+        Course: CourseSerializer,
+        CourseRun: CourseRunSerializer,
+    }
     # Maps a course model with some information about its associated Wagtail page class
     COURSE_MODEL_PAGE_PROPS = {
         Program: SimpleNamespace(
@@ -106,15 +204,22 @@ class SeedDataLoader:
             page_cls=CoursePage, page_field_name=CoursePage.course.field.name
         ),
     }
+    ECOMMERCE_TYPES = {CourseRun, Program}
     # String to prepend to a field value that will indicate seed data.
     SEED_DATA_PREFIX = "SEED"
 
     def __init__(self):
         self.seed_result = SeedResult()
 
-    def _seed_prefixed(self, value):
+    @classmethod
+    def seed_prefixed(cls, value):
         """Returns the same value with a prefix that indicates seed data"""
-        return " ".join([self.SEED_DATA_PREFIX, value])
+        return " ".join([cls.SEED_DATA_PREFIX, value])
+
+    @classmethod
+    def is_seed_value(cls, value):
+        """Returns True of the given value matches the seeded value format"""
+        return value.startswith("{} ".format(cls.SEED_DATA_PREFIX))
 
     def _seeded_field_and_value(self, model_cls, data):
         """
@@ -123,163 +228,294 @@ class SeedDataLoader:
         Example return value: ("title", "SEED My Course Title")
         """
         field_name = self.SEED_DATA_FIELD_MAP[model_cls]
-        seeded_value = self._seed_prefixed(data[field_name])
+        seeded_value = self.seed_prefixed(data[field_name])
         return field_name, seeded_value
+
+    def _get_existing_seeded_qset(self, model_cls, data):
+        """Returns a qset of seed data objects for some model class"""
+        field_name, seeded_value = self._seeded_field_and_value(model_cls, data)
+        return model_cls.objects.filter(**{field_name: seeded_value})
 
     def _deserialize(self, serializer_cls, data):
         """
-        Attempts to deserialize and save an object if it doesn't already exist,
-        and adds it to the results according to whether or not it was created.
+        Attempts to deserialize and save a courseware object (Program/Course/CourseRun),
+        and creates it if it doesn't exist.
         """
         model_cls = serializer_cls.Meta.model
         field_name, seeded_value = self._seeded_field_and_value(model_cls, data)
-        existing_obj = model_cls.objects.filter(**{field_name: seeded_value}).first()
-        if existing_obj:
-            self.seed_result.add_existing(existing_obj)
-            return existing_obj
-        model_data = filter_for_model_fields(model_cls, data)
-        serialized = serializer_cls(
-            data={
-                # Set 'live' to True for seeded objects by default
-                "live": True,
-                **model_data,
-                field_name: seeded_value,
-            }
-        )
-        serialized.is_valid(raise_exception=True)
-        added_obj = serialized.save()
-        self.seed_result.add_created(added_obj)
-        return added_obj
+        model_object_data = {
+            # Set 'live' to True for seeded objects by default
+            "live": True,
+            # Use every property in 'data' that corresponds to a model property
+            **filter_for_model_fields(model_cls, data),
+            # Use the seed-adjusted value for the property that we're using to identify seeded objects
+            field_name: seeded_value,
+        }
+        existing_qset = self._get_existing_seeded_qset(model_cls, data)
+        if existing_qset.exists():
+            existing_qset.update(**model_object_data)
+            courseware_obj = existing_qset.first()
+            self.seed_result.add_updated(courseware_obj)
+        else:
+            serialized = serializer_cls(data=model_object_data)
+            serialized.is_valid(raise_exception=True)
+            courseware_obj = serialized.save()
+            self.seed_result.add_created(courseware_obj)
+        return courseware_obj
 
-    def _create_cms_page(self, model_obj, data):
+    def _deserialize_product(self, courseware_obj, product_data):
         """
-        Creates a Wagtail CMS page for some Program/Course if one doesn't exist
+        Attempts to deserialize and save Product/ProductVersion data, and creates those objects if they don't exist.
         """
-        model_cls = model_obj.__class__
+        product, created = Product.objects.get_or_create(
+            content_type=ContentType.objects.get_for_model(courseware_obj.__class__),
+            object_id=courseware_obj.id,
+        )
+        if created:
+            self.seed_result.add_created(product)
+        latest_version = product.latest_version
+        if not latest_version or not has_equal_properties(latest_version, product_data):
+            new_version = ProductVersion.objects.create(product=product, **product_data)
+            self.seed_result.add_created(new_version)
+            return new_version
+        else:
+            self.seed_result.add_ignored(latest_version)
+            return latest_version
+
+    def _deserialize_courseware_cms_page(self, courseware_obj, data):
+        """
+        Attempts to deserialize and save a Wagtail CMS page for some Program/Course,
+        and creates one if one doesn't exist
+        """
+        model_cls = courseware_obj.__class__
         cms_page_props = self.COURSE_MODEL_PAGE_PROPS[model_cls]
         cms_page_cls = cms_page_props.page_cls
         cms_page_field_name = cms_page_props.page_field_name
-        existing_obj = cms_page_cls.objects.filter(
-            **{cms_page_field_name: model_obj}
-        ).first()
-        if existing_obj:
-            self.seed_result.add_existing(existing_obj)
-            return existing_obj
-        base_wagtail_page = get_top_level_wagtail_page()
-        cms_model_data = filter_for_model_fields(cms_page_cls, data)
+        # Build a queryset for any existing CMS pages for this Program/Course
+        existing_page_qset = cms_page_cls.objects.filter(
+            **{cms_page_field_name: courseware_obj}
+        )
         # CMS pages have a title property as well. Use the seed-adjusted value for it
         field_name, seeded_value = self._seeded_field_and_value(model_cls, data)
-        page_obj = cms_page_cls(
-            **{
-                cms_page_field_name: model_obj,
-                **cms_model_data,
-                field_name: seeded_value,
-            }
-        )
-        added_obj = base_wagtail_page.add_child(instance=page_obj)
-        self.seed_result.add_created(added_obj)
-        return added_obj
+        cms_model_data = {
+            cms_page_field_name: courseware_obj,
+            **filter_for_model_fields(cms_page_cls, data),
+            field_name: seeded_value,
+        }
+        if existing_page_qset.exists():
+            existing_page_qset.update(**cms_model_data)
+            existing_page = existing_page_qset.first()
+            self.seed_result.add_updated(existing_page)
+            return existing_page
+        else:
+            page_obj = cms_page_cls(**cms_model_data)
+            courseware_page_parent = get_courseware_page_parent(courseware_obj)
+            courseware_page_parent.add_child(instance=page_obj)
+            page_obj.save()
+            self.seed_result.add_created(page_obj)
+            return page_obj
 
-    def _delete(self, model_cls, data):
-        """
-        Attempts to delete an object if it doesn't already exist, and adds it to
-        the results if it was deleted.
-        """
-        field_name, seeded_value = self._seeded_field_and_value(model_cls, data)
-        existing_obj = model_cls.objects.filter(**{field_name: seeded_value}).first()
-        if not existing_obj:
-            return 0, {}
-        # If there are any Wagtail pages associated with this object that will be deleted,
-        # delete the Wagtail pages first.
-        cms_page_props = self.COURSE_MODEL_PAGE_PROPS[existing_obj.__class__]
-        if cms_page_props:
-            cms_page_cls = cms_page_props.page_cls
-            cms_page_field_name = cms_page_props.page_field_name
-            deleted_count, deleted_type_counts = delete_wagtail_pages(
-                cms_page_cls, {cms_page_field_name: existing_obj}
-            )
-            self.seed_result.add_deleted(deleted_type_counts)
-        deleted_count, deleted_type_counts = existing_obj.delete()
+    def _deserialize_cms_resource_page(self, resource_page_data):
+        """Create/update Wagtail resource pages."""
+        existing_page_qset = ResourcePage.objects.filter(
+            title=resource_page_data["title"]
+        )
+        page_data = {
+            **filter_for_model_fields(ResourcePage, resource_page_data),
+            "content": json.dumps(resource_page_data["content"]),
+        }
+        if existing_page_qset.exists():
+            existing_page = existing_page_qset.first()
+            existing_page = set_model_properties_from_dict(existing_page, page_data)
+            self.seed_result.add_updated(existing_page)
+            return existing_page
+        else:
+            page_obj = ResourcePage(**page_data)
+            added_obj = get_home_page().add_child(instance=page_obj)
+            self.seed_result.add_created(added_obj)
+            return added_obj
+
+    def _delete_courseware_cms_page(self, courseware_obj, cms_page_props):
+        """Deletes a Wagtail page associated with a given Program/Course"""
+        cms_page_cls = cms_page_props.page_cls
+        cms_page_field_name = cms_page_props.page_field_name
+        deleted_count, deleted_type_counts = delete_wagtail_pages(
+            cms_page_cls, {cms_page_field_name: courseware_obj}
+        )
         self.seed_result.add_deleted(deleted_type_counts)
         return deleted_count, deleted_type_counts
 
-    def _create_cms_resource_page(self, resource_page):
-        """ Create resource pages in CMS if they don't exists."""
-        existing_obj = ResourcePage.objects.filter(slug=resource_page["slug"]).first()
-        if existing_obj:
-            self.seed_result.add_existing(existing_obj)
-            return
+    def _delete_ecommerce_for_courseware_obj(self, courseware_obj):
+        """
+        Deletes all relevant ecommerce objects associated with a given Program/CourseRun. This specialized, ordered
+        deletion is necessary because our ecommerce tables have delete protection.
+        """
+        # First, delete enrollments
+        if courseware_obj.__class__ == CourseRun:
+            enrollment_audit_qset = CourseRunEnrollmentAudit.objects.filter(
+                enrollment__run=courseware_obj
+            )
+            enrollment_qset = CourseRunEnrollment.all_objects.filter(run=courseware_obj)
+        else:
+            enrollment_audit_qset = ProgramEnrollmentAudit.objects.filter(
+                enrollment__program=courseware_obj
+            )
+            enrollment_qset = ProgramEnrollment.all_objects.filter(
+                program=courseware_obj
+            )
+        delete_results = [enrollment_audit_qset.delete(), enrollment_qset.delete()]
 
-        page_obj = ResourcePage(
-            title=resource_page["title"],
-            sub_heading=resource_page["sub_heading"],
-            content=json.dumps(resource_page["content"]),
-            slug=resource_page["slug"],
-        )
-        added_obj = get_top_level_wagtail_page().add_child(instance=page_obj)
-        self.seed_result.add_created(added_obj)
+        # Then, delete ecommerce objects that are associated with the product (if a product
+        # exists for this course run/program)
+        content_type = ContentType.objects.get_for_model(courseware_obj.__class__)
+        product_ids = Product.objects.filter(
+            content_type=content_type, object_id=courseware_obj.id
+        ).values_list("id", flat=True)
+
+        if len(product_ids) > 0:
+            lines = Line.objects.filter(product_version__product_id__in=product_ids)
+            order_ids = {line.order_id for line in lines}
+            basket_ids = BasketItem.objects.filter(
+                product_id__in=product_ids
+            ).values_list("basket__id", flat=True)
+            delete_results.extend(
+                [
+                    CourseRunSelection.objects.filter(
+                        basket_id__in=basket_ids
+                    ).delete(),
+                    CouponSelection.objects.filter(basket_id__in=basket_ids).delete(),
+                    BasketItem.objects.filter(basket_id__in=basket_ids).delete(),
+                    Basket.objects.filter(id__in=basket_ids).delete(),
+                    Line.objects.filter(id__in=[line.id for line in lines]).delete(),
+                    CouponRedemption.objects.filter(order_id__in=order_ids).delete(),
+                    Receipt.objects.filter(order_id__in=order_ids).delete(),
+                    OrderAudit.objects.filter(order_id__in=order_ids).delete(),
+                    Order.objects.filter(id__in=order_ids).delete(),
+                    ProductCouponAssignment.objects.filter(
+                        product_coupon__product_id__in=product_ids
+                    ).delete(),
+                    CouponEligibility.objects.filter(
+                        product_id__in=product_ids
+                    ).delete(),
+                    ProductVersion.objects.filter(product__id__in=product_ids).delete(),
+                    Product.objects.filter(id__in=product_ids).delete(),
+                ]
+            )
+
+        for _, deleted_type_dict in delete_results:
+            self.seed_result.add_deleted(deleted_type_dict)
 
     def _delete_cms_resource_page(self, resource_page):
-        """Delete resource pages from CMS."""
-        existing_obj = ResourcePage.objects.filter(slug=resource_page["slug"]).first()
-
+        """Delete Wagtail resource pages."""
+        existing_obj = ResourcePage.objects.filter(title=resource_page["title"]).first()
         if not existing_obj:
             return 0, {}
-
         __, deleted_type_counts = delete_wagtail_pages(
-            ResourcePage, {"slug": existing_obj.slug}
+            ResourcePage, {"id": existing_obj.id}
         )
         self.seed_result.add_deleted(deleted_type_counts)
 
-    def create_seed_data(self, raw_data):
-        """Idempotently creates seed data based on raw data and returns results"""
-        self.seed_result = SeedResult()
+    def iter_seed_data(self, raw_data):
+        """
+        Iterate through raw seed data and yields the specification for models that will be created/updated/deleted
+        """
         for raw_program_data in raw_data["programs"]:
-            # Create the Program and associated ProgramPage
-            program = self._deserialize(ProgramSerializer, raw_program_data)
-            self._create_cms_page(program, raw_program_data)
+            yield SeedDataSpec(model_cls=Program, data=raw_program_data, parent=None)
 
         for raw_course_data in raw_data["courses"]:
-            # If a Course should belong to a Program, the value for the Course's "program" key
-            # will be the Program's title
             program_title = raw_course_data.get("program")
-            program = (
-                Program.objects.get(title=self._seed_prefixed(program_title)).id
+            program_id = (
+                first_or_none(
+                    Program.objects.filter(
+                        title=self.seed_prefixed(program_title)
+                    ).values_list("id", flat=True)
+                )
                 if program_title
                 else None
             )
             course_runs_data = raw_course_data.get("course_runs", [])
-            course_data = {
-                **dict_without_keys(raw_course_data, "course_runs"),
-                "program": program,
-            }
-            # Create the Course and associated CoursePage
-            course = self._deserialize(CourseSerializer, course_data)
-            self._create_cms_page(course, course_data)
+            course_spec = SeedDataSpec(
+                model_cls=Course,
+                data={
+                    # The deserializer (or Django) will think "course_runs" has CourseRun objects,
+                    # so it has to be excluded
+                    **dict_without_keys(raw_course_data, "course_runs"),
+                    "program": program_id,
+                },
+                parent=None,
+            )
+            yield course_spec
+
+            course_title = raw_course_data["title"]
+            course_id = first_or_none(
+                Course.objects.filter(
+                    title=self.seed_prefixed(course_title)
+                ).values_list("id", flat=True)
+            )
             for raw_course_run_data in course_runs_data:
-                # Create the CourseRun
-                self._deserialize(
-                    CourseRunSerializer, {**raw_course_run_data, "course": course.id}
+                yield SeedDataSpec(
+                    model_cls=CourseRun,
+                    data={**raw_course_run_data, "course": course_id},
+                    parent=course_spec,
                 )
 
-        for resource_page in raw_data["resource_pages"]:
-            self._create_cms_resource_page(resource_page)
+        for resource_page_data in raw_data["resource_pages"]:
+            yield SeedDataSpec(
+                model_cls=ResourcePage, data=resource_page_data, parent=None
+            )
 
+    def create_seed_data(self, raw_data):
+        """
+        Iterate over all objects described in the seed data spec, add/update them one-by-one, and return the results
+        """
+        self.seed_result = SeedResult()
+        for seed_data_spec in self.iter_seed_data(raw_data):
+            if seed_data_spec.model_cls in [Program, Course, CourseRun]:
+                serializer_cls = self.SEED_DATA_DESERIALIZER[seed_data_spec.model_cls]
+                courseware_model_obj = self._deserialize(
+                    serializer_cls, seed_data_spec.data
+                )
+                if seed_data_spec.model_cls in self.COURSE_MODEL_PAGE_PROPS:
+                    self._deserialize_courseware_cms_page(
+                        courseware_model_obj, seed_data_spec.data
+                    )
+                if "_product" in seed_data_spec.data:
+                    self._deserialize_product(
+                        courseware_model_obj, seed_data_spec.data["_product"]
+                    )
+            elif seed_data_spec.model_cls == ResourcePage:
+                self._deserialize_cms_resource_page(seed_data_spec.data)
         return self.seed_result
+
+    def delete_courseware_obj(self, courseware_obj):
+        """
+        Attempts to delete a seeded Program/Course/CourseRun and associated objects
+        """
+        # If there are any Wagtail pages associated with this Program/Course, delete them.
+        cms_page_props = self.COURSE_MODEL_PAGE_PROPS.get(courseware_obj.__class__)
+        if cms_page_props:
+            self._delete_courseware_cms_page(courseware_obj, cms_page_props)
+        if courseware_obj.__class__ in self.ECOMMERCE_TYPES:
+            # If there are ecommerce objects associated with this Program/CourseRun, delete them
+            self._delete_ecommerce_for_courseware_obj(courseware_obj)
+
+        deleted_count, deleted_type_counts = courseware_obj.delete()
+        self.seed_result.add_deleted(deleted_type_counts)
+        return deleted_count, deleted_type_counts
 
     def delete_seed_data(self, raw_data):
-        """Deletes seed data based on raw course data"""
+        """Iterate over all objects described in the seed data spec, delete them one-by-one, and return the results"""
         self.seed_result = SeedResult()
-        for course_data in raw_data["courses"]:
-            self._delete(Course, course_data)
-        for program_data in raw_data["programs"]:
-            self._delete(Program, program_data)
-        for resource_page in raw_data["resource_pages"]:
-            self._delete_cms_resource_page(resource_page)
+        # Traversing in reverse since we want to delete 'leaf' objects first (e.g.: we want to delete CourseRuns
+        # before deleting Courses)
+        for seed_data_spec in reversed(list(self.iter_seed_data(raw_data))):
+            if seed_data_spec.model_cls in [Program, Course, CourseRun]:
+                existing_qset = self._get_existing_seeded_qset(
+                    seed_data_spec.model_cls, seed_data_spec.data
+                )
+                if not existing_qset.exists():
+                    continue
+                self.delete_courseware_obj(existing_qset.first())
+            elif seed_data_spec.model_cls == ResourcePage:
+                self._delete_cms_resource_page(seed_data_spec.data)
         return self.seed_result
-
-
-def get_raw_seed_data_from_file():
-    """Loads raw seed data from our seed data file"""
-    with open(SEED_DATA_FILE_PATH) as f:
-        return json.loads(f.read())

--- a/localdev/seed/api_test.py
+++ b/localdev/seed/api_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from courses.models import Program, Course, CourseRun
 from cms.models import ProgramPage, CoursePage, ResourcePage
+from ecommerce.models import Product, ProductVersion
 from localdev.seed.api import SeedDataLoader, get_raw_seed_data_from_file
 
 
@@ -18,36 +19,15 @@ def seeded():
 
 
 @pytest.mark.django_db
-def test_seed_and_unseed_data(seeded):
-    """Tests that the seed data functions can create and delete seed data"""
-    expected_programs = len(seeded.raw_data["programs"])
-    expected_courses = len(seeded.raw_data["courses"])
-    expected_course_runs = sum(
-        len(course_data.get("course_runs", []))
-        for course_data in seeded.raw_data["courses"]
-    )
-    expected_resource_pages = len(seeded.raw_data["resource_pages"])
-    assert Program.objects.count() == expected_programs
-    assert ProgramPage.objects.count() == expected_programs
-    assert Course.objects.count() == expected_courses
-    assert CoursePage.objects.count() == expected_courses
-    assert CourseRun.objects.count() == expected_course_runs
-    assert ResourcePage.objects.count() == expected_resource_pages
-
-    seeded.loader.delete_seed_data(seeded.raw_data)
-    assert Program.objects.count() == 0
-    assert ProgramPage.objects.count() == 0
-    assert Course.objects.count() == 0
-    assert CoursePage.objects.count() == 0
-    assert CourseRun.objects.count() == 0
-    assert ResourcePage.objects.count() == 0
-
-
-@pytest.mark.django_db
 def test_seed_prefix(seeded):
     """
     Tests that the seed data functions add a prefix to a field values that indicates which objects are seed data
     """
+    # Test helper functions
+    seeded_value = seeded.loader.seed_prefixed("Some Title")
+    assert seeded_value == "{} Some Title".format(SeedDataLoader.SEED_DATA_PREFIX)
+    assert seeded.loader.is_seed_value(seeded_value) is True
+    # Test saved object titles
     assert (
         Program.objects.exclude(
             title__startswith=SeedDataLoader.SEED_DATA_PREFIX
@@ -66,3 +46,35 @@ def test_seed_prefix(seeded):
         ).exists()
         is False
     )
+
+
+@pytest.mark.django_db
+def test_seed_and_unseed_data(seeded):
+    """Tests that the seed data functions can create and delete seed data"""
+    expected_programs = len(seeded.raw_data["programs"])
+    expected_courses = len(seeded.raw_data["courses"])
+    expected_course_runs = sum(
+        len(course_data.get("course_runs", []))
+        for course_data in seeded.raw_data["courses"]
+    )
+    # Hardcoding this value since it would be annoying to check for it programatically
+    expected_products = 7
+    expected_resource_pages = len(seeded.raw_data["resource_pages"])
+    assert Program.objects.count() == expected_programs
+    assert ProgramPage.objects.count() == expected_programs
+    assert Course.objects.count() == expected_courses
+    assert CoursePage.objects.count() == expected_courses
+    assert CourseRun.objects.count() == expected_course_runs
+    assert ResourcePage.objects.count() == expected_resource_pages
+    assert Product.objects.count() == expected_products
+    assert ProductVersion.objects.count() == expected_products
+
+    seeded.loader.delete_seed_data(seeded.raw_data)
+    assert Program.objects.count() == 0
+    assert ProgramPage.objects.count() == 0
+    assert Course.objects.count() == 0
+    assert CoursePage.objects.count() == 0
+    assert CourseRun.objects.count() == 0
+    assert ResourcePage.objects.count() == 0
+    assert Product.objects.count() == 0
+    assert ProductVersion.objects.count() == 0

--- a/localdev/seed/management/commands/delete_seed_data.py
+++ b/localdev/seed/management/commands/delete_seed_data.py
@@ -1,0 +1,81 @@
+"""Management command to delete seeded data"""
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from courses.models import Program, Course, CourseRun
+from localdev.seed.api import SeedDataLoader, get_raw_seed_data_from_file
+
+User = get_user_model()
+
+
+OBJECT_TYPE_CHOICES = {"courserun": CourseRun, "course": Course, "program": Program}
+
+
+def get_program_objects_for_deletion(program):
+    """Generator that yield all objects that should be deleted as part of a program deletion"""
+    for course in program.courses.all():
+        yield from get_course_objects_for_deletion(course)
+    yield program
+
+
+def get_course_objects_for_deletion(course):
+    """Generator that yield all objects that should be deleted as part of a course deletion"""
+    yield from course.courseruns.all()
+    yield course
+
+
+class Command(BaseCommand):
+    """Deletes seeded data based on raw seed data file or specific properties"""
+
+    help = "Deletes seeded data based on raw seed data file or specific properties"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--type",
+            type=str,
+            choices=list(OBJECT_TYPE_CHOICES.keys()),
+            help="The type of seeded object you want to delete",
+        )
+        parser.add_argument(
+            "--title",
+            type=str,
+            help="The title of the seeded object you want to delete",
+        )
+
+    def handle(self, *args, **options):
+        """Handle command execution"""
+        seed_data_loader = SeedDataLoader()
+        if options["type"]:
+            if not options["title"]:
+                raise CommandError("'title' must be specified with 'type'")
+            elif not seed_data_loader.is_seed_value(options["title"]):
+                raise CommandError(
+                    "This command should only be run to delete seeded objects. Seeded objects are indicated "
+                    "by a prefixed title (example: {})".format(
+                        seed_data_loader.seed_prefixed("Some Title")
+                    )
+                )
+            model_cls = OBJECT_TYPE_CHOICES[options["type"]]
+            model_obj = model_cls.objects.get(title=options["title"])
+            if model_cls == Program:
+                objects_to_delete = get_program_objects_for_deletion(model_obj)
+            elif model_cls == Course:
+                objects_to_delete = get_course_objects_for_deletion(model_obj)
+            else:
+                objects_to_delete = [model_obj]
+            for object_to_delete in objects_to_delete:
+                seed_data_loader.delete_courseware_obj(object_to_delete)
+            results = seed_data_loader.seed_result
+        else:
+            self.stdout.write(
+                "Attempting to delete all seed data described in the seed data file..."
+            )
+            raw_seed_data = get_raw_seed_data_from_file()
+            results = seed_data_loader.delete_seed_data(raw_seed_data)
+
+        if not any(results.report.values()):
+            self.stdout.write(self.style.WARNING("No changes made."))
+        else:
+            self.stdout.write(self.style.SUCCESS("RESULTS"))
+            for k, v in results.report.items():
+                self.stdout.write("{}: {}".format(k, v))

--- a/localdev/seed/management/commands/seed_data.py
+++ b/localdev/seed/management/commands/seed_data.py
@@ -1,4 +1,4 @@
-"""Management command to create or delete seed data"""
+"""Management command to create or update seed data"""
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
@@ -8,28 +8,15 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    """Creates or deletes seed data based on a raw seed data file"""
+    """Creates or updates seed data based on a raw seed data file"""
 
-    help = "Creates or deletes seed data based on a raw seed data file"
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--delete",
-            action="store_true",
-            dest="delete",
-            help="Delete existing seed data instead of creating it.",
-        )
+    help = "Creates or updates seed data based on a raw seed data file"
 
     def handle(self, *args, **options):
         """Handle command execution"""
-        delete = options["delete"]
         seed_data_loader = SeedDataLoader()
         raw_seed_data = get_raw_seed_data_from_file()
-        results = (
-            seed_data_loader.create_seed_data(raw_seed_data)
-            if not delete
-            else seed_data_loader.delete_seed_data(raw_seed_data)
-        )
+        results = seed_data_loader.create_seed_data(raw_seed_data)
 
         if not any(results.report.values()):
             self.stdout.write(self.style.WARNING("No changes made."))

--- a/localdev/seed/resources/seed_data.json
+++ b/localdev/seed/resources/seed_data.json
@@ -4,7 +4,10 @@
             "title": "Systems Engineering",
             "subhead": "A four-course online program leading to a Professional Certificate from the Massachusetts Institute of Technology.",
             "description": "<p>A four-course online program leading to a Professional Certificate from the Massachusetts Institute of Technology.</p>",
-            "readable_id": "program-v1:xPRO+SysEngx"
+            "readable_id": "program-v1:xPRO+SysEngx",
+            "_product": {
+                "price": 2499
+            }
         },
         {
             "title": "Digital Learning",
@@ -29,8 +32,11 @@
                 {
                     "title": "edX Demonstration Course - Spring 2013",
                     "courseware_id": "course-v1:edX+DemoX+Demo_Course",
-                    "courseware_url_path": "/courses/course-v1:edX+DemoX+Demo_Course",
-                    "start_date": "2013-02-05T00:00:00+00:00"
+                    "courseware_url_path": "/courses/course-v1:edX+DemoX+Demo_Course/course/",
+                    "start_date": "2013-02-05T00:00:00+00:00",
+                    "_product": {
+                        "price": 321
+                    }
                 }
             ]
         },
@@ -43,12 +49,15 @@
             "readable_id": "course-v1:xPRO+SysEngxB1",
             "course_runs": [
                 {
-                    "title": "Systems Engineering - Fall 2019",
+                    "title": "Architecture of Complex Systems - Fall 2019",
                     "courseware_id": "course-v1:TestX+SysEngxB1+1T2019",
                     "courseware_url_path": "/courses/course-v1:TestX+SysEngxB1+1T2019/course/",
                     "start_date": "2019-08-15T00:00:00+00:00",
                     "end_date": "2019-12-15T00:00:00+00:00",
-                    "enrollment_end": "2019-08-29T00:00:00+00:00"
+                    "enrollment_end": "2019-08-29T00:00:00+00:00",
+                    "_product": {
+                        "price": 846
+                    }
                 }
             ]
         },
@@ -61,12 +70,15 @@
             "readable_id": "course-v1:xPRO+SysEngxB2",
             "course_runs": [
                 {
-                    "title": "Systems Engineering - Spring 2020",
+                    "title": "Models in Engineering - Spring 2020",
                     "courseware_id": "course-v1:TestX+SysEngxB2+1T2019",
                     "courseware_url_path": "/courses/course-v1:TestX+SysEngxB2+1T2019/course/",
                     "end_date": "2020-05-15T00:00:00+00:00",
                     "start_date": "2020-01-15T00:00:00+00:00",
-                    "enrollment_end": "2020-01-29T00:00:00+00:00"
+                    "enrollment_end": "2020-01-29T00:00:00+00:00",
+                    "_product": {
+                        "price": 848
+                    }
                 }
             ]
         },
@@ -79,12 +91,15 @@
             "readable_id": "course-v1:xPRO+SysEngxB3",
             "course_runs": [
                 {
-                    "title": "Systems Engineering - Fall 2020",
+                    "title": "Model-Based Systems Engineering: Documentation and Analysis - Fall 2020",
                     "courseware_id": "course-v1:TestX+SysEngxB3+1T2019",
                     "courseware_url_path": "/courses/course-v1:TestX+SysEngxB3+1T2019/course/",
                     "start_date": "2020-08-15T00:00:00+00:00",
                     "end_date": "2020-12-15T00:00:00+00:00",
-                    "enrollment_end": "2020-08-29T00:00:00+00:00"
+                    "enrollment_end": "2020-08-29T00:00:00+00:00",
+                    "_product": {
+                        "price": 849
+                    }
                 }
             ]
         },
@@ -97,13 +112,16 @@
             "readable_id": "course-v1:xPRO+SysEngxB4",
             "course_runs": [
                 {
-                    "title": "Quantitative Methods - August 2019",
+                    "title": "Quantitative Methods in Systems Engineering - August 2019",
                     "courseware_id": "course-v1:TestX+SysEngxB4+1T2019",
                     "courseware_url_path": "/courses/course-v1:TestX+SysEngxB4+1T2019/course/",
                     "enrollment_start": "2019-08-15T00:00:00+00:00",
                     "end_date": "2019-12-15T00:00:00+00:00",
                     "start_date": "2019-08-15T00:00:00+00:00",
-                    "enrollment_end": "2019-08-29T00:00:00+00:00"
+                    "enrollment_end": "2019-08-29T00:00:00+00:00",
+                    "_product": {
+                        "price": 847
+                    }
                 }
             ]
         },
@@ -292,7 +310,10 @@
                     "enrollment_start": "2016-08-15T00:00:00+00:00",
                     "end_date": "2016-12-15T00:00:00+00:00",
                     "start_date": "2016-08-15T00:00:00+00:00",
-                    "enrollment_end": "2016-08-29T00:00:00+00:00"
+                    "enrollment_end": "2016-08-29T00:00:00+00:00",
+                    "_product": {
+                        "price": 350
+                    }
                 },
                 {
                     "title": "Analog Learning 300 - January 2016",
@@ -351,7 +372,6 @@
         {
             "title": "Terms of service",
             "sub_heading": "Sub heading of terms of service",
-            "slug": "terms-of-service",
             "content": [
                 {
                     "type": "content",
@@ -372,7 +392,6 @@
         {
             "title": "Privacy policy",
             "sub_heading": "Sub heading of privacy policy",
-            "slug": "privacy-policy",
             "content": [
                 {
                     "type": "content",
@@ -393,7 +412,6 @@
         {
             "title": "Honor code",
             "sub_heading": "Sub heading of honor code",
-            "slug": "honor-code",
             "content": [
                 {
                     "type": "content",

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -142,6 +142,18 @@ def has_equal_properties(obj, property_dict):
     return True
 
 
+def first_or_none(iterable):
+    """
+    Returns the first item in an iterable, or None if the iterable is empty
+
+    Args:
+        iterable (iterable): Some iterable
+    Returns:
+        first item or None
+    """
+    return next((x for x in iterable), None)
+
+
 def partition(items, predicate=bool):
     """
     Partitions an iterable into two different iterables - the first does not match the given condition, and the second

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -15,6 +15,7 @@ from mitxpro.utils import (
     partition,
     has_equal_properties,
     remove_password_from_url,
+    first_or_none,
 )
 
 
@@ -106,3 +107,13 @@ def test_partition():
 def test_remove_password_from_url(url, expected):
     """Assert that the url is parsed and the password is not present in the returned value, if provided"""
     assert remove_password_from_url(url) == expected
+
+
+def test_first_or_none():
+    """
+    Assert that first_or_none returns the first item in an iterable or None
+    """
+    assert first_or_none([]) is None
+    assert first_or_none(set()) is None
+    assert first_or_none([1, 2, 3]) == 1
+    assert first_or_none(range(1, 5)) == 1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #425 
Closes #206 
Closes #207 

#### What's this PR do?
- Fixes bug where course/program pages were added under the root page rather than under the course/program index pages
- Fixes bug where seeded objects couldn't be deleted due to delete-protected ecommerce tables
- Adds products & prices to certain seeded objects
- Adds command that allows you to selectively delete all seeded data or just some specific objects

#### How should this be manually tested?
Some of the course run titles in the original `seed_data.json` were poorly set. They were corrected in this PR, which provides an opportunity to test out the delete command. Start by running the following:
- `manage.py delete_seed_data --type courserun --title "SEED Systems Engineering - Fall 2019"`
- `manage.py delete_seed_data --type courserun --title "SEED Systems Engineering - Spring 2020"`
- `manage.py delete_seed_data --type courserun --title "SEED Systems Engineering - Fall 2020"`
- `manage.py delete_seed_data --type courserun --title "SEED Quantitative Methods - August 2019"`

Then run the full seed data command: `manage.py seed_data`

Everything should work, and those course runs should be newly created with correct titles. You should also see that `Product`s/`ProductVersion`s were created or were ignored if they already existed.

You can also test out broader delete functionality:
- Delete all seed data: `manage.py delete_seed_data`
- Delete a program (which deletes all courses, course runs): `manage.py delete_seed_data --type program --title "SEED Digital Learning"`

#### Any background context you want to provide?
- As this code is only related to seed data creation/deletion, feel free to adjust coding standards as you see fit 😁 
- Regarding #207, we already have some CMS page properties in the seed data. If any more properties are desired, we can create specific tickets for them and they can be added easily
- Regarding #206, that issue asks for some coupons to be created, but now that we have the coupon creation and bulk enrollment forms, adding your own coupons is very easy, so it didn't seem necessary to seed any