### PR TITLE
#648 Next run date check for None before comparison

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -205,7 +205,9 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             (
                 course_run.start_date
                 for course_run in self.courseruns.all()
-                if course_run.live and course_run.start_date > now
+                if course_run.live
+                and course_run.start_date
+                and course_run.start_date > now
             ),
             default=None,
         )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#648

#### What's this PR do?
Adds a check for `None` in `next_run_date` for courses.

#### How should this be manually tested?
On any course that has live course runs, set `start_date` to null on all the course runs. Go to catalog page, the course should not be displayed in the catalog and no exceptions should be thrown.
