### PR TITLE
fix regex for false positive, add test for invalid codes

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -12,7 +12,7 @@ from users.models import LegalAddress, User, Profile
 from hubspot.task_helpers import sync_hubspot_user
 
 US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
-CA_POSTAL_RE = re.compile(r"[\w]\d[\w] \d[\w]\d$")
+CA_POSTAL_RE = re.compile(r"[A-Z]\d[A-Z] \d[A-Z]\d$", flags=re.I)
 
 
 class LegalAddressSerializer(serializers.ModelSerializer):

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -107,7 +107,7 @@ def test_valid_ca_postal_codes(sample_address, postal_code):
     assert LegalAddressSerializer(data=sample_address).is_valid()
 
 
-@pytest.mark.parametrize("postal_code", ["0M0 2K0", "J8R P7Q", "GAG 2B7", "L6L 122"])
+@pytest.mark.parametrize("postal_code", ["0M0 2K0", "J8R P7Q", "GAG 2B7", "L6L 122", "K0M-2K0"])
 def test_invalid_ca_postal_codes(sample_address, postal_code):
     """Test that validator will show error on invalid postal code for CA."""
 

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -96,7 +96,7 @@ def test_validate_postal_code_formats(sample_address, data, error):
     assert str(serializer.errors["postal_code"][0]) == error
 
 
-@pytest.mark.parametrize("postal_code", ["K0M 2K0", "J8R 3P7", "G3G 2B7", "L6L 1C2"])
+@pytest.mark.parametrize("postal_code", ["K0M 2K0", "J8R 3P7", "G3G 2B7", "l6l 1c2"])
 def test_valid_ca_postal_codes(sample_address, postal_code):
     """Test that validator won't show error on valid postal code for CA."""
 

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -107,6 +107,20 @@ def test_valid_ca_postal_codes(sample_address, postal_code):
     assert LegalAddressSerializer(data=sample_address).is_valid()
 
 
+@pytest.mark.parametrize("postal_code", ["0M0 2K0", "J8R P7Q", "GAG 2B7", "L6L 122"])
+def test_invalid_ca_postal_codes(sample_address, postal_code):
+    """Test that validator will show error on invalid postal code for CA."""
+
+    expected_error = "Postal Code must be in the format 'ANA NAN'"
+    sample_address.update(
+        {"country": "CA", "state_or_territory": "CA-BC", "postal_code": postal_code}
+    )
+
+    serializer = LegalAddressSerializer(data=sample_address)
+    assert serializer.is_valid() is False
+    assert str(serializer.errors["postal_code"][0]) == expected_error
+
+
 def test_validate_optional_country_data(sample_address):
     """Test that state_or_territory and postal_code are optional for other countries besides US/CA"""
     sample_address.update(

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -107,7 +107,9 @@ def test_valid_ca_postal_codes(sample_address, postal_code):
     assert LegalAddressSerializer(data=sample_address).is_valid()
 
 
-@pytest.mark.parametrize("postal_code", ["0M0 2K0", "J8R P7Q", "GAG 2B7", "L6L 122", "K0M-2K0"])
+@pytest.mark.parametrize(
+    "postal_code", ["0M0 2K0", "J8R P7Q", "GAG 2B7", "L6L 122", "K0M-2K0"]
+)
 def test_invalid_ca_postal_codes(sample_address, postal_code):
     """Test that validator will show error on invalid postal code for CA."""
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #789 

#### What's this PR do?

- Update regex for invalid codes.
- Add test for invalid postal codes.

#### How should this be manually tested?

- go to /create_account and start create account flow
- Click on the verification email link, to go to /create-account/details/
- Enter the account details using a Canadian address, including province and Candian postal code (e.g. K0M 2K0).
- Also try with invalid format of postal code.

#### Any background context you want to provide?
This PR is follow up of #787

