### PR TITLE
Do not include unused_coupons field when syncing contacts to hubspot

### DIFF
--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -207,6 +207,7 @@ def make_contact_sync_message(user_id):
     properties = UserSerializer(user).data
     properties.update(properties.pop("legal_address") or {})
     properties.update(properties.pop("profile") or {})
+    properties.pop("unused_coupons")
     if "street_address" in properties:
         properties["street_address"] = "\n".join(properties.pop("street_address"))
     return [make_sync_message(user.id, properties)]

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -97,6 +97,7 @@ def test_make_contact_sync_message(user):
     serialized_user.update(serialized_user.pop("legal_address") or {})
     serialized_user.update(serialized_user.pop("profile") or {})
     serialized_user["street_address"] = "\n".join(serialized_user.pop("street_address"))
+    serialized_user.pop("unused_coupons")
     assert contact_sync_message == [
         {
             "integratorObjectId": "{}-{}".format(settings.HUBSPOT_ID_PREFIX, user.id),


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #765

#### What's this PR do?
Removes `unused_coupons` field from contact sync message JSON

#### How should this be manually tested?
Run `docker-compose run web python manage.py sync_hubspot --contacts`, it should complete without errors.
