### PR TITLE
Remove pep8

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,12 +1,6 @@
 [pytest]
-addopts = --cov . --pep8 --pylint --cov-report term --cov-report html --ds=mitxpro.settings --reuse-db
+addopts = --cov . --pylint --cov-report term --cov-report html --ds=mitxpro.settings --reuse-db
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
-pep8ignore =
-   */migrations/* ALL
-   W503
-   E203
-   E501
-pep8maxlinelength = 119
 filterwarnings =
     error
     ignore::DeprecationWarning

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -17,7 +17,6 @@ pytest==4.4.1
 pytest-cov>=2.6.1
 pytest-django
 pytest-env
-pytest-pep8
 pytest-mock
 pytest-pylint==0.12.3
 pytest-lazy-fixture==0.5.1


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes pep8. With `black` and `pylint` we should be well covered already with linting.

#### How should this be manually tested?
Tests should pass
