### PR TITLE
Add support for IE11

### DIFF
--- a/static/js/hero.js
+++ b/static/js/hero.js
@@ -2,7 +2,7 @@
 /*eslint semi: ["error", "always"]*/
 /* global Hls */
 
-function configureHlsVideo(selector, autoplay = false) {
+function configureHlsVideo(selector, autoplay) {
   const video = $(selector).get(0);
 
   if (video) {

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -26,7 +26,6 @@ module.exports = {
   },
   babelSharedLoader: {
     test:    /\.jsx?$/,
-    exclude: /node_modules/,
     loader:  "babel-loader",
     query:   {
       presets: [
@@ -34,7 +33,6 @@ module.exports = {
         "@babel/preset-react",
         "@babel/preset-flow"
       ],
-      ignore:  ["node_modules/**"],
       plugins: [
         "@babel/plugin-transform-flow-strip-types",
         "react-hot-loader/babel",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
IE11 was not working properly because arrow functions which were present in the webpack bundle aren't supported in IE11. This PR configures webpack to also transpile libraries used by our bundle in addition to our own code. I don't know what the downsides are but I assume webpack will take longer to compile, will probably use more memory, and the bundles will probably be larger than before.

`hero.js` is not transpiled at all so the default parameter is removed so that it won't cause a syntax error.

Note that the hero banner video still doesn't work but this is outside the scope of this PR.

#### How should this be manually tested?
Go to the home page. You should be able to see the "sign in" and "create account" buttons.

#### What GIF best describes this PR or how it makes you feel?
![](https://images.techhive.com/images/article/2015/03/20150319_clippy_ie-620x465-100574393-primary.idge.jpg)
