### PR TITLE
#914 Inactive products should not show on catalog

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -144,6 +144,7 @@ class CatalogPage(Page):
         sorted_courserun_qset = CourseRun.objects.order_by("start_date")
         program_pages = (
             ProgramPage.objects.live()
+            .filter(program__live=True)
             .order_by("id")
             .prefetch_related(
                 Prefetch("program__courses__courseruns", queryset=sorted_courserun_qset)
@@ -151,14 +152,15 @@ class CatalogPage(Page):
         )
         course_pages = (
             CoursePage.objects.live()
+            .filter(course__live=True)
             .order_by("id")
             .prefetch_related(
                 Prefetch("course__courseruns", queryset=sorted_courserun_qset)
             )
         )
         featured_product = ProgramPage.objects.filter(
-            featured=True
-        ) or CoursePage.objects.filter(featured=True)
+            featured=True, program__live=True
+        ) or CoursePage.objects.filter(featured=True, course__live=True)
         return dict(
             **super().get_context(request),
             **get_js_settings_context(request),

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -1,12 +1,20 @@
 """Tests for CMS views"""
+from datetime import timedelta
+
 import pytest
-
 from django.urls import reverse
-from wagtail.core.models import Site
 from rest_framework import status
+from wagtail.core.models import Site
 
-from cms.factories import TextSectionFactory
-from cms.models import HomePage, CourseIndexPage, ProgramIndexPage
+from cms.factories import (
+    CatalogPageFactory,
+    CoursePageFactory,
+    ProgramPageFactory,
+    TextSectionFactory,
+)
+from cms.models import CourseIndexPage, HomePage, ProgramIndexPage
+from courses.factories import CourseFactory, CourseRunFactory
+from mitxpro.utils import now_in_utc
 
 pytestmark = pytest.mark.django_db
 
@@ -68,3 +76,68 @@ def test_course_program_child_view(client):
     child_page.save_revision().publish()
     resp = client.get(child_page.get_url())
     assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_catalog_page_product(client):
+    """
+    Verify that the catalog page does not include cards for either product pages
+    that are not live (unpublished) or pages that have a product with live=False
+    """
+    homepage = Site.objects.get(is_default_site=True).root_page
+
+    catalog_page = CatalogPageFactory.create(parent=homepage)
+    catalog_page.save_revision().publish()
+
+    now = now_in_utc()
+    start_date = now + timedelta(days=2)
+    end_date = now + timedelta(days=10)
+
+    # Live course page and course with a future course run. Should be included in upcoming context
+    active_course_page = CoursePageFactory.create(course__live=True)
+    CourseRunFactory.create(
+        course=active_course_page.product,
+        start_date=start_date,
+        end_date=end_date,
+        live=True,
+    )
+
+    # Live program page and program containing a live course with a future course run. Should be
+    # included in upcoming context
+    active_program_page = ProgramPageFactory.create(program__live=True)
+    active_program_course = CourseFactory.create(
+        program=active_program_page.product, live=True
+    )
+    CourseRunFactory.create(
+        course=active_program_course,
+        start_date=start_date,
+        end_date=end_date,
+        live=True,
+    )
+
+    # The course isn't live however it has a valid and live run. This should be filtered out in the
+    # upcoming template context
+    inactive_course_page = CoursePageFactory.create(course__live=False)
+    CourseRunFactory.create(
+        course=inactive_course_page.product,
+        start_date=start_date,
+        end_date=end_date,
+        live=True,
+    )
+
+    # Both the course and course run are live, however the program is not. This should be filtered
+    # out in the upcoming template context
+    inactive_program_page = ProgramPageFactory.create(program__live=False)
+    inactive_program_course = CourseFactory.create(
+        program=inactive_program_page.product, live=True
+    )
+    CourseRunFactory.create(
+        course=inactive_program_course,
+        start_date=start_date,
+        end_date=end_date,
+        live=True,
+    )
+
+    resp = client.get(catalog_page.get_url())
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.context_data["course_pages"] == [active_course_page]
+    assert resp.context_data["program_pages"] == [active_program_page]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#914 

#### What's this PR do?
Adds filters to catalog contents to exclude all entries which have a product with `live=False`.

#### How should this be manually tested?
Go to catalog, select any course or program and in the django admin against that course or program, set `live=False`. Verify that course or program card does not appear on the catalog anymore. This also applies to featured product card.
