### PR TITLE
#740 Product Page: Add commas to prices tile

### DIFF
--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -1,3 +1,4 @@
+{% load humanize %}
 <div class="tiles-block">
   <div class="container">
     <ul class="tiles-list">
@@ -44,7 +45,7 @@
       {% if price %}
         <li>
           <span class="title">PRICE</span>
-          <span class="text">${{ price|floatformat:"0" }}</span>
+          <span class="text">${{ price|floatformat:"0"|intcomma }}</span>
         </li>
       {% endif %}
     </ul>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#740 

#### What's this PR do?
Humanizes the price display on product page metadata tiles.

#### How should this be manually tested?
On any product page that has a price, the tile should display the value with appropriate thousands separators.

#### Screenshots (if appropriate)
![Screenshot from 2019-07-03 14-51-20](https://user-images.githubusercontent.com/45350418/60582456-45a1b880-9da2-11e9-8cf5-f9904e0db02a.png)
![Screenshot from 2019-07-03 14-51-10](https://user-images.githubusercontent.com/45350418/60582457-46d2e580-9da2-11e9-93d3-bdb0d2cbddf3.png)
