### PR TITLE
#783 React should scroll to top on page load

### DIFF
--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -4,6 +4,7 @@ import { Provider } from "react-redux"
 
 import App from "./containers/App"
 import withTracker from "./util/withTracker"
+import ScrollToTop from "./components/ScrollToTop"
 
 export default class Root extends React.Component {
   props: {
@@ -17,7 +18,9 @@ export default class Root extends React.Component {
     return (
       <div>
         <Provider store={store}>
-          <ReactRouter history={history}>{children}</ReactRouter>
+          <ReactRouter history={history}>
+            <ScrollToTop>{children}</ScrollToTop>
+          </ReactRouter>
         </Provider>
       </div>
     )

--- a/static/js/components/ScrollToTop.js
+++ b/static/js/components/ScrollToTop.js
@@ -1,0 +1,16 @@
+import React from "react"
+import { withRouter } from "react-router"
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0)
+    }
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+export default withRouter(ScrollToTop)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#783 

#### What's this PR do?
Adds a component to the router which, when navigation occurs (page loads), scrolls the window to the top of the page.

#### How should this be manually tested?
Go to any page that is rendered by react. Make sure window height is small enough to enable vertical scrolling. Navigate to any other react rendered page, the screen should scroll to top of the content. An example is going to "Create Account" link, scrolling to the bottom till the form is barely visible, enter an existing email address. The form upon submission should try to redirect to the sign in form. The screen should scroll to top.

You can also verify by switching between the profile and dashboard pages given viewport height is small enough to enable vertical scrolling.