### PR TITLE
Update audit table serialization for program and course run enrollments

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -447,7 +447,7 @@ class CourseRunEnrollment(EnrollmentModel):
         return cls.objects.filter(user=user, run__course__program=program)
 
     def to_dict(self):
-        return {**super().to_dict(), "readable_id": self.run.courseware_id}
+        return {**super().to_dict(), "text_id": self.run.courseware_id}
 
     def __str__(self):
         return f"CourseRunEnrollment for {self.user} and {self.run}"
@@ -491,7 +491,7 @@ class ProgramEnrollment(EnrollmentModel):
         )
 
     def to_dict(self):
-        return {**super().to_dict(), "readable_id": self.program.readable_id}
+        return {**super().to_dict(), "text_id": self.program.readable_id}
 
     def __str__(self):
         return f"ProgramEnrollment for {self.user} and {self.program}"

--- a/courses/models.py
+++ b/courses/models.py
@@ -393,7 +393,13 @@ class EnrollmentModel(TimestampedModel, AuditableModel):
         raise NotImplementedError
 
     def to_dict(self):
-        return serialize_model_object(self)
+        return {
+            **serialize_model_object(self),
+            "username": self.user.username,
+            "full_name": self.user.name,
+            "email": self.user.email,
+            "company_name": self.company.name if self.company else None,
+        }
 
     def deactivate_and_save(self, change_status, no_user=False):
         """Sets an enrollment to inactive, sets the status, and saves"""
@@ -440,6 +446,9 @@ class CourseRunEnrollment(EnrollmentModel):
         """
         return cls.objects.filter(user=user, run__course__program=program)
 
+    def to_dict(self):
+        return {**super().to_dict(), "readable_id": self.run.courseware_id}
+
     def __str__(self):
         return f"CourseRunEnrollment for {self.user} and {self.run}"
 
@@ -480,6 +489,9 @@ class ProgramEnrollment(EnrollmentModel):
         return CourseRunEnrollment.get_program_run_enrollments(
             user=self.user, program=self.program
         )
+
+    def to_dict(self):
+        return {**super().to_dict(), "readable_id": self.program.readable_id}
 
     def __str__(self):
         return f"ProgramEnrollment for {self.user} and {self.program}"

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -410,7 +410,7 @@ def test_audit(user, is_program, has_company):
         "full_name": enrollment.user.name,
         "id": enrollment.id,
         "order": enrollment.order.id,
-        "readable_id": enrollment.program.readable_id
+        "text_id": enrollment.program.readable_id
         if is_program
         else enrollment.run.courseware_id,
         "updated_on": format_as_iso8601(enrollment.updated_on),

--- a/mitxpro/test_utils.py
+++ b/mitxpro/test_utils.py
@@ -104,3 +104,14 @@ def create_tempfile_csv(rows_iter):
         return SimpleUploadedFile(
             f.name, user_csv.read().encode("utf8"), content_type="application/csv"
         )
+
+
+def format_as_iso8601(time):
+    """Helper function to format datetime with the Z at the end"""
+    # Can't use datetime.isoformat() because format is slightly different from this
+    iso_format = "%Y-%m-%dT%H:%M:%S"
+    formatted_time = time.strftime(iso_format)
+    if time.microsecond:
+        miniseconds_format = ".%f"
+        formatted_time += time.strftime(miniseconds_format)[:4]
+    return formatted_time + "Z"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #690 

#### What's this PR do?
Adds information to the `CourseRunEnrollment` and `ProgramEnrollment` audit tables

#### How should this be manually tested?
Check out and add an enrollment. Check the audit table for that enrollment and verify that the fields listed in the linked issue are part of the audit table now.
