### PR TITLE
fix comparison error when there is not start_data for course run

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -205,7 +205,9 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             (
                 course_run.start_date
                 for course_run in self.courseruns.all()
-                if course_run.live and course_run.start_date > now
+                if course_run.live
+                and course_run.start_date
+                and course_run.start_date > now
             ),
             default=None,
         )

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -234,7 +234,7 @@ def test_course_next_run_date():
     next_run_date should return the date of the CourseRun with the nearest future start date
     """
     course = CourseFactory.create()
-    CourseRunFactory.create_batch(2, course=course, past_start=True)
+    CourseRunFactory.create_batch(2, course=course, past_start=True, live=True)
     assert course.next_run_date is None
 
     now = now_in_utc()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #643 

#### What's this PR do?
fix comparison error when there is not start_data for course run

#### How should this be manually tested?

- Goto admin/courses/courserun.
- Edit any course run.
- Remove start datetime.
- Save it.
- Reload the /catalog page
- No error should raise
