### PR TITLE
display message when account already exists

### DIFF
--- a/static/js/containers/pages/register/RegisterEmailPage.js
+++ b/static/js/containers/pages/register/RegisterEmailPage.js
@@ -37,6 +37,8 @@ type Props = {
 const emailNotificationText = (email: string): string =>
   `We sent an email to ${email}. Please verify your address to continue.`
 
+const accountExistsNotificationText = (email: string): string =>
+  `You have already have an account with ${email}. Enter password to signin.`
 export class RegisterEmailPage extends React.Component<Props> {
   async onSubmit(
     { email, recaptcha }: RegisterEmailFormValues,
@@ -65,6 +67,14 @@ export class RegisterEmailPage extends React.Component<Props> {
         })
         history.push(routes.login.begin)
       } else if (state === STATE_LOGIN_PASSWORD) {
+        addUserNotification({
+          "account-exists": {
+            type:  ALERT_TYPE_TEXT,
+            props: {
+              text: accountExistsNotificationText(email)
+            }
+          }
+        })
         history.push(routes.login.password)
       } else if (errors.length > 0) {
         setErrors({

--- a/static/js/containers/pages/register/RegisterEmailPage_test.js
+++ b/static/js/containers/pages/register/RegisterEmailPage_test.js
@@ -74,7 +74,7 @@ describe("RegisterEmailPage", () => {
   })
 
   it("handles onSubmit for an existing user password login", async () => {
-    const { inner } = await renderPage()
+    const { inner, store } = await renderPage()
 
     helper.handleRequestStub.returns({
       body: {
@@ -97,6 +97,17 @@ describe("RegisterEmailPage", () => {
     })
     sinon.assert.notCalled(setErrorsStub)
     sinon.assert.calledWith(setSubmittingStub, false)
+
+    const { ui } = store.getState()
+
+    assert.deepEqual(ui.userNotifications, {
+      "account-exists": {
+        type:  ALERT_TYPE_TEXT,
+        props: {
+          text: `You have already have an account with ${email}. Enter password to signin.`
+        }
+      }
+    })
   })
 
   it("handles onSubmit for a confirmation email", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #600 

#### What's this PR do?
Display message when user has already account with provided email.

#### How should this be manually tested?

- Try to create an account with an existing account email.
- You should see a message.

#### Screenshots (if appropriate)
<img width="1251" alt="Screen Shot 2019-07-19 at 2 41 36 PM" src="https://user-images.githubusercontent.com/4245618/61526177-581f2180-aa33-11e9-8514-75f28afb7884.png">
