### PR TITLE
asadiqbal08/mitxpro-925  "More Dates" on Course Product page doesn't work in Safari

### DIFF
--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -9,7 +9,7 @@
           {% if page.product.unexpired_runs|length > 1 %}
             {% with course_runs=page.product.unexpired_runs %}
               <span class="dates-link">
-                <a class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
+                <a tabindex="0" role="button" class="dates-tooltip" id="datesPopover" data-trigger="focus" href="#" onClick="event.preventDefault();"
                   data-toggle="popover" data-html="true" data-placement="auto" title="More dates available for this course"
                   data-content="
                     <div>


### PR DESCRIPTION
Fix: #925 

#### Steps to Reproduce

- Go to https://xpro.mit.edu/courses/course-v1:xPRO+SysEngx1/ in Safari
- Click on "More Dates" on the "Start Date" tile.

#### Expected Behavior

- Pop-up should display with list of future course dates.

#### Try to test on different browsers. 