### PR TITLE
Fixed enrollment commands - set order status, changed output

### DIFF
--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -2,7 +2,11 @@
 from django.core.management.base import CommandError
 from django.contrib.auth import get_user_model
 
-from courses.management.utils import EnrollmentChangeCommand, fetch_user
+from courses.management.utils import (
+    EnrollmentChangeCommand,
+    fetch_user,
+    enrollment_summary,
+)
 from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
 from courses.models import CourseRun, CourseRunEnrollment
 
@@ -16,17 +20,22 @@ class Command(EnrollmentChangeCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--user", type=str, help="The id, email, or username of the enrolled User"
+            "--user",
+            type=str,
+            help="The id, email, or username of the enrolled User",
+            required=True,
         )
         parser.add_argument(
             "--from-run",
             type=str,
             help="The 'courseware_id' value for an enrolled CourseRun",
+            required=True,
         )
         parser.add_argument(
             "--to-run",
             type=str,
             help="The 'courseware_id' value for the CourseRun that you are deferring to",
+            required=True,
         )
         super().add_arguments(parser)
 
@@ -75,7 +84,7 @@ class Command(EnrollmentChangeCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 "Deferred enrollment for user: {} ({})\nEnrollment created/updated: {}".format(
-                    user.username, user.email, to_enrollment
+                    user.username, user.email, enrollment_summary(to_enrollment)
                 )
             )
         )

--- a/courses/management/commands/transfer_enrollment.py
+++ b/courses/management/commands/transfer_enrollment.py
@@ -2,7 +2,11 @@
 from django.core.management.base import CommandError
 from django.contrib.auth import get_user_model
 
-from courses.management.utils import EnrollmentChangeCommand, fetch_user
+from courses.management.utils import (
+    EnrollmentChangeCommand,
+    fetch_user,
+    enrollment_summaries,
+)
 from courses.constants import ENROLL_CHANGE_STATUS_TRANSFERRED
 from courses.models import CourseRunEnrollment
 
@@ -19,11 +23,13 @@ class Command(EnrollmentChangeCommand):
             "--from-user",
             type=str,
             help="The id, email, or username of the enrolled User",
+            required=True,
         )
         parser.add_argument(
             "--to-user",
             type=str,
             help="The id, email, or username of the User to whom the enrollment will be transferred",
+            required=True,
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
@@ -79,7 +85,9 @@ class Command(EnrollmentChangeCommand):
                     from_user.email,
                     to_user.username,
                     to_user.email,
-                    list(filter(bool, [new_program_enrollment] + new_run_enrollments)),
+                    enrollment_summaries(
+                        filter(bool, [new_program_enrollment] + new_run_enrollments)
+                    ),
                 )
             )
         )

--- a/courses/management/utils.py
+++ b/courses/management/utils.py
@@ -13,6 +13,33 @@ from mitxpro.utils import has_equal_properties
 User = get_user_model()
 
 
+def enrollment_summary(enrollment):
+    """
+    Returns a string representation of an enrollment for command output
+
+    Args:
+        enrollment (ProgramEnrollment or CourseRunEnrollment): The enrollment
+    Returns:
+        str: A string representation of an enrollment
+    """
+    if isinstance(enrollment, ProgramEnrollment):
+        return "<ProgramEnrollment for {}>".format(enrollment.program.text_id)
+    else:
+        return "<CourseRunEnrollment for {}>".format(enrollment.run.text_id)
+
+
+def enrollment_summaries(enrollments):
+    """
+    Returns a list of string representations of enrollments for command output
+
+    Args:
+        enrollments (iterable of ProgramEnrollment or CourseRunEnrollment): The enrollments
+    Returns:
+        list of str: A list of string representations of enrollments
+    """
+    return list(map(enrollment_summary, enrollments))
+
+
 def fetch_user(user_property):
     """
     Attempts to fetch a user based on several properties


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #655 
Fixes #780

#### What's this PR do?
- Sets the associated order to refunded when an enrollment is refunded
- Changes the enrollment summary output to indicate the readable_id/courseware_id of the enrolled objects

#### How should this be manually tested?
- Purchase some program/course via full-price coupon, then set it to refunded via the `refund_enrollment` management command. It should set the associated order to refunded as well, and the command output should indicate that
- Run any of the enrollment change commands (including `refund_enrollment`) and check that the enrollment summaries in the output look readable

#### Screenshots (if appropriate)
![ss 2019-07-09 at 17 43 04 ](https://user-images.githubusercontent.com/14932219/60925398-99fcda80-a271-11e9-9b80-ad86ae53ef3c.png)

