### PR TITLE
#908 Wagtail admin generated URLs for child pages

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -16,6 +16,7 @@ from wagtail.core import blocks
 from wagtail.core.blocks import PageChooserBlock, RawHTMLBlock
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable, Page
+from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.models import Image
 from wagtail.images.edit_handlers import ImageChooserPanel
@@ -635,6 +636,28 @@ class CourseProgramChildPage(Page):
             self.title = self.__class__._meta.verbose_name.title()
         self.slug = slugify("{}-{}".format(self.get_parent().id, self.title))
         super().save(*args, **kwargs)
+
+    def get_url_parts(self, request=None):
+        """
+        Override how the url is generated for course/program child pages
+        """
+        # Verify the page is routable
+        url_parts = super().get_url_parts(request=request)
+
+        if not url_parts:
+            return None
+
+        site_id, site_root, parent_path = self.get_parent().specific.get_url_parts(
+            request=request
+        )
+        page_path = ""
+
+        # Depending on whether we have trailing slashes or not, build the correct path
+        if WAGTAIL_APPEND_SLASH:
+            page_path = "{}{}/".format(parent_path, self.slug)
+        else:
+            page_path = "{}/{}".format(parent_path, self.slug)
+        return (site_id, site_root, page_path)
 
     def serve(self, request, *args, **kwargs):
         """

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -5,6 +5,7 @@ import pytest
 import factory
 
 from django.urls import resolve
+from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 
 from cms.factories import (
     ResourcePageFactory,
@@ -339,6 +340,49 @@ def test_program_page_testimonials():
         assert testimonial.value.get("title") == "title"
         assert testimonial.value.get("image").title == "image"
         assert testimonial.value.get("quote") == "quote"
+
+
+def test_child_page_unroutable():
+    """
+    Child page should not provide a URL if it unroutable
+    """
+    home_page = HomePageFactory.create()
+    child_page = TextSectionFactory.create(parent=home_page)
+    assert not child_page.get_full_url()
+
+
+def test_program_page_child_page_url():
+    """
+    The live URL of child pages should be of the correct format:
+    <site_root>/programs/<program__readable_id>/<child_page__slug>
+    """
+    program_page = ProgramPageFactory.create(program__readable_id="program:test")
+    child_page = TextSectionFactory.create(parent=program_page)
+
+    program_page_url = program_page.get_full_url()
+    child_page_url = child_page.get_full_url()
+
+    if WAGTAIL_APPEND_SLASH:
+        assert child_page_url == "{}{}/".format(program_page_url, child_page.slug)
+    else:
+        assert child_page_url == "{}/{}".format(program_page_url, child_page.slug)
+
+
+def test_course_page_child_page_url():
+    """
+    The live URL of child pages should be of the correct format:
+    <site_root>/courses/<course__readable_id>/<child_page__slug>
+    """
+    course_page = CoursePageFactory.create(course__readable_id="course:test")
+    child_page = TextSectionFactory.create(parent=course_page)
+
+    course_page_url = course_page.get_full_url()
+    child_page_url = child_page.get_full_url()
+
+    if WAGTAIL_APPEND_SLASH:
+        assert child_page_url == "{}{}/".format(course_page_url, child_page.slug)
+    else:
+        assert child_page_url == "{}/{}".format(course_page_url, child_page.slug)
 
 
 def test_course_page_for_teams():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#908 

#### What's this PR do?
Updates the `CourseProgramChildPage` class to generate the correct URL in the form:
`/courses|programs/<readable_id>/<child_page_slug>`

#### How should this be manually tested?
Go to wagtail admin (cms) and click on `live` links of any course/program child pages. The **link** should be of the format described above (please bear in mind that most of the child pages are right now set up to raise a 404 on these links, so that is the expected behavior).