### PR TITLE
#885 Use catalog_details for featured product card

### DIFF
--- a/cms/templates/partials/featured_card.html
+++ b/cms/templates/partials/featured_card.html
@@ -75,8 +75,8 @@
           </label>
           <div id="{{ collapse_id }}" class="collapse">
             <div class="details-body">
-              {% if courseware_page.description %}
-              <div class="description">{{ courseware_page.description|richtext }}</div>
+              {% if courseware_page.catalog_details %}
+                <div class="description">{{ courseware_page.catalog_details|richtext }}</div>
               {% endif %}
               {% if object_type == "program" %}
               <ul class="program-course-links">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#885 

#### What's this PR do?
Updates featured product card to use `catalog_details` instead of `description` (which was previously being used). 

#### How should this be manually tested?
Go to the catalog page, the featured product card should show the same catalog description that it shows for the normal card for that product (ensure you have set a `courseware_page.catalog_details` different from the `courseware_page.description` so you can see the different). 
