### PR TITLE
Add protection rules for ProductVersion, CouponVersion, CouponPaymentVersion

### DIFF
--- a/ecommerce/migrations/0015_db_protect.py
+++ b/ecommerce/migrations/0015_db_protect.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+from ecommerce.utils import (
+    create_update_rule,
+    create_delete_rule,
+    rollback_update_rule,
+    rollback_delete_rule,
+)
+
+
+def protection_rules(table_name):
+    """
+    Helper function to create protection rules for a table,
+    to prevent updates and deletes (but creates are still allowed)
+    """
+    return [
+        migrations.RunSQL(
+            sql=create_delete_rule(table_name),
+            reverse_sql=rollback_delete_rule(table_name),
+        ),
+        migrations.RunSQL(
+            sql=create_update_rule(table_name),
+            reverse_sql=rollback_update_rule(table_name),
+        ),
+    ]
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("ecommerce", "0014_productversion_text_id")]
+
+    operations = [
+        *protection_rules("productversion"),
+        *protection_rules("couponversion"),
+        *protection_rules("couponpaymentversion"),
+    ]

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -102,7 +102,6 @@ def test_product_version_save_text_id_courserun():
     product_version = ProductVersionFactory.create(
         product=ProductFactory.create(content_object=run)
     )
-    product_version.save()
     assert product_version.text_id == run.courseware_id
 
 
@@ -112,7 +111,6 @@ def test_product_version_save_text_id_program():
     product_version = ProductVersionFactory.create(
         product=ProductFactory.create(content_object=program)
     )
-    product_version.save()
     assert product_version.text_id == program.readable_id
 
 
@@ -122,7 +120,6 @@ def test_product_version_save_text_id_badproduct(mocker):
     product_version = ProductVersionFactory.create(
         product=ProductFactory.create(content_object=LineFactory())
     )
-    product_version.save()
     assert product_version.text_id is None
     assert mock_log.called_once_with(
         f"The content object for this ProductVersion ({product_version.id}) does not have a `text_id` property"

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -1,0 +1,21 @@
+"""Utility functions for ecommerce"""
+
+
+def create_delete_rule(table_name):
+    """Helper function to make SQL to create a rule to prevent deleting from the ecommerce table"""
+    return f"CREATE RULE delete_protect AS ON DELETE TO ecommerce_{table_name} DO INSTEAD NOTHING"
+
+
+def create_update_rule(table_name):
+    """Helper function to make SQL to create a rule to prevent updating a row in the ecommerce table"""
+    return f"CREATE RULE update_protect AS ON UPDATE TO ecommerce_{table_name} DO INSTEAD NOTHING"
+
+
+def rollback_delete_rule(table_name):
+    """Helper function to make SQL to create a rule to allow deleting from the ecommerce table"""
+    return f"DROP RULE delete_protect ON ecommerce_{table_name}"
+
+
+def rollback_update_rule(table_name):
+    """Helper function to make SQL to create a rule to allow updating from the ecommerce table"""
+    return f"DROP RULE update_protect ON ecommerce_{table_name}"

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -47,6 +47,7 @@ from ecommerce.serializers import (
     CurrentCouponPaymentSerializer,
     DataConsentUserSerializer,
 )
+from ecommerce.test_utils import unprotect_version_tables
 from mitxpro.test_utils import create_tempfile_csv
 from users.factories import UserFactory
 
@@ -518,9 +519,10 @@ def test_patch_basket_clear_coupon_no_auto(
     """ Test that all coupons are cleared from basket  """
     basket = basket_and_coupons.basket
 
-    auto_coupon_payment = basket_and_coupons.coupongroup_worst.payment_version
-    auto_coupon_payment.automatic = False
-    auto_coupon_payment.save()
+    with unprotect_version_tables():
+        auto_coupon_payment = basket_and_coupons.coupongroup_worst.payment_version
+        auto_coupon_payment.automatic = False
+        auto_coupon_payment.save()
 
     original_basket = BasketSerializer(instance=basket, context=mock_context).data
     assert len(original_basket.get("coupons")) == 1

--- a/localdev/seed/api_test.py
+++ b/localdev/seed/api_test.py
@@ -6,6 +6,7 @@ import pytest
 from courses.models import Program, Course, CourseRun
 from cms.models import ProgramPage, CoursePage, ResourcePage
 from ecommerce.models import Product, ProductVersion
+from ecommerce.test_utils import unprotect_version_tables
 from localdev.seed.api import SeedDataLoader, get_raw_seed_data_from_file
 
 
@@ -69,7 +70,8 @@ def test_seed_and_unseed_data(seeded):
     assert Product.objects.count() == expected_products
     assert ProductVersion.objects.count() == expected_products
 
-    seeded.loader.delete_seed_data(seeded.raw_data)
+    with unprotect_version_tables():
+        seeded.loader.delete_seed_data(seeded.raw_data)
     assert Program.objects.count() == 0
     assert ProgramPage.objects.count() == 0
     assert Course.objects.count() == 0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #492 

#### What's this PR do?
Prevents updating or deleting rows from `ProductVersion`, `CouponVersion`, or `CouponPaymentVersion`

#### How should this be manually tested?
Run the migrations and try updating or deleting information from those models
