### PR TITLE
Change validation error message to Enrollment / Promotional Code

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -334,7 +334,11 @@ class BasketSerializer(serializers.ModelSerializer):
             )
             if coupon_version is None:
                 raise ValidationError(
-                    {"coupons": "Coupon code {} is invalid".format(coupon_code)}
+                    {
+                        "coupons": "Enrollment / Promotional Code {} is invalid".format(
+                            coupon_code
+                        )
+                    }
                 )
         elif coupons is not None:
             # Coupon was cleared, get the best available auto coupon for the product instead

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -481,7 +481,10 @@ def test_patch_basket_update_coupon_invalid(basket_client, basket_and_coupons):
     resp = basket_client.patch(reverse("basket_api"), type="json", data=data)
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     resp_data = resp.json()
-    assert resp_data["errors"]["coupons"] == f"Coupon code {bad_code} is invalid"
+    assert (
+        resp_data["errors"]["coupons"]
+        == f"Enrollment / Promotional Code {bad_code} is invalid"
+    )
 
 
 def test_patch_basket_clear_coupon_auto(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #778 

#### What's this PR do?
Updates the validation message for an invalid coupon code

#### How should this be manually tested?
At the checkout page, type some random string that's not a coupon code and click 'Apply Coupon'. 
