### PR TITLE
#776 Allow Mixed Case Section Heads and Subheads

### DIFF
--- a/cms/templates/partials/course-carousel.html
+++ b/cms/templates/partials/course-carousel.html
@@ -2,7 +2,7 @@
 <div id="courseLineup" class="course-in-program">
   <div class="container">
     <div class="head">
-      <h1 class="text-uppercase">{{ page.heading }}</h1>
+      <h1>{{ page.heading }}</h1>
       {% if page.body %}{{ page.body|richtext }}{% endif %}
     </div>
     <div class="course-slider">

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -2,7 +2,7 @@
 <div id="faculty" class="faculty-block">
   <div class="container">
     <div class="head">
-      <h1 class="text-uppercase">{{ page.heading }}</h1>
+      <h1>{{ page.heading }}</h1>
       {% if page.subhead %}
         <h3>{{ page.subhead }}</h3>
       {% endif %}

--- a/cms/templates/partials/for-teams.html
+++ b/cms/templates/partials/for-teams.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-7 {% if page.switch_layout %}order-2{% endif %}">
-        <h1 class="text-uppercase" >{{ page.title }}</h1>
+        <h1>{{ page.title }}</h1>
         {{ page.content|safe }}
         {% if page.action_url and page.action_title %}
           <a href="{{ page.action_url }}" class="btn btn-primary text-uppercase px-5 py-2 action-button">{{ page.action_title }}</a>

--- a/cms/templates/partials/learning-techniques.html
+++ b/cms/templates/partials/learning-techniques.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 <div id="learningTechniques" class="container learning-techniques-block section-spacing">
-  <h1 class="text-uppercase">{{ page.title }}</h1>
+  <h1>{{ page.title }}</h1>
   <ul class="learning-techniques-list">
     {% for technique in page.technique_items %}
       <li>

--- a/cms/templates/partials/target-audience.html
+++ b/cms/templates/partials/target-audience.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-6 {% if page.switch_layout %}order-2{% endif %}">
-        <h1 class="text-uppercase">Who Should Enroll</h1>
+        <h1>Who Should Enroll</h1>
         <ul class="item-list">
           {% for item in page.content %}
             <li>{{ item }}</li>

--- a/cms/templates/partials/text-section.html
+++ b/cms/templates/partials/text-section.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-lg-10">
-        <h1 class="text-uppercase text-center" >{{ page.title }}</h1>
+        <h1 class="text-center" >{{ page.title }}</h1>
         {{ page.content|richtext }}
         {% if page.action_url and page.action_title %}
           <div class="text-center">

--- a/cms/templates/partials/text-video-section.html
+++ b/cms/templates/partials/text-video-section.html
@@ -2,7 +2,7 @@
 
 <div class="tv-block {% if page.dark_theme %} dark-theme {% endif %}">
   <div class="container">
-    <h1 class="text-uppercase">{{ page.title }}</h1>
+    <h1>{{ page.title }}</h1>
     <div class="row">
       <div class="col-lg-6 {% if page.switch_layout %}order-2{% endif %}">
         {{ page.content|richtext }}

--- a/static/scss/detail/companies-trust.scss
+++ b/static/scss/detail/companies-trust.scss
@@ -13,7 +13,6 @@
   h1 {
     color: $primary;
     margin: 0 0 50px;
-    text-transform: uppercase;
     text-align: center;
   }
 }

--- a/static/scss/detail/faculty.scss
+++ b/static/scss/detail/faculty.scss
@@ -21,7 +21,6 @@
 
   h1 {
     margin: 0 0 10px;
-    text-transform: uppercase;
     font-weight: 600;
     color: white;
     @include media-breakpoint-up(lg) {

--- a/static/scss/detail/for-teams.scss
+++ b/static/scss/detail/for-teams.scss
@@ -55,7 +55,6 @@
     color: $primary;
     font-weight: 600;
     margin: 0 0 10px;
-    text-transform: uppercase;
     @include media-breakpoint-up(lg) {
       margin: 0 0 40px;
     }

--- a/static/scss/detail/learning-techniques.scss
+++ b/static/scss/detail/learning-techniques.scss
@@ -10,7 +10,6 @@
     margin: 0 0 50px;
     color: $primary;
     font-weight: 600;
-    text-transform: uppercase;
   }
 }
 

--- a/static/scss/detail/testimonial-carousel.scss
+++ b/static/scss/detail/testimonial-carousel.scss
@@ -34,7 +34,6 @@
   h1 {
     color: $primary;
     margin: 0 0 10px;
-    text-transform: uppercase;
 
     @include media-breakpoint-up(lg) {
       margin: 0 0 25px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#776 

#### What's this PR do?
Removes forced `text-uppercase` classes and `text-transform: uppercase;` properties on section heads and subheads so mixed case can be used.

#### How should this be manually tested?
Go to any section, modify it's title to use mixed case. On the page where the section appears, verify that the head/subhead appears as configured in CMS and not forced to uppercase.

#### Screenshots (if appropriate)
![Screenshot from 2019-07-10 18-37-51](https://user-images.githubusercontent.com/45350418/60973644-152dc180-a342-11e9-8d14-ea04bf45691d.png)
