### PR TITLE
Fix typo with command arg

### DIFF
--- a/compliance/management/commands/decrypt_exports_inquiry.py
+++ b/compliance/management/commands/decrypt_exports_inquiry.py
@@ -32,8 +32,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Run the command"""
 
-        if options["id"]:
-            user = User.objects.get(id=options["id"])
+        if options["user_id"]:
+            user = User.objects.get(id=options["user_id"])
         elif options["username"]:
             user = User.objects.get(username=options["username"])
         elif options["email"]:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a typo in the command that caused it to immediate crash

#### How should this be manually tested?

- Run `./manage.py decrypt_exports_inquiry --user-id 1`
- Command should not crash or exit and you should see a prompt
- No need to test further