### PR TITLE
show past enrollments on dashboard

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -6,9 +6,15 @@ from collections import namedtuple
 from courses.models import CourseRunEnrollment, ProgramEnrollment
 from mitxpro.utils import partition
 
-
 UserEnrollments = namedtuple(
-    "UserEnrollments", ["programs", "program_runs", "non_program_runs"]
+    "UserEnrollments",
+    [
+        "programs",
+        "past_programs",
+        "program_runs",
+        "non_program_runs",
+        "past_non_program_runs",
+    ],
 )
 
 
@@ -45,8 +51,18 @@ def get_user_enrollments(user):
             course_run_enrollment.run.course_id in program_course_ids
         ),
     )
+    program_enrollments, past_program_enrollments = partition(
+        program_enrollments, lambda program_enrollment: program_enrollment.is_ended
+    )
+    non_program_run_enrollments, past_non_program_run_enrollments = partition(
+        non_program_run_enrollments,
+        lambda non_program_run_enrollment: non_program_run_enrollment.is_ended,
+    )
+
     return UserEnrollments(
         programs=program_enrollments,
+        past_programs=past_program_enrollments,
         program_runs=program_run_enrollments,
         non_program_runs=non_program_run_enrollments,
+        past_non_program_runs=past_non_program_run_enrollments,
     )

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1,4 +1,6 @@
 """Courses API tests"""
+from datetime import timedelta
+
 import pytest
 import factory
 
@@ -11,19 +13,37 @@ from courses.factories import (
 )
 
 # pylint: disable=redefined-outer-name
+from mitxpro.utils import now_in_utc
 
 
 @pytest.mark.django_db
 def test_get_user_enrollments(user):
     """Test that get_user_enrollments returns an object with a user's program and course enrollments"""
+    past_date = now_in_utc() - timedelta(days=1)
     program = ProgramFactory.create()
+    past_program = ProgramFactory.create()
+
     program_course_runs = CourseRunFactory.create_batch(3, course__program=program)
+    past_program_course_runs = CourseRunFactory.create_batch(
+        3, end_date=past_date, course__program=past_program
+    )
     non_program_course_runs = CourseRunFactory.create_batch(2, course__program=None)
-    all_course_runs = program_course_runs + non_program_course_runs
+    past_non_program_course_runs = CourseRunFactory.create_batch(
+        2, end_date=past_date, course__program=None
+    )
+    all_course_runs = (
+        program_course_runs
+        + past_program_course_runs
+        + non_program_course_runs
+        + past_non_program_course_runs
+    )
     course_run_enrollments = CourseRunEnrollmentFactory.create_batch(
         len(all_course_runs), run=factory.Iterator(all_course_runs), user=user
     )
     program_enrollment = ProgramEnrollmentFactory.create(program=program, user=user)
+    past_program_enrollment = ProgramEnrollmentFactory.create(
+        program=past_program, user=user
+    )
     # Add a non-active enrollment so we can confirm that it isn't returned
     CourseRunEnrollmentFactory.create(user=user, active=False)
 
@@ -33,11 +53,12 @@ def test_get_user_enrollments(user):
 
     user_enrollments = get_user_enrollments(user)
     assert list(user_enrollments.programs) == [program_enrollment]
+    assert list(user_enrollments.past_programs) == [past_program_enrollment]
     assert sorted(list(user_enrollments.program_runs), key=key_func) == sorted(
         [
             run_enrollment
             for run_enrollment in course_run_enrollments
-            if run_enrollment.run in program_course_runs
+            if run_enrollment.run in program_course_runs + past_program_course_runs
         ],
         key=key_func,
     )
@@ -46,6 +67,15 @@ def test_get_user_enrollments(user):
             run_enrollment
             for run_enrollment in course_run_enrollments
             if run_enrollment.run in non_program_course_runs
+        ],
+        key=key_func,
+    )
+
+    assert sorted(list(user_enrollments.past_non_program_runs), key=key_func) == sorted(
+        [
+            run_enrollment
+            for run_enrollment in course_run_enrollments
+            if run_enrollment.run in past_non_program_course_runs
         ],
         key=key_func,
     )

--- a/courses/models.py
+++ b/courses/models.py
@@ -435,6 +435,11 @@ class CourseRunEnrollment(EnrollmentModel):
     class Meta:
         unique_together = ("user", "run", "order")
 
+    @property
+    def is_ended(self):
+        """Return True, if run associated with enrollment is ended."""
+        return self.run.is_past
+
     @classmethod
     def get_audit_class(cls):
         return CourseRunEnrollmentAudit
@@ -481,6 +486,11 @@ class ProgramEnrollment(EnrollmentModel):
 
     class Meta:
         unique_together = ("user", "program", "order")
+
+    @property
+    def is_ended(self):
+        """Return True, if runs associated with enrollment are ended."""
+        return all(enrollment.run.is_past for enrollment in self.get_run_enrollments())
 
     @classmethod
     def get_audit_class(cls):

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -466,3 +466,20 @@ def test_audit(user, is_program, has_company):
         enrollment.get_audit_class().objects.get(enrollment=enrollment).data_after
         == expected
     )
+
+
+def test_enrollment_is_ended():
+    """Verify that is_ended returns True, if all of course runs in a program/course are ended."""
+    past_date = now_in_utc() - timedelta(days=1)
+    past_program = ProgramFactory.create()
+    past_course = CourseFactory.create()
+
+    past_course_runs = CourseRunFactory.create_batch(
+        3, end_date=past_date, course=past_course, course__program=past_program
+    )
+
+    program_enrollment = ProgramEnrollmentFactory.create(program=past_program)
+    course_enrollment = CourseRunEnrollmentFactory.create(run=past_course_runs[0])
+
+    assert program_enrollment.is_ended
+    assert course_enrollment.is_ended

--- a/courses/views.py
+++ b/courses/views.py
@@ -92,19 +92,34 @@ class UserEnrollmentsView(APIView):
         """Read-only access"""
         user = request.user
         user_enrollments = get_user_enrollments(user)
+        program_runs = list(user_enrollments.program_runs)
 
         return Response(
             status=status.HTTP_200_OK,
             data={
-                "program_enrollments": ProgramEnrollmentSerializer(
-                    user_enrollments.programs,
-                    many=True,
-                    context={
-                        "course_run_enrollments": list(user_enrollments.program_runs)
-                    },
-                ).data,
-                "course_run_enrollments": CourseRunEnrollmentSerializer(
-                    user_enrollments.non_program_runs, many=True
-                ).data,
+                "program_enrollments": self._serialize_program_enrollments(
+                    user_enrollments.programs, program_runs
+                ),
+                "course_run_enrollments": self._serialize_course_enrollments(
+                    user_enrollments.non_program_runs
+                ),
+                "past_course_run_enrollments": self._serialize_course_enrollments(
+                    user_enrollments.past_non_program_runs
+                ),
+                "past_program_enrollments": self._serialize_program_enrollments(
+                    user_enrollments.past_programs, program_runs
+                ),
             },
         )
+
+    def _serialize_course_enrollments(self, enrollments):
+        """Helper method to serialize course enrollments"""
+
+        return CourseRunEnrollmentSerializer(enrollments, many=True).data
+
+    def _serialize_program_enrollments(self, programs, program_runs):
+        """helper method to serialize program enrollments"""
+
+        return ProgramEnrollmentSerializer(
+            programs, many=True, context={"course_run_enrollments": list(program_runs)}
+        ).data

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -352,7 +352,11 @@ def test_user_enrollments_view(mocker, client, user):
     Test that UserEnrollmentsView returns serialized information about a user's enrollments
     """
     user_enrollments = UserEnrollments(
-        programs=[], program_runs=[], non_program_runs=[]
+        programs=[],
+        past_programs=[],
+        program_runs=[],
+        non_program_runs=[],
+        past_non_program_runs=[],
     )
     patched_get_user_enrollments = mocker.patch(
         "courses.views.get_user_enrollments", return_value=user_enrollments
@@ -372,7 +376,10 @@ def test_user_enrollments_view(mocker, client, user):
     assert resp.json() == {
         "program_enrollments": [{"program": "enrollment"}],
         "course_run_enrollments": [{"courserun": "enrollment"}],
+        "past_course_run_enrollments": [{"courserun": "enrollment"}],
+        "past_program_enrollments": [{"program": "enrollment"}],
     }
+
     patched_get_user_enrollments.assert_called_with(user)
-    patched_program_enroll_serializer.assert_called_once()
-    patched_course_enroll_serializer.assert_called_once()
+    assert patched_program_enroll_serializer.call_count == 2
+    assert patched_course_enroll_serializer.call_count == 2

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -142,6 +142,16 @@ export class DashboardPage extends React.Component<Props, State> {
     )
   }
 
+  pastEnrollmentsExist = (): boolean => {
+    const { enrollments } = this.props
+
+    return (
+      enrollments &&
+      (enrollments.past_program_enrollments.length > 0 ||
+        enrollments.past_course_run_enrollments.length > 0)
+    )
+  }
+
   isLinkableCourseRun = ({ run }: CourseRunEnrollment): boolean =>
     !R.isNil(run.courseware_url) &&
     !R.isNil(run.start_date) &&
@@ -278,6 +288,7 @@ export class DashboardPage extends React.Component<Props, State> {
     const { enrollments } = this.props
 
     const enrollmentsExist = this.enrollmentsExist()
+    const pastEnrollmentsExist = this.pastEnrollmentsExist()
 
     return (
       <React.Fragment>
@@ -318,6 +329,21 @@ export class DashboardPage extends React.Component<Props, State> {
                     this.renderCourseEnrollment(false)
                   )}
                 </div>
+                {pastEnrollmentsExist ? (
+                  <div className="past-enrollments">
+                    <h3>Past Courses and Programs</h3>
+                    <div className="program-enrollments">
+                      {enrollments.past_program_enrollments.map(
+                        this.renderProgramEnrollment
+                      )}
+                    </div>
+                    <div className="non-program-course-enrollments">
+                      {enrollments.past_course_run_enrollments.map(
+                        this.renderCourseEnrollment(false)
+                      )}
+                    </div>
+                  </div>
+                ) : null}
               </React.Fragment>
             ) : (
               <span>Loading...</span>

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -62,15 +62,19 @@ describe("DashboardPage", () => {
     const { inner } = await renderPage()
     assert.isTrue(inner.find(".user-dashboard").exists())
     const programEnrollments = userEnrollments.program_enrollments
-    const programRunEnrollments =
-      userEnrollments.program_enrollments[0].course_run_enrollments
-    const nonProgramRunEnrollments = userEnrollments.course_run_enrollments
+    const pastProgramEnrollments = userEnrollments.past_program_enrollments
+    const programRunEnrollments = userEnrollments.program_enrollments[0].course_run_enrollments.concat(
+      userEnrollments.past_program_enrollments[0].course_run_enrollments
+    )
+    const nonProgramRunEnrollments = userEnrollments.course_run_enrollments.concat(
+      userEnrollments.past_course_run_enrollments
+    )
     assert.lengthOf(programEnrollments, 1)
-    assert.lengthOf(programRunEnrollments, 2)
-    assert.lengthOf(nonProgramRunEnrollments, 2)
+    assert.lengthOf(programRunEnrollments, 4)
+    assert.lengthOf(nonProgramRunEnrollments, 4)
     assert.lengthOf(
       inner.find(".program-enrollment"),
-      programEnrollments.length
+      programEnrollments.length + pastProgramEnrollments.length
     )
     assert.lengthOf(
       inner.find(".program-enrollments .course-enrollment"),
@@ -109,7 +113,10 @@ describe("DashboardPage", () => {
     sinon.assert.callCount(
       getDateSummaryStub,
       userEnrollments.program_enrollments[0].course_run_enrollments.length +
-        userEnrollments.course_run_enrollments.length
+        userEnrollments.past_program_enrollments[0].course_run_enrollments
+          .length +
+        userEnrollments.course_run_enrollments.length +
+        userEnrollments.past_course_run_enrollments.length
     )
 
     const dates = programDateRangeStub()
@@ -136,7 +143,15 @@ describe("DashboardPage", () => {
       willExpand ? "expands" : "collapses"
     } a program courses section`, async () => {
       const programEnrollmentId = userEnrollments.program_enrollments[0].id
-      const { inner } = await renderPage()
+      const { inner } = await renderPage({
+        entities: {
+          enrollments: {
+            program_enrollments:      userEnrollments.program_enrollments,
+            past_program_enrollments: []
+          }
+        }
+      })
+
       inner.setState({
         collapseVisible: {
           [programEnrollmentId]: !willExpand
@@ -204,8 +219,10 @@ describe("DashboardPage", () => {
       const { inner } = await renderPage({
         entities: {
           enrollments: {
-            program_enrollments:    [],
-            course_run_enrollments: [userRunEnrollment]
+            program_enrollments:         [],
+            past_program_enrollments:    [],
+            course_run_enrollments:      [userRunEnrollment],
+            past_course_run_enrollments: []
           }
         }
       })

--- a/static/js/factories/course.js
+++ b/static/js/factories/course.js
@@ -86,5 +86,13 @@ export const makeProgramEnrollment = (): ProgramEnrollment => ({
 
 export const makeUserEnrollments = (): UserEnrollments => ({
   program_enrollments:    [makeProgramEnrollment()],
-  course_run_enrollments: [makeCourseRunEnrollment(), makeCourseRunEnrollment()]
+  course_run_enrollments: [
+    makeCourseRunEnrollment(),
+    makeCourseRunEnrollment()
+  ],
+  past_program_enrollments:    [makeProgramEnrollment()],
+  past_course_run_enrollments: [
+    makeCourseRunEnrollment(),
+    makeCourseRunEnrollment()
+  ]
 })

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -48,5 +48,7 @@ export type ProgramEnrollment = {
 
 export type UserEnrollments = {
   program_enrollments: Array<ProgramEnrollment>,
-  course_run_enrollments: Array<CourseRunEnrollment>
+  course_run_enrollments: Array<CourseRunEnrollment>,
+  past_program_enrollments: Array<ProgramEnrollment>,
+  past_course_run_enrollments: Array<CourseRunEnrollment>
 }

--- a/static/js/lib/courses.js
+++ b/static/js/lib/courses.js
@@ -33,10 +33,17 @@ export const getDateSummary = (
     }
   }
   const endDate = parseDateString(courseRunEnrollment.run.end_date)
-  if (endDate && endDate.isAfter(now)) {
-    return {
-      text:       `Ends: ${formatPrettyDate(endDate)}`,
-      inProgress: true
+  if (endDate) {
+    if (endDate.isAfter(now)) {
+      return {
+        text:       `Ends: ${formatPrettyDate(endDate)}`,
+        inProgress: true
+      }
+    } else {
+      return {
+        text:       `Ended: ${formatPrettyDate(endDate)}`,
+        inProgress: false
+      }
     }
   } else if (startDate) {
     return {

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -94,6 +94,10 @@
   margin-bottom: 15px;
 }
 
+.past-enrollments {
+  margin-top: 40px;
+}
+
 .program-image-column,
 .course-image-column {
   img {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #876 

#### What's this PR do?
Show past courses and programs on dashboard.

#### How should this be manually tested?

- Enroll in couple courses and programs.
- Make at least one course/program as ended. 
- View your dashboard.

#### Any background context you want to provide?

- Courses is considered ended if all of its runs are ended.
- Program is considered as ended if all of its courses are ended.

#### Screenshots (if appropriate)
![Screen Shot 2019-07-30 at 3 24 32 PM](https://user-images.githubusercontent.com/4245618/62121997-2da85080-b2de-11e9-90c0-a47a42ce4b93.png)
