### PR TITLE
#882 display more dates on program page

### DIFF
--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -7,21 +7,41 @@
           <span class="title">START DATE</span>
           <span class="text">{{ page.product.first_unexpired_run.start_date|date:"F j, Y" }}</span>
           {% if page.product.unexpired_runs|length > 1 %}
-            <span class="dates-link">
-              <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
-                data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this course"
-                data-content="
-                  <div>
-                    <p>Click below to enroll in one of these dates</p>
-                  </div>
-                  {% for course_run in page.product.unexpired_runs %}
+            {% with course_runs=page.product.unexpired_runs %}
+              <span class="dates-link">
+                <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                  data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this course"
+                  data-content="
                     <div>
-                      <a class='date-link' href='{% url 'checkout-page' %}?product={{ course_run.products.first.id }}' data-id='{{ course_run.id }}'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                      <p>Click below to enroll in one of these dates</p>
                     </div>
-                  {% endfor %}">
-                More Dates
-              </a>
-            </span>
+                    {% for course_run in course_runs %}
+                      <div>
+                        <a class='date-link' href='{% url 'checkout-page' %}?product={{ course_run.products.first.id }}'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                      </div>
+                    {% endfor %}">
+                  More Dates
+                </a>
+              </span>
+            {% endwith %}
+          {% elif page.product.first_course_unexpired_runs|length > 1 %}
+            {% with course_runs=page.product.first_course_unexpired_runs product_id=page.product.products.first.id %}
+              <span class="dates-link">
+                <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                  data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this program"
+                  data-content="
+                    <div>
+                      <p>Click below to enroll in one of these dates</p>
+                    </div>
+                    {% for course_run in course_runs %}
+                      <div>
+                        <a class='date-link' href='{% url 'checkout-page' %}?product={{ product_id }}&preselect={{ course_run.id }}'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                      </div>
+                    {% endfor %}">
+                  More Dates
+                </a>
+              </span>
+            {% endwith %}
           {% endif %}
         </li>
       {% endif %}

--- a/courses/models.py
+++ b/courses/models.py
@@ -167,6 +167,13 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         )
 
     @property
+    def first_course_unexpired_runs(self):
+        """Gets the unexpired course runs for the first (earliest) course in this program"""
+        first_course_run = self.first_unexpired_run
+        if first_course_run:
+            return first_course_run.course.unexpired_runs
+
+    @property
     def text_id(self):
         """ Gets the readable_id"""
         return self.readable_id

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -66,6 +66,30 @@ def test_program_next_run_date():
     assert program.next_run_date == future_dates[0]
 
 
+def test_program_first_course_unexpired_runs():
+    """
+    first_course_unexpired_runs should return the unexpired course runs of the earliest course
+    """
+    program = ProgramFactory.create()
+    course = CourseFactory.create(live=True, program=program)
+    CourseRunFactory.create_batch(
+        2,
+        course=course,
+        end_date__before_now=True,
+        enrollment_start__before_now=True,
+        enrollment_end__before_now=True,
+        live=True,
+    )
+    CourseRunFactory.create_batch(
+        3,
+        course=course,
+        enrollment_start__before_now=True,
+        enrollment_end__after_now=True,
+        live=True,
+    )
+    assert len(program.first_course_unexpired_runs) == 3
+
+
 def test_program_current_price():
     """
     current_price should return the price of the latest product version if it exists

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -38,7 +38,10 @@ type State = {
   errors: null
 }
 
-export const calcSelectedRunIds = (item: BasketItem): { [number]: number } => {
+export const calcSelectedRunIds = (
+  item: BasketItem,
+  preselectId: number = 0
+): { [number]: number } => {
   if (item.type === "courserun") {
     const course = item.courses[0]
     return {
@@ -58,6 +61,12 @@ export const calcSelectedRunIds = (item: BasketItem): { [number]: number } => {
     for (const run of course.courseruns) {
       courseLookup[run.id] = course.id
     }
+  }
+
+  // Try to preselect a run if the ID was given
+  if (preselectId) {
+    const courseId = courseLookup[preselectId]
+    selectedRunIds[courseId] = preselectId
   }
 
   for (const runId of item.run_ids) {
@@ -81,8 +90,9 @@ export class CheckoutPage extends React.Component<Props, State> {
     } = this.props
     const params = queryString.parse(search)
     return {
-      productId:  parseInt(params.product),
-      couponCode: params.code
+      productId:   parseInt(params.product),
+      preselectId: parseInt(params.preselect),
+      couponCode:  params.code
     }
   }
 
@@ -204,8 +214,8 @@ export class CheckoutPage extends React.Component<Props, State> {
     const coupon = basket.coupons.find(coupon =>
       coupon.targets.includes(item.id)
     )
-    const { couponCode } = this.getQueryParams()
-    const selectedRuns = calcSelectedRunIds(item)
+    const { couponCode, preselectId } = this.getQueryParams()
+    const selectedRuns = calcSelectedRunIds(item, preselectId)
 
     return (
       <CheckoutForm

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -89,6 +89,25 @@ describe("CheckoutPage", () => {
     assert.equal(inner.find("CheckoutForm").prop("couponCode"), code)
   })
 
+  it("parses the preselect ID from the query parameter and verifies it exists in selected runs", async () => {
+    const course = basket.items[0].courses[0]
+    const courseId = course.id
+    const courseRunId = course.courseruns[0].id
+    const { inner } = await renderPage(
+      {},
+      {
+        location: {
+          search: `product=4567&preselect=${courseRunId}`
+        }
+      }
+    )
+    // Verify that the preselected courseRunId is included against the courseId in selectedRuns
+    assert.equal(
+      inner.find("CheckoutForm").prop("selectedRuns")[courseId],
+      courseRunId
+    )
+  })
+
   it("submits the coupon code", async () => {})
   ;[true, false].forEach(hasCouponCode => {
     [true, false].forEach(hasError => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#882 

#### What's this PR do?
Enables "more dates" to be displayed on the program page with  dates from the earliest course in the program. ~~runs/products loaded appropriately for the first (one with the earliest course run) course in the program. Clicking on the start date in the pop up should display checkout page with the correct course run loaded in cart.~~
Clicking on the start date in the pop up should display the program checkout page with the appropriate course run (for which the date was clicked to get here) already selected for that specific course.

#### How should this be tested?
Set up a program with different courses. The first course (one with the earliest unexpired course run) should have multiple course runs which are live, have a valid (unexpired) enrollment time span. When you visit the program detail page the metadata tiles should display the start date of the earliest course run of the earliest course in the program. It should also show "more dates" link/popup which should be populated with all the other unexpired run dates for the earliest course. Clicking on any of the dates should bring up the program checkout page with the appropriate course run already selected (for which the date that was clicked previously).



#### Screenshots (if appropriate)
![Screenshot from 2019-07-24 17-05-35](https://user-images.githubusercontent.com/45350418/61792087-54294000-ae35-11e9-9956-028cbde70494.png)
