### PR TITLE
Tasawer/fix account creation for Canadian users

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -152,6 +152,11 @@ class SocialAuthSerializer(serializers.Serializer):
             log.exception("Received unexpected AuthException")
             result = SocialAuthState(SocialAuthState.STATE_ERROR, errors=[str(exc)])
 
+        except RequirePasswordAndPersonalInfoException as exc:
+            result = SocialAuthState(
+                SocialAuthState.STATE_REGISTER_DETAILS, partial=exc.partial
+            )
+            
         if isinstance(result, SocialAuthState):
             if result.partial is not None:
                 strategy = self.context["strategy"]
@@ -272,13 +277,7 @@ class RegisterConfirmSerializer(SocialAuthSerializer):
 
     def create(self, validated_data):
         """Try to 'save' the request"""
-        try:
-            result = super()._authenticate(SocialAuthState.FLOW_REGISTER)
-        except RequirePasswordAndPersonalInfoException as exc:
-            result = SocialAuthState(
-                SocialAuthState.STATE_REGISTER_DETAILS, partial=exc.partial
-            )
-        return result
+        return super()._authenticate(SocialAuthState.FLOW_REGISTER)
 
 
 class RegisterDetailsSerializer(SocialAuthSerializer):

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -148,15 +148,16 @@ class SocialAuthSerializer(serializers.Serializer):
             result = SocialAuthState(
                 SocialAuthState.STATE_REGISTER_EXTRA_DETAILS, partial=exc.partial
             )
-        except AuthException as exc:
-            log.exception("Received unexpected AuthException")
-            result = SocialAuthState(SocialAuthState.STATE_ERROR, errors=[str(exc)])
 
         except RequirePasswordAndPersonalInfoException as exc:
             result = SocialAuthState(
                 SocialAuthState.STATE_REGISTER_DETAILS, partial=exc.partial
             )
-            
+
+        except AuthException as exc:
+            log.exception("Received unexpected AuthException")
+            result = SocialAuthState(SocialAuthState.STATE_ERROR, errors=[str(exc)])
+
         if isinstance(result, SocialAuthState):
             if result.partial is not None:
                 strategy = self.context["strategy"]

--- a/static/js/containers/pages/register/RegisterEmailPage.js
+++ b/static/js/containers/pages/register/RegisterEmailPage.js
@@ -80,7 +80,7 @@ export class RegisterEmailPage extends React.Component<Props> {
     return (
       <div className="container auth-page">
         <div className="row">
-          <h1 className="col-12">Sign Up</h1>
+          <h1 className="col-12">Create Account</h1>
         </div>
         <div className="auth-form auth-card card-shadow row">
           <div className="col-12">

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -12,7 +12,7 @@ from users.models import LegalAddress, User, Profile
 from hubspot.task_helpers import sync_hubspot_user
 
 US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
-CA_POSTAL_RE = re.compile(r"[\w]\d[\w][ -]?\d[\w]\d$")
+CA_POSTAL_RE = re.compile(r"[\w]\d[\w] \d[\w]\d$")
 
 
 class LegalAddressSerializer(serializers.ModelSerializer):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -12,7 +12,7 @@ from users.models import LegalAddress, User, Profile
 from hubspot.task_helpers import sync_hubspot_user
 
 US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
-CA_POSTAL_RE = re.compile(r"[0-9][A-Z][0-9] [A-Z][0-9][A-Z]", flags=re.I)
+CA_POSTAL_RE = re.compile(r"[\w]\d[\w][ -]?\d[\w]\d$")
 
 
 class LegalAddressSerializer(serializers.ModelSerializer):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -96,6 +96,20 @@ def test_validate_postal_code_formats(sample_address, data, error):
     assert str(serializer.errors["postal_code"][0]) == error
 
 
+@pytest.mark.parametrize("postal_code", ["K0M 2K0", "J8R 3P7", "G3G 2B7", "L6L 1C2"])
+def test_valid_ca_postal_codes(sample_address, postal_code):
+    """Test that validator won't show error on valid postal code for CA."""
+
+    import pdb
+
+    pdb.set_trace()
+    sample_address.update(
+        {"country": "CA", "state_or_territory": "CA-BC", "postal_code": postal_code}
+    )
+
+    assert LegalAddressSerializer(data=sample_address).is_valid()
+
+
 def test_validate_optional_country_data(sample_address):
     """Test that state_or_territory and postal_code are optional for other countries besides US/CA"""
     sample_address.update(

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -100,9 +100,6 @@ def test_validate_postal_code_formats(sample_address, data, error):
 def test_valid_ca_postal_codes(sample_address, postal_code):
     """Test that validator won't show error on valid postal code for CA."""
 
-    import pdb
-
-    pdb.set_trace()
     sample_address.update(
         {"country": "CA", "state_or_territory": "CA-BC", "postal_code": postal_code}
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #782 and #786

#### What's this PR do?

- Update regex to match Canadian postal codes.
- Replace sign up with create account

#### How should this be manually tested?

- go to `/create_account` and start create account flow
- Click on the verification email link, to go to `/create-account/details/`
- Enter the account details using a Canadian address, including province and Candian postal code (e.g. K0M 2K0).