### PR TITLE
Upgrade Django to 2.2, wagtail to 2.5.1

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -11,11 +11,7 @@ from django.utils.text import slugify
 from django.http.response import Http404
 from django.shortcuts import reverse
 from modelcluster.fields import ParentalKey
-from wagtail.admin.edit_handlers import (
-    FieldPanel,
-    InlinePanel,
-    StreamFieldPanel,
-)
+from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
 from wagtail.core import blocks
 from wagtail.core.blocks import PageChooserBlock, RawHTMLBlock
 from wagtail.core.fields import RichTextField, StreamField

--- a/cms/models.py
+++ b/cms/models.py
@@ -1010,14 +1010,6 @@ class FrequentlyAskedQuestion(Orderable):
     question = models.TextField()
     answer = RichTextField()
 
-    content_panels = [
-        MultiFieldPanel(
-            [FieldPanel("question"), FieldPanel("answer")],
-            heading="Frequently Asked Questions",
-            classname="collapsible",
-        )
-    ]
-
 
 class ResourcePage(Page):
     """

--- a/cms/models.py
+++ b/cms/models.py
@@ -14,7 +14,6 @@ from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     InlinePanel,
-    MultiFieldPanel,
     StreamFieldPanel,
 )
 from wagtail.core import blocks

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ beautifulsoup4==4.6.0
 celery==4.2.0
 boto3==1.9.115
 dj-database-url==0.4.2
-django==2.1.9
+django==2.2.3
 django-anymail[mailgun]==3.*
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
@@ -29,6 +29,6 @@ sentry-sdk
 social-auth-app-django==3.1.0
 ulid-py
 uwsgi
-wagtail==2.4
+wagtail==2.5.1
 wagtail-metadata==2.0.1
 zeep==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ django-taggit==0.23.0     # via wagtail
 django-templated-mail==1.1.1  # via djoser
 django-treebeard==4.3     # via wagtail
 django-webpack-loader==0.5.0
-django==2.1.9
+django==2.2.3
 djangorestframework==3.9.4
 djoser==1.5.1
 docutils==0.14            # via botocore
@@ -77,6 +77,7 @@ sentry-sdk==0.9.5
 six==1.12.0               # via django-anymail, django-compat, django-server-status, edx-api-client, html5lib, isodate, prompt-toolkit, pynacl, python-dateutil, social-auth-app-django, social-auth-core, traitlets, wagtail, zeep
 social-auth-app-django==3.1.0
 social-auth-core==3.1.0   # via social-auth-app-django
+sqlparse==0.3.0           # via django
 traitlets==4.3.2          # via ipython
 ulid-py==0.0.9
 unidecode==1.0.23         # via wagtail
@@ -84,7 +85,7 @@ urllib3==1.24.2           # via botocore, elasticsearch, requests, sentry-sdk
 uwsgi==2.0.18
 vine==1.3.0               # via amqp
 wagtail-metadata==2.0.1
-wagtail==2.4
+wagtail==2.5.1
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via html5lib
 willow==1.1               # via wagtail


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #774 

#### What's this PR do?
Upgrades Django to 2.2, and wagtail to 2.5.1 because wagtail 2.4 won't work with Django 2.2

#### How should this be manually tested?
Nothing should break. You can double check the release notes for django and wagtail, but I didn't notice anything that would affect us when I looked earlier.