### PR TITLE
Use next_run_id for a default for the checkout page course run selection

### DIFF
--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -46,6 +46,13 @@ export const calcSelectedRunIds = (item: BasketItem): { [number]: number } => {
     }
   }
 
+  const selectedRunIds = {}
+  for (const course of item.courses) {
+    if (course.next_run_id) {
+      selectedRunIds[course.id] = course.next_run_id
+    }
+  }
+
   const courseLookup = {}
   for (const course of item.courses) {
     for (const run of course.courseruns) {
@@ -53,7 +60,6 @@ export const calcSelectedRunIds = (item: BasketItem): { [number]: number } => {
     }
   }
 
-  const selectedRunIds = {}
   for (const runId of item.run_ids) {
     const courseId = courseLookup[runId]
 

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -359,6 +359,17 @@ describe("CheckoutPage", () => {
       }
       assert.deepEqual(calcSelectedRunIds(item), expected)
     })
+
+    it("uses the next_run_id for a default selected course run", () => {
+      const item = basket.items[0]
+      item.type = PRODUCT_TYPE_PROGRAM
+      const expected = {}
+      for (const course of item.courses) {
+        expected[course.id] = course.next_run_id
+      }
+      item.run_ids = []
+      assert.deepEqual(calcSelectedRunIds(item), expected)
+    })
   })
 
   //

--- a/static/js/factories/course.js
+++ b/static/js/factories/course.js
@@ -34,19 +34,25 @@ export const makeCourseRun = (): CourseRun => ({
 })
 
 const genCourseId = incrementer()
-export const makeBaseCourse = (): BaseCourse => ({
+const makeBaseCourse = (nextRunId: ?number): BaseCourse => ({
   // $FlowFixMe
   id:            genCourseId.next().value,
   title:         casual.text,
   description:   casual.text,
   thumbnail_url: casual.url,
-  readable_id:   casual.word
+  readable_id:   casual.word,
+  next_run_id:   nextRunId
 })
 
-export const makeCourse = (): Course => ({
-  ...makeBaseCourse(),
-  courseruns: range(0, 3).map(() => makeCourseRun())
-})
+export const makeCourse = (): Course => {
+  const runs = range(0, 3).map(() => makeCourseRun())
+  const baseCourse = makeBaseCourse(runs[1].id)
+
+  return {
+    ...baseCourse,
+    courseruns: runs
+  }
+}
 
 const genProgramId = incrementer()
 export const makeProgram = (): Program => ({
@@ -58,10 +64,13 @@ export const makeProgram = (): Program => ({
   readable_id:   casual.word.concat(genReadableId.next().value)
 })
 
-export const makeCourseRunDetail = (): CourseRunDetail => ({
-  ...makeCourseRun(),
-  course: makeBaseCourse()
-})
+export const makeCourseRunDetail = (): CourseRunDetail => {
+  const run = makeCourseRun()
+  return {
+    ...makeCourseRun(),
+    course: makeBaseCourse(run.id)
+  }
+}
 
 export const makeCourseRunEnrollment = (): CourseRunEnrollment => ({
   run: makeCourseRunDetail()

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -16,7 +16,8 @@ export type BaseCourse = {
   title: string,
   description: ?string,
   thumbnail_url: string,
-  readable_id: ?string
+  readable_id: ?string,
+  next_run_id: ?number,
 }
 
 export type Course = BaseCourse & {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #421 

#### What's this PR do?
Use the next unexpired run as a default option for selected runs in the checkout page

#### How should this be manually tested?
Go to `/checkout/?product=???` for a certain product. You should see default options selected on the checkout page. You should be able to change the runs as before and the changes should persist.