### PR TITLE
Changed refund command to properly create order audit record

### DIFF
--- a/courses/management/commands/refund_enrollment.py
+++ b/courses/management/commands/refund_enrollment.py
@@ -62,7 +62,7 @@ class Command(EnrollmentChangeCommand):
 
         if enrollment.order:
             enrollment.order.status = Order.REFUNDED
-            enrollment.order.save()
+            enrollment.order.save_and_log(None)
             success_msg += "\nOrder status set to '{}' (order id: {})".format(
                 enrollment.order.status, enrollment.order.id
             )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #894 

#### What's this PR do?
Fixes bug where the `refund_enrollment` command did not call the correct save method that automatically adds an audit record when changes are made

#### How should this be manually tested?
Refund some enrollment, then check the OrderAudit table in Django admin to make sure a record was created that reflects the change of status
