### PR TITLE
Change voucher pages style

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -36,6 +36,7 @@
 @import "notification";
 @import "user-menu";
 @import "error";
+@import "voucher";
 
 body {
   font-family: Rajdhani,"Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -13,6 +13,7 @@ $light-blue: #15729b;
 $navy-blue: #355b6b;
 $cornflower-blue: #579cf9;
 $denim-blue: #16729b;
+$deep-sky-blue: #07a3ff;
 $tile-background: #fff;
 $tiles-background: rgba(53, 53, 53, 97);
 $tab-color: #c2c0bf;

--- a/static/scss/voucher.scss
+++ b/static/scss/voucher.scss
@@ -1,0 +1,60 @@
+.voucher-container {
+  max-width: 800px;
+  margin: auto;
+  font-family: Rajdhani;
+  font-size: 16px;
+
+  .upload-gray {
+    color: $light-gray;
+  }
+
+  a {
+    color: $deep-sky-blue;
+  }
+
+  .voucher-card {
+
+    padding-left: 137px;
+    padding-right: 137px;
+
+    @include media-breakpoint-down(sm)  {
+      padding: 20px;
+    }
+
+    @include media-breakpoint-down(xs)  {
+      padding: 15px 0;
+    }
+
+    background-color: $very-light-gray;
+    border-width: 7px 0 0 0;
+    border-style: solid;
+    border-image-source: linear-gradient(90deg, #43bebc, #ebbb47);
+    border-image-slice: 1;
+    padding: 40px;
+  }
+
+  .voucher-form {
+    .form-control {
+      font-size: inherit;
+      font-weight: inherit;
+    }
+
+    .form-error {
+      font-size: 1rem;
+      font-weight: 400;
+    }
+
+    .errored {
+      border: 2px solid $red;
+    }
+
+    label {
+      font-weight: 600;
+    }
+
+    .submit-row {
+      margin-top: 25px;
+    }
+  }
+
+}

--- a/static/scss/voucher.scss
+++ b/static/scss/voucher.scss
@@ -14,9 +14,6 @@
 
   .voucher-card {
 
-    padding-left: 137px;
-    padding-right: 137px;
-
     @include media-breakpoint-down(sm)  {
       padding: 20px;
     }
@@ -30,13 +27,20 @@
     border-style: solid;
     border-image-source: linear-gradient(90deg, #43bebc, #ebbb47);
     border-image-slice: 1;
-    padding: 40px;
+    padding: 40px 137px;
   }
 
   .voucher-form {
     .form-control {
       font-size: inherit;
       font-weight: inherit;
+    }
+
+
+
+    select {
+      background-color: $white;
+      min-width: 75%;
     }
 
     .form-error {

--- a/voucher/templates/enroll.html
+++ b/voucher/templates/enroll.html
@@ -9,16 +9,16 @@
         <div class="voucher-card">
             <h2>Confirm Course</h2>
             <hr/>
-            <p>Please confirm this is the course you are trying to enroll in::</p>
+            <p>Please confirm this is the course you are trying to enroll in:</p>
             <form method="post" enctype="multipart/form-data" class="voucher-form ">
                 {% csrf_token %}
-                <select name="coupon_version" id="coupon_version">
+                <select name="coupon_version" id="coupon_version" classname="form-control">
                     {% for choice in eligible_choices %}
                         <option value="{{ choice.0 }}">{{ choice.1 }}</option>
                     {% endfor %}
                 </select>
                 <hr/>
-                <div class="row justify-content-end">
+                <div class="text-right">
                     <button type="submit" class="btn btn-primary btn-light-blue">NEXT</button>
                 </div>
             </form>

--- a/voucher/templates/enroll.html
+++ b/voucher/templates/enroll.html
@@ -4,27 +4,24 @@
 {% block title %}{{ site_name }} | Boeing Course Enroll{% endblock %}
 
 {% block content %}
-  <div class="container voucher-container">
-    <h1>Boeing employee enrollment page</h1>
-    {% if eligible_choices|length == 1 %}
-      <p>You're eligible for the following course:</p>
-      <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        <input type="hidden" name="coupon_version" value="{{ eligible_choices.0.0 }}">
-        <button type="submit">{{ eligible_choices.0.1 }}</button>
-      </form>
-    {% else %}
-      <p>You're eligible for the following courses:</p>
-      <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        <label for="coupon_version">Courses:</label>
-        <select name="coupon_version" id="coupon_version">
-          {% for choice in eligible_choices %}
-            <option value="{{ choice.0 }}">{{ choice.1 }}</option>
-          {% endfor %}
-        </select>
-        <button type="submit">Redeem coupon</button>
-      </form>
-    {% endif %}
-  </div>
+    <div class="container voucher-container">
+        <h1>Boeing employee enrollment page</h1>
+        <div class="voucher-card">
+            <h2>Confirm Course</h2>
+            <hr/>
+            <p>Please confirm this is the course you are trying to enroll in::</p>
+            <form method="post" enctype="multipart/form-data" class="voucher-form ">
+                {% csrf_token %}
+                <select name="coupon_version" id="coupon_version">
+                    {% for choice in eligible_choices %}
+                        <option value="{{ choice.0 }}">{{ choice.1 }}</option>
+                    {% endfor %}
+                </select>
+                <hr/>
+                <div class="row justify-content-end">
+                    <button type="submit" class="btn btn-primary btn-light-blue">NEXT</button>
+                </div>
+            </form>
+        </div>
+    </div>
 {% endblock content %}

--- a/voucher/templates/enroll.html
+++ b/voucher/templates/enroll.html
@@ -19,7 +19,7 @@
                 </select>
                 <hr/>
                 <div class="text-right">
-                    <button type="submit" class="btn btn-primary btn-light-blue">NEXT</button>
+                    <button type="submit" class="btn btn-primary btn-light-blue">ENROLL</button>
                 </div>
             </form>
         </div>

--- a/voucher/templates/redeemed.html
+++ b/voucher/templates/redeemed.html
@@ -13,7 +13,7 @@
                 If you believe this is an error, please contact:
             </p>
             <p>
-                MIT xPrO Customer Support
+                MIT xPRO Customer Support
                 <br/>
                 <a href="mailto:xpro@mit.edu">xpro@mit.edu</a>
             </p>

--- a/voucher/templates/redeemed.html
+++ b/voucher/templates/redeemed.html
@@ -4,8 +4,20 @@
 {% block title %}{{ site_name }} | Boeing Course Enroll{% endblock %}
 
 {% block content %}
-  <div class="container voucher-container">
-    <h1>Boeing employee enrollment page</h1>
-    <p>The voucher you have submitted has already been redeemed. If you believe this is an error, please contact <a href="mailto:xpro@mit.edu">xpro@mit.edu</a></p>
-  </div>
+    <div class="container voucher-container">
+        <h1>Boeing employee enrollment page</h1>
+        <div class="voucher-card">
+            <h2>Upload Voucher</h2>
+            <hr/>
+            <p class="form-error">The voucher you have submitted has already been redeemed.
+                If you believe this is an error, please contact:
+            </p>
+            <p>
+                MIT xPrO Customer Support
+                <br/>
+                <a href="mailto:xpro@mit.edu">xpro@mit.edu</a>
+            </p>
+        </div>
+
+    </div>
 {% endblock content %}

--- a/voucher/templates/resubmit.html
+++ b/voucher/templates/resubmit.html
@@ -12,7 +12,7 @@
             <p class="form-error">We are sorry but we were not able to complete your enrollment.</p>
             <p>Please send the voucher as an attachment to:</p>
             <p>
-                MIT xPrO Customer Support
+                MIT xPRO Customer Support
                 <br/>
                 <a href="mailto:xpro@mit.edu">xpro@mit.edu</a>
             </p>

--- a/voucher/templates/resubmit.html
+++ b/voucher/templates/resubmit.html
@@ -4,8 +4,19 @@
 {% block title %}{{ site_name }} | Boeing Course Enroll{% endblock %}
 
 {% block content %}
-  <div class="container voucher-container">
-    <h1>Boeing employee enrollment page</h1>
-    <p>We are sorry but we were not able to complete your enrollment. Please send the voucher as an attachment to <a href="mailto:xpro@mit.edu">xpro@mit.edu</a></p>
-  </div>
+    <div class="container voucher-container">
+        <h1>Boeing employee enrollment page</h1>
+        <div class="voucher-card">
+            <h2>Upload Voucher</h2>
+            <hr/>
+            <p class="form-error">We are sorry but we were not able to complete your enrollment.</p>
+            <p>Please send the voucher as an attachment to:</p>
+            <p>
+                MIT xPrO Customer Support
+                <br/>
+                <a href="mailto:xpro@mit.edu">xpro@mit.edu</a>
+            </p>
+        </div>
+
+    </div>
 {% endblock content %}

--- a/voucher/templates/upload.html
+++ b/voucher/templates/upload.html
@@ -4,15 +4,21 @@
 {% block title %}{{ site_name }} | Boeing Enroll{% endblock %}
 
 {% block content %}
-  <div class="container voucher-container">
-    <h1>Boeing employee enrollment page</h1>
-    <p>Please upload your voucher to enroll in our courses</p>
-
-    <form method="post" enctype="multipart/form-data">
-      {% csrf_token %}
-      {{ form.as_p }}
-      <br>
-      <input type="submit" value="Submit">
-    </form>
-  </div>
+    <div class="container voucher-container">
+        <h1>Boeing employee enrollment page</h1>
+        <div class="voucher-card">
+                <h2>Upload Voucher</h2>
+                <hr/>
+                <p class="upload-gray">Please upload your voucher or sponsorship letter to enroll in our courses</p>
+                <form method="post" enctype="multipart/form-data" class="voucher-form upload-gray">
+                    {% csrf_token %}
+                    {{ form.as_p }}
+                    <hr/>
+                    <br>
+                    <div class="row justify-content-end">
+                        <input type="submit" value="SUBMIT" class="btn btn-primary btn-light-blue">
+                    </div>
+                </form>
+            </div>
+    </div>
 {% endblock content %}

--- a/voucher/templates/upload.html
+++ b/voucher/templates/upload.html
@@ -9,13 +9,13 @@
         <div class="voucher-card">
                 <h2>Upload Voucher</h2>
                 <hr/>
-                <p class="upload-gray">Please upload your voucher or sponsorship letter to enroll in our courses</p>
+                <p class="upload-gray">Please upload your voucher or sponsorship letter to enroll in our courses.</p>
                 <form method="post" enctype="multipart/form-data" class="voucher-form upload-gray">
                     {% csrf_token %}
                     {{ form.as_p }}
                     <hr/>
                     <br>
-                    <div class="row justify-content-end">
+                    <div class="text-right">
                         <input type="submit" value="SUBMIT" class="btn btn-primary btn-light-blue">
                     </div>
                 </form>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Closes #818

#### What's this PR do?
- Changes voucher page styling to resemble invision design

#### How should this be manually tested?
- Set the following .env variables to the same as used on CI:
```
VOUCHER_***
AWS_ACCESS_KEY_ID=
AWS_SECRET_ACCESS_KEY=
AWS_STORAGE_BUCKET_NAME=
```

Also set the following:
```
VOUCHER_COMPANY_ID=1
```

- Create a course run, product, product version, and 100% off single-use coupons by company (id=1) that will match a sample voucher pdf that I can send you.
- Go to `/voucher/upload`, check the page styling. 
- Upload the voucher
- You should end up at `/voucher/enroll`. Check the styling.
- Also go directly to `/voucher/resubmit` and `/voucher/redeemed`, and check the styling.

#### Screenshots (if appropriate)
<img width="1128" alt="Screen Shot 2019-07-12 at 2 50 50 PM" src="https://user-images.githubusercontent.com/187676/61151672-7aa1bf80-a4b4-11e9-8d04-06d7c4d19d0e.png">

<img width="953" alt="Screen Shot 2019-07-12 at 2 44 28 PM" src="https://user-images.githubusercontent.com/187676/61151690-82616400-a4b4-11e9-8c37-b9be5763dc4d.png">

<img width="951" alt="Screen Shot 2019-07-12 at 2 43 57 PM" src="https://user-images.githubusercontent.com/187676/61151704-8db48f80-a4b4-11e9-826f-c581929cdbc5.png">

<img width="1127" alt="Screen Shot 2019-07-12 at 2 52 44 PM" src="https://user-images.githubusercontent.com/187676/61151818-cfddd100-a4b4-11e9-9960-508acd0abaf1.png">


<img width="409" alt="Screen Shot 2019-07-12 at 2 54 43 PM" src="https://user-images.githubusercontent.com/187676/61151903-04ea2380-a4b5-11e9-9bee-5b6cfd356117.png">

<img width="370" alt="Screen Shot 2019-07-12 at 2 43 19 PM" src="https://user-images.githubusercontent.com/187676/61151917-0ddaf500-a4b5-11e9-8d04-1a089689ff3f.png">

<img width="366" alt="Screen Shot 2019-07-12 at 2 52 52 PM" src="https://user-images.githubusercontent.com/187676/61151926-13383f80-a4b5-11e9-82fe-64a1177502b7.png">

<img width="369" alt="Screen Shot 2019-07-12 at 2 43 48 PM" src="https://user-images.githubusercontent.com/187676/61151935-1d5a3e00-a4b5-11e9-8b2d-3692c11434b2.png">

