### PR TITLE
Coupon form improvements

### DIFF
--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -2,7 +2,7 @@
 import React from "react"
 import moment from "moment"
 import Picky from "react-picky"
-import { filter, pathSatisfies, equals, sortBy, prop } from "ramda"
+import { filter, pathSatisfies, equals, includes, always, sortBy, prop } from "ramda"
 import { formatDate, parseDate } from "react-day-picker/moment"
 import DayPickerInput from "react-day-picker/DayPickerInput"
 import { Formik, Field, Form, ErrorMessage } from "formik"
@@ -254,6 +254,17 @@ export const CouponForm = ({
             checked={values.product_type === PRODUCT_TYPE_COURSERUN}
           />
           Course runs
+          <Field
+            type="radio"
+            name="product_type"
+            value=""
+            onClick={evt => {
+              setFieldValue("product_type", evt.target.value)
+              setFieldValue("products", [])
+            }}
+            checked={values.product_type === ""}
+          />
+          All products
         </div>
         <ErrorMessage name="products" component="div" />
         <div className="product-selection">
@@ -262,7 +273,7 @@ export const CouponForm = ({
             valueKey="id"
             labelKey="title"
             options={filter(
-              pathSatisfies(equals(values.product_type), ["product_type"]),
+              values.product_type ? pathSatisfies(equals(values.product_type), ["product_type"]) : always(true),
               sortBy(prop("title"), products || [])
             )}
             value={values.products}

--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -2,7 +2,7 @@
 import React from "react"
 import moment from "moment"
 import Picky from "react-picky"
-import { filter, pathSatisfies, equals, includes, always, sortBy, prop } from "ramda"
+import { filter, pathSatisfies, equals, always, sortBy, prop } from "ramda"
 import { formatDate, parseDate } from "react-day-picker/moment"
 import DayPickerInput from "react-day-picker/DayPickerInput"
 import { Formik, Field, Form, ErrorMessage } from "formik"
@@ -273,7 +273,9 @@ export const CouponForm = ({
             valueKey="id"
             labelKey="title"
             options={filter(
-              values.product_type ? pathSatisfies(equals(values.product_type), ["product_type"]) : always(true),
+              values.product_type
+                ? pathSatisfies(equals(values.product_type), ["product_type"])
+                : always(true),
               sortBy(prop("title"), products || [])
             )}
             value={values.products}

--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -77,7 +77,7 @@ const couponValidations = yup.object().shape({
 
 const zeroHour = value => {
   if (value instanceof Date) {
-    value.setUTCHours(0, 0, 0, 0)
+    value.setHours(0, 0, 0, 0)
   }
 }
 

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -86,14 +86,21 @@ describe("CouponForm", () => {
     ["activation_date", 0, "", "Valid activation date required"],
     ["expiration_date", 1, "bad_date", "Valid expiration date required"],
     ["activation_date", 0, "bad_date", "Valid activation date required"],
+    ["activation_date", 0, "06/27/2019", null],
     [
       "expiration_date",
       1,
-      moment().format("YYYY-MM-DD"),
-      "Date cannot be less than activation date"
+      moment()
+        .add(1, "days")
+        .format("MM/DD/YYYY"),
+      null
     ],
-    ["activation_date", 0, moment().format("YYYY-MM-DD"), null],
-    ["activation_date", 0, "2001-01-01T00:00:00Z", "Date cannot be in the past"]
+    [
+      "expiration_date",
+      1,
+      moment().format("MM/DD/YYYY"),
+      "Expiration date must be after today/activation date"
+    ]
   ].forEach(([name, idx, value, errorMessage]) => {
     it(`validates the field name=${name}, value=${JSON.stringify(
       value
@@ -113,6 +120,29 @@ describe("CouponForm", () => {
         findFormikErrorByName(wrapper, name).text(),
         errorMessage
       )
+    })
+  })
+
+  //
+  ;[
+    ["activation_date", 0, "06/27/2019", "2019-06-27T00:00:00.000Z"],
+    ["expiration_date", 1, "06/27/2519", "2519-06-27T00:00:00.000Z"]
+  ].forEach(([name, idx, value, formattedDate]) => {
+    it(`converts the field name=${name}, value=${JSON.stringify(
+      value
+    )} to date string ${JSON.stringify(formattedDate)}`, async () => {
+      const wrapper = renderForm()
+      const formik = wrapper.find("Formik").instance()
+      const input = wrapper
+        .find("DayPickerInput")
+        .at(idx)
+        .find("input")
+      input.simulate("click")
+      input.simulate("change", { persist: () => {}, target: { name, value } })
+      input.simulate("blur")
+      await wait()
+      wrapper.update()
+      assert.equal(formik.state.values[name].toISOString(), formattedDate)
     })
   })
 

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -20,15 +20,16 @@ import {
 
 describe("CouponForm", () => {
   let sandbox, onSubmitStub
+  const products = [
+    makeProduct(PRODUCT_TYPE_COURSERUN),
+    makeProduct(PRODUCT_TYPE_PROGRAM)
+  ]
 
   const renderForm = () =>
     mount(
       <CouponForm
         onSubmit={onSubmitStub}
-        products={[
-          makeProduct(PRODUCT_TYPE_COURSERUN),
-          makeProduct(PRODUCT_TYPE_PROGRAM)
-        ]}
+        products={products}
         companies={[makeCompany(), makeCompany()]}
       />
     )
@@ -177,20 +178,41 @@ describe("CouponForm", () => {
   })
 
   //
-  ;[PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM, ""].forEach(
-    ([productType]) => {
-      it(`displays correct list of products when productType radio button value="${productType}"`, async () => {
-        const wrapper = renderForm()
-        const formik = wrapper.find("Formik").instance()
-        formik.setFieldValue("product-selection", productType)
-        formik.setFieldTouched("product-selection")
-        await wait()
-        wrapper.update()
-        const options = wrapper.find(".picky").find("option")
-        assert.equal(options.length(), 1)
-      })
-    }
-  )
+  ;[
+    [PRODUCT_TYPE_COURSERUN, [products[0]]],
+    [PRODUCT_TYPE_PROGRAM, [products[1]]],
+    ["", products]
+  ].forEach(([productType, availableProduct]) => {
+    it(`displays correct product checkboxes when productType radio button value="${productType}"`, async () => {
+      const wrapper = renderForm()
+      wrapper
+        .find(`input[name='product_type'][value='${productType}']`)
+        .simulate("click")
+      await wait()
+      wrapper.update()
+      const options = wrapper.find(".picky").find("input[type='checkbox']")
+      assert.equal(
+        options
+          .at(0)
+          .parents()
+          .at(0)
+          .text(),
+        availableProduct[0].title
+      )
+      if (productType === "") {
+        assert.equal(
+          options
+            .at(1)
+            .parents()
+            .at(1)
+            .text(),
+          availableProduct[1].title
+        )
+      } else {
+        assert.isNotOk(options.at(1).exists())
+      }
+    })
+  })
 
   //
   ;[

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -190,26 +190,12 @@ describe("CouponForm", () => {
         .simulate("click")
       await wait()
       wrapper.update()
-      const options = wrapper.find(".picky").find("input[type='checkbox']")
-      assert.equal(
-        options
-          .at(0)
-          .parents()
-          .at(0)
-          .text(),
-        availableProduct[0].title
-      )
+      const picky = wrapper.find(".picky")
+      const options = picky.find("input[type='checkbox']")
+      assert.equal(options.at(1).exists(), productType === "")
+      assert.ok(picky.text().includes(availableProduct[0].title))
       if (productType === "") {
-        assert.equal(
-          options
-            .at(1)
-            .parents()
-            .at(1)
-            .text(),
-          availableProduct[1].title
-        )
-      } else {
-        assert.isNotOk(options.at(1).exists())
+        assert.ok(picky.text().includes(availableProduct[1].title))
       }
     })
   })

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -7,7 +7,11 @@ import { mount } from "enzyme"
 import wait from "waait"
 
 import { CouponForm } from "./CouponForm"
-import { COUPON_TYPE_PROMO } from "../../constants"
+import {
+  COUPON_TYPE_PROMO,
+  PRODUCT_TYPE_COURSERUN,
+  PRODUCT_TYPE_PROGRAM
+} from "../../constants"
 import { makeCompany, makeProduct } from "../../factories/ecommerce"
 import {
   findFormikFieldByName,
@@ -21,7 +25,10 @@ describe("CouponForm", () => {
     mount(
       <CouponForm
         onSubmit={onSubmitStub}
-        products={[makeProduct(), makeProduct()]}
+        products={[
+          makeProduct(PRODUCT_TYPE_COURSERUN),
+          makeProduct(PRODUCT_TYPE_PROGRAM)
+        ]}
         companies={[makeCompany(), makeCompany()]}
       />
     )
@@ -168,6 +175,22 @@ describe("CouponForm", () => {
       )
     })
   })
+
+  //
+  ;[PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM, ""].forEach(
+    ([productType]) => {
+      it(`displays correct list of products when productType radio button value="${productType}"`, async () => {
+        const wrapper = renderForm()
+        const formik = wrapper.find("Formik").instance()
+        formik.setFieldValue("product-selection", productType)
+        formik.setFieldTouched("product-selection")
+        await wait()
+        wrapper.update()
+        const options = wrapper.find(".picky").find("option")
+        assert.equal(options.length(), 1)
+      })
+    }
+  )
 
   //
   ;[


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #555
Closes #736 

#### What's this PR do?
- Sets time on start/end dates to 00:00:00
- Orders products by title
- Adds an 'All Products' radio button so that both programs and course runs can be selected.

#### How should this be manually tested?
- Go to `http://xpro.odl.local:8053/ecommerce/admin/coupons`
- Click the `All Products` radio button, you should be able to see and select both programs and runs.
- Fill out the form and save.  Go to django admin and verify that the start and end dates for the new `CouponPaymentVersion` have a time of `00:00:00`

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
