### PR TITLE
asadiqbal08/mitxpro- Send enrollment/unenrollment emails

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -7,7 +7,11 @@ from django.conf import settings
 from django.urls import reverse
 
 from mail import api
-from mail.constants import EMAIL_BULK_ENROLL, EMAIL_COURSE_RUN_ENROLLMENT
+from mail.constants import (
+    EMAIL_BULK_ENROLL,
+    EMAIL_COURSE_RUN_ENROLLMENT,
+    EMAIL_COURSE_RUN_UNENROLLMENT,
+)
 from ecommerce.models import ProductCouponAssignment
 
 log = logging.getLogger()
@@ -93,3 +97,25 @@ def send_course_run_enrollment_email(enrollment):
         )
     except:  # pylint: disable=bare-except
         log.exception("Error sending enrollment success email")
+
+
+def send_course_run_unenrollment_email(enrollment):
+    """
+    Notify the user of successful unenrollment for a course run
+
+    Args:
+        enrollment (CourseRunEnrollment): the enrollment for which to send the email
+    """
+    try:
+        user = enrollment.user
+        api.send_message(
+            api.message_for_recipient(
+                user.email,
+                api.context_for_user(
+                    user=user, extra_context={"enrollment": enrollment}
+                ),
+                EMAIL_COURSE_RUN_UNENROLLMENT,
+            )
+        )
+    except Exception as exp:  # pylint: disable=broad-except
+        log.exception("Error sending unenrollment success email: %s", exp)

--- a/mail/constants.py
+++ b/mail/constants.py
@@ -4,6 +4,7 @@ EMAIL_VERIFICATION = "verification"
 EMAIL_PW_RESET = "password_reset"
 EMAIL_BULK_ENROLL = "bulk_enroll"
 EMAIL_COURSE_RUN_ENROLLMENT = "course_run_enrollment"
+EMAIL_COURSE_RUN_UNENROLLMENT = "course_run_unenrollment"
 
 EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_VERIFICATION: "Verify Email",

--- a/mail/templates/course_run_enrollment/subject.txt
+++ b/mail/templates/course_run_enrollment/subject.txt
@@ -1,1 +1,1 @@
-You have been enrolled in {{ enrollment.run.course.title }}
+You have been enrolled in {{ enrollment.run }}

--- a/mail/templates/course_run_unenrollment/body.html
+++ b/mail/templates/course_run_unenrollment/body.html
@@ -9,7 +9,7 @@
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
                       <p style="margin: 0 0 10px;">
-                        You have been enrolled in {{ enrollment.run }}. The course should now appear on your <a href="{{ base_url }}{% url 'user-dashboard' %}">{{ site_name }} dashboard</a>.
+                        You have been unenrolled in {{ enrollment.run }} starting {{ run.start_date|date:"F j, Y"}}. The course will no longer appear on your <a href="{{ base_url }}{% url 'user-dashboard' %}">{{ site_name }} dashboard</a>.
                       </p>
                   </td>
               </tr>

--- a/mail/templates/course_run_unenrollment/subject.txt
+++ b/mail/templates/course_run_unenrollment/subject.txt
@@ -1,0 +1,1 @@
+You have been unenrolled in {{ enrollment.run }}


### PR DESCRIPTION
Task: #835 

#### UnEnrollment Email:

<img width="607" alt="Screen Shot 2019-07-24 at 1 45 06 PM" src="https://user-images.githubusercontent.com/7334669/61778998-57aece00-ae19-11e9-9734-3f73ebbc3ecb.png">


#### Acceptance Criteria:

- [ ] When refunding an enrollment, send an unenrollment email
- [ ] When deferring an enrollment, send an unenrollment email for the original course run and an enrollment email for the new one. They should both go to the same user. 
- [ ] When transferrring an enrollment, send an unenrollment email to the `from-user` and an enrollment email to the `to-user` 
- [ ] for enrollment, use the template at https://github.com/mitodl/mitxpro/blob/master/mail/templates/course_run_enrollment/body.html but update it to include the course run start date. 
- [ ] for unenrollment, use a similar template but change the text to read: "You have been unenrolled from {{ enrollment.run.course.title }} starting {{ enrollment.run.start_date}}. The course will no longer appear on your <a href="{{ base_url }}{% url 'user-dashboard' %}">{{ site_name }} dashboard</a>.

#### Out of Scope

- We still don't have the necessary code for automatically unenrolling the user in open edX.


#### Testing Instructions:
- We need to run the following commands that are listed under [/mitxpro/courses/](https://github.com/mitodl/mitxpro/tree/master/courses/management/commands)
- For enrolling in course / program, a person can set the price to `0` and go through the checkout process. 
- Email should be send according to the acceptance criteria above. 

###### I have updated the email body+subject of both (enrollment + unenrollment templates) to show **enrollment run title** instead of **course/program title**. The reason is that, when defering an enrollment `--from-run` to `--to-run` then we send the both `enrollment + unenrollemt` to the same user so have course/program title was not meaningful to distinguish them. 


#### I did not see the tests for the existing commands. I think, we should create a separate story for adding tests. 
