### PR TITLE
Added explicit buffer size to uWSGI for cookie size issues

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -39,3 +39,4 @@ endif =
 if-not-env = UWSGI_SOCKET_TIMEOUT
 socket-timeout = 3
 endif =
+buffer-size = 65535


### PR DESCRIPTION
In order to mitigate the issue we are seeing with cookie sizes resulting in 502 errors

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
N/A
#### What's this PR do?
Increases the uWSGI buffer size to allow for larger cookies and headers

#### How should this be manually tested?
Create a set of cookies that are larger than 4k and attempt to make a request