### PR TITLE
Coerce fields to and from empty strings to fix React uncontrolled warnings

### DIFF
--- a/static/js/components/forms/EditProfileForm.js
+++ b/static/js/components/forms/EditProfileForm.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import { isNil } from "ramda"
+import { pathOr } from "ramda"
 import { Formik, Form } from "formik"
 
 import {
@@ -26,22 +26,10 @@ const getInitialValues = (user: User) => ({
     ...user.profile,
     // Should be null but React complains about null values in form fields. So we need to convert to
     // string and then back to null on submit.
-    // $FlowFixMe
-    job_function: isNil(user.profile.job_function)
-      ? ""
-      : user.profile.job_function,
-    // $FlowFixMe
-    company_size: isNil(user.profile.company_size)
-      ? ""
-      : user.profile.company_size,
-    // $FlowFixMe
-    leadership_level: isNil(user.profile.leadership_level)
-      ? ""
-      : user.profile.leadership_level,
-    // $FlowFixMe
-    years_experience: isNil(user.profile.years_experience)
-      ? ""
-      : user.profile.years_experience
+    job_function:     pathOr("", ["job_function"], user.profile),
+    company_size:     pathOr("", ["company_size"], user.profile),
+    leadership_level: pathOr("", ["leadership_level"], user.profile),
+    years_experience: pathOr("", ["years_experience"], user.profile)
   }
 })
 

--- a/static/js/components/forms/EditProfileForm.js
+++ b/static/js/components/forms/EditProfileForm.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react"
+import { isNil } from "ramda"
 import { Formik, Form } from "formik"
 
 import {
@@ -21,7 +22,27 @@ const getInitialValues = (user: User) => ({
   name:          user.name,
   email:         user.email,
   legal_address: user.legal_address,
-  profile:       user.profile
+  profile:       {
+    ...user.profile,
+    // Should be null but React complains about null values in form fields. So we need to convert to
+    // string and then back to null on submit.
+    // $FlowFixMe
+    job_function: isNil(user.profile.job_function)
+      ? ""
+      : user.profile.job_function,
+    // $FlowFixMe
+    company_size: isNil(user.profile.company_size)
+      ? ""
+      : user.profile.company_size,
+    // $FlowFixMe
+    leadership_level: isNil(user.profile.leadership_level)
+      ? ""
+      : user.profile.leadership_level,
+    // $FlowFixMe
+    years_experience: isNil(user.profile.years_experience)
+      ? ""
+      : user.profile.years_experience
+  }
 })
 
 const EditProfileForm = ({ onSubmit, countries, user }: Props) => (

--- a/static/js/components/forms/EditProfileForm_test.js
+++ b/static/js/components/forms/EditProfileForm_test.js
@@ -120,4 +120,36 @@ describe("EditProfileForm", () => {
       )
     })
   })
+
+  //
+  ;[true, false].forEach(hasEmpty => {
+    it(`sets initialValues for the form${
+      hasEmpty ? "with some empty fields" : ""
+    }`, async () => {
+      const keys = [
+        "job_function",
+        "company_size",
+        "leadership_level",
+        "years_experience"
+      ]
+      for (const key of keys) {
+        // $FlowFixMe
+        user.profile[key] = hasEmpty ? null : key
+      }
+      const wrapper = renderForm()
+      const initialValues = wrapper.find("Formik").prop("initialValues")
+      assert.equal(initialValues.name, user.name)
+      assert.equal(initialValues.email, user.email)
+      assert.deepEqual(initialValues.legal_address, user.legal_address)
+
+      Object.keys(initialValues.profile).forEach(key => {
+        if (keys.includes(key)) {
+          assert.equal(initialValues.profile[key], hasEmpty ? "" : key)
+        } else {
+          // $FlowFixMe
+          assert.deepEqual(initialValues.profile[key], user.profile[key])
+        }
+      })
+    })
+  })
 })

--- a/static/js/containers/pages/profile/EditProfilePage.js
+++ b/static/js/containers/pages/profile/EditProfilePage.js
@@ -38,10 +38,29 @@ export class EditProfilePage extends React.Component<Props> {
   async onSubmit(profileData: User, { setSubmitting, setErrors }: Object) {
     const { editProfile, history } = this.props
 
+    const payload = {
+      ...profileData,
+      ...(profileData.profile
+        ? {
+          profile: {
+            ...profileData.profile,
+            company_size:
+                profileData.profile.company_size === ""
+                  ? null
+                  : profileData.profile.company_size,
+            years_experience:
+                profileData.profile.years_experience === ""
+                  ? null
+                  : profileData.profile.years_experience
+          }
+        }
+        : {})
+    }
+
     try {
       const {
         body: { errors }
-      }: { body: Object } = await editProfile(profileData)
+      }: { body: Object } = await editProfile(payload)
 
       if (errors && errors.length > 0) {
         setErrors({

--- a/static/js/containers/pages/profile/EditProfilePage_test.js
+++ b/static/js/containers/pages/profile/EditProfilePage_test.js
@@ -1,5 +1,6 @@
 // @flow
 import { assert } from "chai"
+import sinon from "sinon"
 
 import EditProfilePage, {
   EditProfilePage as InnerEditProfilePage
@@ -53,4 +54,66 @@ describe("EditProfilePage", () => {
       inner.text().includes("You must be logged in to edit your profile.")
     )
   })
+
+  //
+  ;[[true, true], [true, false], [false, true], [false, false]].forEach(
+    ([hasError, hasEmptyFields]) => {
+      it(`submits the updated profile ${
+        hasEmptyFields ? "with some empty fields " : ""
+      }${hasError ? "and received an error" : "successfully"}`, async () => {
+        // $FlowFixMe
+        user.profile.company_size = hasEmptyFields ? "" : 50
+        // $FlowFixMe
+        user.profile.years_experience = hasEmptyFields ? "" : 5
+
+        const { inner } = await renderPage()
+        const setSubmitting = helper.sandbox.stub()
+        const setErrors = helper.sandbox.stub()
+        const values = user
+        const actions = {
+          setErrors,
+          setSubmitting
+        }
+
+        helper.handleRequestStub.returns({
+          body: {
+            errors: hasError ? "some errors" : null
+          }
+        })
+
+        await inner.find("EditProfileForm").prop("onSubmit")(values, actions)
+
+        const expectedPayload = {
+          ...user,
+          profile: {
+            ...user.profile
+          }
+        }
+        if (hasEmptyFields) {
+          // $FlowFixMe
+          expectedPayload.profile.company_size = null
+          // $FlowFixMe
+          expectedPayload.profile.years_experience = null
+        }
+
+        sinon.assert.calledWith(
+          helper.handleRequestStub,
+          "/api/users/me",
+          "PATCH",
+          {
+            body:        expectedPayload,
+            credentials: undefined,
+            headers:     { "X-CSRFTOKEN": null }
+          }
+        )
+        sinon.assert.calledWith(setSubmitting, false)
+        assert.equal(setErrors.length, 0)
+        if (hasError) {
+          assert.isNull(helper.currentLocation)
+        } else {
+          assert.equal(helper.currentLocation.pathname, "/profile/")
+        }
+      })
+    }
+  )
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #735 

#### What's this PR do?
Changes some null fields to empty strings when the values are rendered, then changes some back to null for the PATCH of the payload.

#### How should this be manually tested?
On the `/profile/edit/` page, set all of the fields below the dashed line, for example "Years of experience", to non-empty values. Click "Continue" and then click "Edit". All values should have been persisted correctly.

Next, clear those values and click 'Continue', then click 'Edit'. All values should now be blank in the UI.