### PR TITLE
fix spaces around coupon code

### DIFF
--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -215,6 +215,12 @@ describe("CheckoutForm", () => {
     sinon.assert.notCalled(submitCouponStub)
   })
 
+  it("loads the coupon code even if there are spaces around the coupon", async () => {
+    const couponCode = "  xyz  "
+    await renderForm({ couponCode: couponCode })
+    sinon.assert.calledWith(submitCouponStub, couponCode)
+  })
+
   it("does not load the coupon code if the code matches the coupon already in the basket", async () => {
     await renderForm({ couponCode: basket.coupons[0].code })
     sinon.assert.notCalled(submitCouponStub)

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -174,7 +174,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       coupons: couponCode
         ? [
           {
-            code: couponCode
+            code: couponCode.trim()
           }
         ]
         : []


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #824 

#### What's this PR do?
Trim spaces around coupon code before applying.

#### How should this be manually tested?

- Create coupon at `/ecommerce/admin`
- Apply it on basket including spaces around it.
- There should be no error.
