### PR TITLE
Django admin for version tables

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -206,7 +206,7 @@ class ProductVersionInline(admin.StackedInline):
 
 
 class ProductAdmin(admin.ModelAdmin):
-    """Admin for CouponRedemptions"""
+    """Admin for Product"""
 
     model = Product
     inlines = [ProductVersionInline]

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -94,22 +94,31 @@ class CouponPaymentVersionInline(admin.StackedInline):
     """Admin Inline for CouponPaymentVersion objects"""
 
     model = CouponPaymentVersion
-    extra = 1
+    readonly_fields = get_field_names(CouponPaymentVersion)
+    extra = 0
     show_change_link = True
+    can_delete = False
+    ordering = ("-created_on",)
+    min_num = 0
 
 
 class CouponVersionInline(admin.StackedInline):
     """Admin Inline for CouponVersion objects"""
 
     model = CouponVersion
-    extra = 1
+    readonly_fields = get_field_names(CouponVersion)
+    extra = 0
     show_change_link = True
+    can_delete = False
+    ordering = ("-created_on",)
+    min_num = 0
 
 
 class CouponAdmin(admin.ModelAdmin):
     """Admin for Coupons"""
 
     model = Coupon
+    save_on_top = True
     inlines = [CouponVersionInline]
 
 
@@ -117,6 +126,7 @@ class CouponPaymentAdmin(admin.ModelAdmin):
     """Admin for CouponPayments"""
 
     model = CouponPayment
+    save_on_top = True
     inlines = [CouponPaymentVersionInline]
 
 
@@ -124,12 +134,30 @@ class CouponPaymentVersionAdmin(admin.ModelAdmin):
     """Admin for CouponPaymentVersions"""
 
     model = CouponPaymentVersion
+    save_as = True
+    save_as_continue = False
+    save_on_top = True
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    class Media:
+        css = {"all": ("css/django-admin-version.css",)}
 
 
 class CouponVersionAdmin(admin.ModelAdmin):
     """Admin for CouponVersions"""
 
     model = CouponVersion
+    save_as = True
+    save_as_continue = False
+    save_on_top = True
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    class Media:
+        css = {"all": ("css/django-admin-version.css",)}
 
 
 class CouponSelectionAdmin(admin.ModelAdmin):
@@ -150,17 +178,38 @@ class CouponRedemptionAdmin(admin.ModelAdmin):
     model = CouponRedemption
 
 
-class ProductAdmin(admin.ModelAdmin):
-    """Admin for CouponRedemptions"""
-
-    model = Product
-
-
 class ProductVersionAdmin(admin.ModelAdmin):
     """Admin for ProductVersion"""
 
     model = ProductVersion
-    readonly_fields = ("text_id",)
+    save_as = True
+    save_as_continue = False
+    save_on_top = True
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    class Media:
+        css = {"all": ("css/django-admin-version.css",)}
+
+
+class ProductVersionInline(admin.StackedInline):
+    """Inline form for ProductVersion"""
+
+    model = ProductVersion
+    readonly_fields = get_field_names(ProductVersion)
+    extra = 0
+    show_change_link = True
+    can_delete = False
+    ordering = ("-created_on",)
+    min_num = 0
+
+
+class ProductAdmin(admin.ModelAdmin):
+    """Admin for CouponRedemptions"""
+
+    model = Product
+    inlines = [ProductVersionInline]
 
 
 class DataConsentUserAdmin(admin.ModelAdmin):

--- a/static/css/django-admin-version.css
+++ b/static/css/django-admin-version.css
@@ -1,0 +1,3 @@
+input[name="_continue"], input[name="_save"], .historylink {
+    display: none !important;
+}


### PR DESCRIPTION
Blocked until #795 is merged

#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #830 

#### What's this PR do?
On the admin page for the three version models (`CouponVersion`, `CouponPaymentVersion`, `ProductVersion`) you should not be allowed to edit or delete the model. You can edit and click 'Save as new' to persist your change as a newer version.

On the admin page for the related models `Coupon`, `CouponPayment`, and `Product` you should see the contents of the version model on the inline panel but none of the fields should be editable. There should be links to click to edit the inline models. Note that the Django admin doesn't seem to allow restricting the number of inline forms but they should be ordered so the most recent is first.

#### How should this be manually tested?
Try out editing via the Django admin. Please comment if you see anything that feels strange or is missing.
