### PR TITLE
minor scss fixes

### DIFF
--- a/static/scss/detail/companies-trust.scss
+++ b/static/scss/detail/companies-trust.scss
@@ -21,7 +21,7 @@
 .logos-slider {
 
   .img-holder {
-    min-height: 100px;
+    height: 100%;
     text-align: center;
     padding: 0 10px;
     letter-spacing: -.32em;
@@ -32,7 +32,7 @@
       content: '';
       width: 2px;
       margin: -2px;
-      height: 100px;
+      height: inherit;
     }
 
     img {

--- a/static/scss/slick.scss
+++ b/static/scss/slick.scss
@@ -123,7 +123,7 @@
   cursor: pointer;
 
   @include media-breakpoint-up(md) {
-    left: -15px;
+    left: -25px;
     width: 50px;
     height: 50px;
     padding: 5px 0;
@@ -132,12 +132,15 @@
   }
 
   @include media-breakpoint-up(lg) {
-    left: -30px;
-    width: 70px;
-    height: 70px;
+    width: 50px;
+    height: 50px;
     padding: 15px 0;
   }
-
+  @media (min-width: 1275px) {
+    left: -65px;
+    width: 70px;
+    height: 70px;
+  }
   @media (min-width: 1450px) {
     left: -135px;
   }
@@ -153,6 +156,10 @@
     font-family: icomoon;
     content: "\e900";
     @include media-breakpoint-up(md) {
+      font-size: 22px;
+      line-height: 20px;
+    }
+    @media (min-width: 1275px) {
       font-size: 30px;
       line-height: 40px;
     }
@@ -164,15 +171,14 @@
   right: 0px;
 
   @include media-breakpoint-up(md) {
-    right: -15px;
-  }
-
-  @include media-breakpoint-up(lg) {
-    right: -30px;
+    right: -25px;
   }
 
   &:after {
     content: "\e901";
+  }
+  @media (min-width: 1275px) {
+    right: -65px;
   }
 
   @media (min-width: 1450px) {


### PR DESCRIPTION
#### Fixes #772 & Possible fix for #777

@pdpinch for #777 I have adjusted the `min-width: 1275px` but if screen size would be lower than that then arrows will overlap again over cards again due to space constraint over there. There is no any space remain for left/right arrows. 

#### Screen over min-width:1275px
<img width="808" alt="Screen Shot 2019-07-10 at 4 42 54 PM" src="https://user-images.githubusercontent.com/7334669/60966607-122ad500-a332-11e9-852f-ff808100db3b.png">

#### Screen over min-width:1274px
<img width="657" alt="Screen Shot 2019-07-10 at 4 44 20 PM" src="https://user-images.githubusercontent.com/7334669/60966604-10f9a800-a332-11e9-85ee-218247a7800f.png">

#### Companies Carousal
<img width="1280" alt="Screen Shot 2019-07-10 at 4 47 14 PM" src="https://user-images.githubusercontent.com/7334669/60966783-777ec600-a332-11e9-947a-3685b27fa827.png">
