### PR TITLE
Fix django admin search for CoursewareUser

### DIFF
--- a/courseware/admin.py
+++ b/courseware/admin.py
@@ -11,7 +11,7 @@ class CoursewareUserAdmin(admin.ModelAdmin):
     """Admin for CoursewareUser"""
 
     model = CoursewareUser
-    search_fields = ["user", "platform"]
+    search_fields = ["user__username", "user__email", "user__name", "platform"]
     list_filter = ["platform"]
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #677 

#### What's this PR do?
Changes the `search_fields` option for `CoursewareUserAdmin` so it doesn't break

#### How should this be manually tested?
Go to `http://xpro.odl.local:8053/admin/courseware/coursewareuser/` and run a text search.  You should not get any errors.
