### PR TITLE
#738 Remove course position label from product page

### DIFF
--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -29,9 +29,6 @@
       <video autoplay muted loop class="background-video" id="background-video" data-source="{{ page.background_video_url }}">
       </video>
     {% endif %}
-    {% if page.course.program %}
-      <h5 class="program-position">Course {{ page.course.position_in_program }} of {{ page.course.program.num_courses }} in {{ page.course.program.page.title }}</h5>
-    {% endif %}
     <div class="row">
       <div class="col-lg-7">
         <div class="header-title">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #738 

#### What's this PR do?
Removes the `h5` label from product page that displays a course's position in its program

#### Screenshots (if appropriate)
![Screenshot from 2019-07-03 14-39-52](https://user-images.githubusercontent.com/45350418/60581619-a3cd9c00-9da0-11e9-94b0-613b4c589af7.png)
![Screenshot from 2019-07-03 14-40-21](https://user-images.githubusercontent.com/45350418/60581623-a5975f80-9da0-11e9-8f5a-3b4c442e2b50.png)
