### PR TITLE
asadiqbal08/mitxpro-903 Removed un existent field 'description'

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -20,7 +20,7 @@ class ProgramAdmin(admin.ModelAdmin):
     """Admin for Program"""
 
     model = Program
-    search_fields = ["title", "description"]
+    search_fields = ["title"]
     list_filter = ["live"]
 
 
@@ -28,7 +28,7 @@ class CourseAdmin(admin.ModelAdmin):
     """Admin for Course"""
 
     model = Course
-    search_fields = ["title", "description"]
+    search_fields = ["title"]
     list_filter = ["live", "program"]
 
 


### PR DESCRIPTION
Fix: #903 

It looks like the course admin defines the nonexistent description as a searchable field which is causing this.

#### How to produce ? 
visit `admin/courses/course/` and `admin/courses/program/`
perform search against the course/program title. 
It will complain: `Cannot resolve keyword 'description' into field.`


#### How to test ? 
visit `admin/courses/course/` and `admin/courses/program/`
perform search against the course/program title. 
It should not complain about the `description` field now. 
