### PR TITLE
Fix incorrect password redirecting a user to the create account error page

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -235,7 +235,9 @@ class LoginPasswordSerializer(SocialAuthSerializer):
             result = super()._authenticate(SocialAuthState.FLOW_LOGIN)
         except InvalidPasswordException as exc:
             result = SocialAuthState(
-                SocialAuthState.STATE_ERROR, partial=exc.partial, errors=[str(exc)]
+                SocialAuthState.STATE_ERROR,
+                partial=exc.partial,
+                field_errors={"password": str(exc)},
             )
         return result
 

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -403,7 +403,9 @@ class AuthStateMachine(RuleBasedStateMachine):
                 "password": "invalidpass",
             },
             {
-                "errors": ["Unable to login with that email and password combination"],
+                "field_errors": {
+                    "password": "Unable to login with that email and password combination"
+                },
                 "flow": auth_state["flow"],
                 "state": SocialAuthState.STATE_ERROR,
             },


### PR DESCRIPTION
#### Pre-Flight checklist

  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #936

#### What's this PR do?
Fixes a regression on the login password page caused by changes in #853 

#### How should this be manually tested?
- Go to login
- Enter an incorrect password
- You should see an inline error message instead of the redirect that happens on master
