### PR TITLE
Added tagging for sentry errors to review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -119,6 +119,10 @@
       "description": "Google analytics tracking ID",
       "required": false
     },
+    "HEROKU_APP_NAME": {
+      "description": "The name of the review app",
+      "required": false
+    },
     "HOST_IP": {
       "description": null,
       "required": false

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -42,6 +42,11 @@ ENVIRONMENT = get_string(
     required=True,
 )
 
+# this is only available to heroku review apps
+HEROKU_APP_NAME = get_string(
+    "HEROKU_APP_NAME", None, description="The name of the review app"
+)
+
 ALLOWED_HOSTS = ["*"]
 
 SECURE_SSL_REDIRECT = get_bool(
@@ -515,6 +520,9 @@ sentry_sdk.init(
         LoggingIntegration(level=SENTRY_LOG_LEVEL),
     ],
 )
+with sentry_sdk.configure_scope() as scope:
+    if HEROKU_APP_NAME:
+        scope.set_tag("review_app_name", HEROKU_APP_NAME)
 
 # server-status
 STATUS_TOKEN = get_string(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #367 

#### What does this PR do?
Adds tagging of review apps so we can tell when a "CI" error is really a PR app.
Example:
https://sentry.io/organizations/mit-office-of-digital-learning/issues/1127338602/?project=1413655&query=is%3Aunresolved&statsPeriod=14d

#### How should this be manually tested?
Open a shell in heroku and raise an error so it logs to sentry:

```python
import sentry_sdk                                                                                                                                                                
sentry_sdk.capture_exception(Exception("test")) 
```

Verify it shows up on sentry with the review app name tagged.