### PR TITLE
Add notification when user verifies their email

### DIFF
--- a/static/js/containers/pages/register/RegisterConfirmPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage.js
@@ -8,6 +8,8 @@ import qs from "query-string"
 import { path } from "ramda"
 import { createStructuredSelector } from "reselect"
 
+import { addUserNotification } from "../../../actions"
+import { ALERT_TYPE_TEXT } from "../../../constants"
 import queries from "../../../lib/queries"
 import { routes } from "../../../lib/urls"
 import { STATE_REGISTER_DETAILS, STATE_INVALID_EMAIL } from "../../../lib/auth"
@@ -27,9 +29,9 @@ type Props = {
   auth: ?AuthResponse
 }
 
-class RegisterConfirmPage extends React.Component<Props> {
+export class RegisterConfirmPage extends React.Component<Props> {
   componentDidUpdate(prevProps) {
-    const { auth, history } = this.props
+    const { addUserNotification, auth, history } = this.props
     const prevState = path(["auth", "state"], prevProps)
 
     if (
@@ -40,6 +42,15 @@ class RegisterConfirmPage extends React.Component<Props> {
     ) {
       const params = qs.stringify({
         partial_token: auth.partialToken
+      })
+      addUserNotification({
+        "email-verified": {
+          type:  ALERT_TYPE_TEXT,
+          props: {
+            text:
+              "Success! We've verified your email. Please finish your account creation below."
+          }
+        }
       })
       history.push(`${routes.register.details}?${params}`)
     }
@@ -82,7 +93,14 @@ const registerConfirmEmail = (code: string, partialToken: string) =>
 const mapPropsToConfig = ({ params: { verificationCode, partialToken } }) =>
   registerConfirmEmail(verificationCode, partialToken)
 
+const mapDispatchToProps = {
+  addUserNotification
+}
+
 export default compose(
-  connect(mapStateToProps),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
   connectRequest(mapPropsToConfig)
 )(RegisterConfirmPage)

--- a/static/js/containers/pages/register/RegisterConfirmPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage.js
@@ -24,13 +24,14 @@ import type { RouterHistory, Location } from "react-router"
 import type { AuthResponse } from "../../../flow/authTypes"
 
 type Props = {
+  addUserNotification: Function,
   location: Location,
   history: RouterHistory,
   auth: ?AuthResponse
 }
 
 export class RegisterConfirmPage extends React.Component<Props> {
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     const { addUserNotification, auth, history } = this.props
     const prevState = path(["auth", "state"], prevProps)
 

--- a/static/js/containers/pages/register/RegisterConfirmPage_test.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage_test.js
@@ -1,0 +1,59 @@
+// @flow
+import { assert } from "chai"
+
+import IntegrationTestHelper from "../../../util/integration_test_helper"
+import RegisterConfirmPage, {
+  RegisterConfirmPage as InnerRegisterConfirmPage
+} from "./RegisterConfirmPage"
+import { STATE_REGISTER_DETAILS } from "../../../lib/auth"
+
+describe("RegisterConfirmPage", () => {
+  let helper, renderPage
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    renderPage = helper.configureHOCRenderer(
+      RegisterConfirmPage,
+      InnerRegisterConfirmPage,
+      {},
+      {
+        location: {
+          search: ""
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("shows a message when the confirmation page is displayed and redirects", async () => {
+    helper.handleRequestStub.returns({})
+    const token = "asdf"
+    const { inner, store } = await renderPage({
+      entities: {
+        auth: {
+          state:        STATE_REGISTER_DETAILS,
+          partialToken: token,
+          extraData:    {
+            name: "name"
+          }
+        }
+      }
+    })
+
+    inner.instance().componentDidUpdate({}, {})
+    assert.deepEqual(store.getState().ui.userNotifications, {
+      "email-verified": {
+        type:  "text",
+        props: {
+          text:
+            "Success! We've verified your email. Please finish your account creation below."
+        }
+      }
+    })
+    assert.equal(helper.currentLocation.pathname, "/create-account/details/")
+    assert.equal(helper.currentLocation.search, `?partial_token=${token}`)
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #719 

#### What's this PR do?
Adds a notification which shows up when the user goes to the email verification page

#### How should this be manually tested?
Register a new account and click the verification email link. You should see something like the screenshot below.

#### Screenshots (if appropriate)
![Screenshot from 2019-07-03 16-28-20](https://user-images.githubusercontent.com/863262/60626196-02eadb00-9db8-11e9-9dda-c8bd8abf43b1.png)
