### PR TITLE
#792 Featured Product Card Thumbnail Fix

### DIFF
--- a/cms/templates/partials/catalog-card.html
+++ b/cms/templates/partials/catalog-card.html
@@ -4,7 +4,7 @@
         <div class="cover-image">
             <div class="cover-image-frame">
                 {% if courseware_page.thumbnail_image %}
-                    {% image courseware_page.thumbnail_image fill-335x203 %}
+                    {% image courseware_page.thumbnail_image fill-275x155 %}
                 {% else %}
                     <img src="{% static default_image_path %}" alt="Preview image">
                 {% endif %}

--- a/cms/templates/partials/featured_card.html
+++ b/cms/templates/partials/featured_card.html
@@ -9,7 +9,11 @@
           </div>
           <div class="cover-image">
             <div class="cover-image-frame">
-              <img src="/static/images/mit-dome.png" alt="Preview image">
+              {% if courseware_page.thumbnail_image %}
+                {% image courseware_page.thumbnail_image fill-275x155 %}
+              {% else %}
+                <img src="{% static default_image_path %}" alt="Preview image">
+              {% endif %}
             </div>
           </div>
           <div class="top-level-details">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#792 
#### What's this PR do?
Fixes featured product card to use the product thumbnail instead of only the default image. 
Extra: Also fixes the wagtail image rendition size according to the image dimensions.

#### How should this be manually tested?
Mark a product featured and make sure that product has a thumbnail image. Go to the catalog page, verify that the catalog card and featured product card show the same thumbnail.

#### Screenshots (if appropriate)
![Screenshot from 2019-07-10 18-52-49](https://user-images.githubusercontent.com/45350418/60974815-35f71680-a344-11e9-9771-298aa308a4d1.png)
![Screenshot from 2019-07-10 18-52-16](https://user-images.githubusercontent.com/45350418/60974817-35f71680-a344-11e9-81a8-1ca6526d2ccd.png)
