### PR TITLE
Added catalog link to empty dashboard

### DIFF
--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -14,6 +14,7 @@ import { RibbonText } from "../../components/Ribbon"
 
 import { addUserNotification } from "../../actions"
 import queries from "../../lib/queries"
+import { routes } from "../../lib/urls"
 import { getDateSummary, programDateRange } from "../../lib/courses"
 import { formatPrettyDate, findItemWithTextId, wait } from "../../lib/util"
 
@@ -284,7 +285,14 @@ export class DashboardPage extends React.Component<Props, State> {
                 (enrollmentsExist ? (
                   <h3>Courses and Programs</h3>
                 ) : (
-                  <h2>You are not yet enrolled in any courses or programs.</h2>
+                  <div className="empty-msg">
+                    <h2>
+                      You are not yet enrolled in any courses or programs.
+                    </h2>
+                    <a href={routes.catalog} className="link-button light-blue">
+                      Browse Our Catalog
+                    </a>
+                  </div>
                 ))}
             </div>
           </div>

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -43,6 +43,12 @@ a.link-button {
     background-color: rgb(163, 31, 52);
     color: #ffffff;
   }
+
+  &.light-blue {
+    border-radius: 5px;
+    background-color: $light-blue;
+    color: #ffffff;
+  }
 }
 
 .form-error {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -41,6 +41,14 @@
     font-weight: inherit;
   }
 
+  .link-button {
+    font-weight: 400;
+  }
+
+  .empty-msg h2 {
+    margin-bottom: 30px;
+  }
+
   .alert {
     color: white;
     font-size: 24px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #682 

#### What's this PR do?
Adds catalog link to the dashboard when there are no enrollments

#### How should this be manually tested?
Clear out any enrollments you have for some user and visit `/dashboard`. If you click the link it should take you to the catalog

#### Any background context you want to provide?
I'm pretty sure that header issue in the mobile view is an existing bug

#### Screenshots (if appropriate)
<img width="1268" alt="ss 2019-07-02 at 17 39 24 " src="https://user-images.githubusercontent.com/14932219/60549023-a329fc80-9cf1-11e9-8268-43db1c754bf8.png">
<img width="795" alt="ss 2019-07-02 at 17 38 15 " src="https://user-images.githubusercontent.com/14932219/60549024-a329fc80-9cf1-11e9-990c-248cde9b962e.png">
<img width="368" alt="ss 2019-07-02 at 17 49 07 " src="https://user-images.githubusercontent.com/14932219/60549056-ba68ea00-9cf1-11e9-8a2a-d06a82bb1459.png">
