### PR TITLE
Added config to avoid OSERRORs from uwsgi

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -74,6 +74,7 @@ http {
             uwsgi_pass unix:/tmp/nginx.socket;
             uwsgi_pass_request_headers on;
             uwsgi_pass_request_body on;
+            uwsgi_ignore_client_abort on;
             client_max_body_size 25M;
         }
     }


### PR DESCRIPTION
When a user aborts an HTTP request, uWSGI will still attempt to write back to the request socket, resulting in an OSERROR. By adding the `ignore_client_abort` parameter we avoid spamming our Sentry logs with this exception.

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes the occurrence of OSERRORs from uWSGI when a client aborts a request before it is completed

#### How should this be manually tested?
Deploy to CI, start a web request and close the tab before it completes