### PR TITLE
 Add pages for bulk enrollment code purchase and a receipt page to download codes

### DIFF
--- a/b2b_ecommerce/urls.py
+++ b/b2b_ecommerce/urls.py
@@ -27,6 +27,6 @@ urlpatterns = [
         B2BOrderStatusView.as_view(),
         name="b2b-order-status",
     ),
-    path("^ecommerce/bulk/", index, name="bulk-enrollment-code"),
-    path("^ecommerce/bulk/receipt/", index, name="bulk-enrollment-code-receipt"),
+    path("ecommerce/bulk/", index, name="bulk-enrollment-code"),
+    path("ecommerce/bulk/receipt/", index, name="bulk-enrollment-code-receipt"),
 ]

--- a/static/js/components/B2BPurchaseSummary.js
+++ b/static/js/components/B2BPurchaseSummary.js
@@ -1,0 +1,44 @@
+// @flow
+import React from "react"
+
+import { formatPrice } from "../lib/ecommerce"
+
+import type Decimal from "decimal.js-light"
+type Props = {
+  itemPrice: Decimal,
+  totalPrice: Decimal,
+  numSeats: ?number
+}
+const B2BPurchaseSummary = ({ itemPrice, totalPrice, numSeats }: Props) => (
+  <div className="b2b-order-summary">
+    <div className="container">
+      <div className="row">
+        <div className="col-12">
+          <div className="total-paid">Total Paid</div>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-4">Price:</div>
+        <div className="col-8">
+          <span className="item-price">{formatPrice(itemPrice)}</span>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-4">Quantity:</div>
+        <div className="col-8">
+          <span className="quantity">{numSeats || ""}</span>
+        </div>
+      </div>
+    </div>
+    <div className="bar" />
+    <div className="container">
+      <div className="row">
+        <div className="col-4">Total:</div>
+        <div className="col-8">
+          <span className="total-price">{formatPrice(totalPrice)}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+export default B2BPurchaseSummary

--- a/static/js/components/B2BPurchaseSummary_test.js
+++ b/static/js/components/B2BPurchaseSummary_test.js
@@ -1,0 +1,27 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import B2BPurchaseSummary from "./B2BPurchaseSummary"
+
+import { formatPrice } from "../lib/ecommerce"
+
+describe("B2BPurchaseSummary", () => {
+  it("renders a summary of a B2B order", () => {
+    const itemPrice = "123.45",
+      totalPrice = "246.90",
+      numSeats = 2
+
+    const wrapper = shallow(
+      <B2BPurchaseSummary
+        itemPrice={itemPrice}
+        totalPrice={totalPrice}
+        numSeats={numSeats}
+      />
+    )
+    assert.equal(wrapper.find(".quantity").text(), String(numSeats))
+    assert.equal(wrapper.find(".item-price").text(), formatPrice(itemPrice))
+    assert.equal(wrapper.find(".total-price").text(), formatPrice(totalPrice))
+  })
+})

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -1,0 +1,114 @@
+// @flow
+import React from "react"
+import { ErrorMessage, Field, Formik, Form } from "formik"
+import Decimal from "decimal.js-light"
+
+import B2BPurchaseSummary from "../B2BPurchaseSummary"
+import ProductSelector from "../input/ProductSelector"
+
+import type { ProductDetail } from "../../flow/ecommerceTypes"
+
+type Props = {
+  products: Array<ProductDetail>,
+  onSubmit: Function,
+  requestPending: boolean
+}
+
+const errorMessageRenderer = msg => <span className="error">{msg}</span>
+
+export const validate = (values: Object) => {
+  const errors = {}
+
+  const numSeats = parseInt(values.num_seats)
+  if (isNaN(numSeats) || numSeats <= 0) {
+    errors.num_seats = "Number of seats is required"
+  }
+
+  if (!values.email.includes("@")) {
+    errors.email = "Email is required"
+  }
+
+  if (!values.product) {
+    errors.product = "No product selected"
+  }
+
+  return errors
+}
+
+const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
+  <Formik
+    onSubmit={onSubmit}
+    initialValues={{
+      num_seats: "",
+      email:     "",
+      product:   ""
+    }}
+    validate={validate}
+    render={({ values }) => {
+      let itemPrice, totalPrice, numSeats
+      const productId = parseInt(values.product)
+      const product = products.find(product => product.id === productId)
+      const productVersion = product ? product.latest_version : null
+      if (productVersion) {
+        numSeats = parseInt(values.num_seats)
+        if (!isNaN(numSeats) && productVersion.price !== null) {
+          itemPrice = new Decimal(productVersion.price)
+          totalPrice = itemPrice * new Decimal(numSeats)
+        }
+      }
+
+      return (
+        <Form className="b2b-purchase-form container">
+          <div className="row">
+            <div className="col-lg-12">
+              <div className="title">Bulk Seats</div>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-lg-8">
+              <p>Purchase one or more seats for your team.</p>
+              <label htmlFor="product">
+                <h5>Select to view available courses or programs:</h5>
+                <Field
+                  component={ProductSelector}
+                  products={products}
+                  name="product"
+                />
+                <ErrorMessage name="product" render={errorMessageRenderer} />
+              </label>
+
+              <label htmlFor="num_seats">
+                *Number of seats:
+                <Field type="text" name="num_seats" className="num-seats" />
+                <ErrorMessage name="num_seats" render={errorMessageRenderer} />
+              </label>
+
+              <label htmlFor="email">
+                *Email Address:
+                <Field type="text" name="email" />
+                <ErrorMessage name="email" render={errorMessageRenderer} />
+              </label>
+            </div>
+            <div className="col-lg-4">
+              <B2BPurchaseSummary
+                itemPrice={itemPrice}
+                totalPrice={totalPrice}
+                numSeats={numSeats}
+              />
+
+              <button
+                className="checkout-button"
+                type="submit"
+                disabled={requestPending}
+              >
+                Place order
+              </button>
+            </div>
+          </div>
+        </Form>
+      )
+    }}
+  />
+)
+
+export default B2BPurchaseForm

--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -1,0 +1,138 @@
+// @flow
+import React from "react"
+import { mount, shallow } from "enzyme"
+import sinon from "sinon"
+import { assert } from "chai"
+import Decimal from "decimal.js-light"
+
+import { Field, Formik } from "formik"
+
+import B2BPurchaseForm, { validate } from "./B2BPurchaseForm"
+import { makeProduct } from "../../factories/ecommerce"
+import ProductSelector from "../input/ProductSelector"
+
+describe("B2BPurchaseForm", () => {
+  let sandbox, onSubmitStub, products
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+
+    onSubmitStub = sandbox.stub()
+    products = [makeProduct(), makeProduct(), makeProduct()]
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const render = (props = {}) =>
+    mount(
+      <B2BPurchaseForm
+        products={products}
+        onSubmit={onSubmitStub}
+        requestPending={false}
+        {...props}
+      />
+    )
+
+  it("renders a form", () => {
+    const wrapper = render()
+
+    const [productSelectorProps, numSeatsProps, emailProps] = wrapper
+      .find(Field)
+      .map(_field => _field.props())
+
+    assert.equal(productSelectorProps.name, "product")
+    assert.deepEqual(productSelectorProps.products, products)
+    assert.equal(productSelectorProps.component, ProductSelector)
+    assert.equal(numSeatsProps.name, "num_seats")
+    assert.equal(emailProps.name, "email")
+  })
+
+  //
+  ;[true, false].forEach(requestPending => {
+    it(`disables the submit button if the request is ${
+      requestPending ? "pending" : "not pending"
+    }`, () => {
+      const wrapper = render({ requestPending })
+      assert.equal(
+        wrapper.find("button[type='submit']").prop("disabled"),
+        requestPending
+      )
+    })
+  })
+
+  //
+  it("renders the order summary with correct price and quantity info", () => {
+    const selectedProduct = products[2]
+    const values = {
+      num_seats: "5",
+      product:   String(selectedProduct.id)
+    }
+    const wrapper = shallow(
+      <B2BPurchaseForm
+        products={products}
+        onSubmit={onSubmitStub}
+        requestPending={false}
+      />
+    )
+    const actions = {}
+    const innerWrapper = shallow(
+      shallow(wrapper.prop("render")({ values })).prop("children")(
+        values,
+        actions
+      )
+    )
+
+    const numSeats = parseInt(values.num_seats)
+    assert.deepEqual(innerWrapper.find("B2BPurchaseSummary").props(), {
+      numSeats,
+      totalPrice: new Decimal(selectedProduct.latest_version.price) * numSeats,
+      itemPrice:  new Decimal(selectedProduct.latest_version.price)
+    })
+  })
+
+  describe("validation", () => {
+    it("has the validate function in the props", () => {
+      const wrapper = render()
+      assert.equal(wrapper.find(Formik).prop("validate"), validate)
+    })
+
+    it("requires all fields", () => {
+      assert.deepEqual(
+        validate({
+          num_seats: "",
+          email:     "",
+          product:   ""
+        }),
+        {
+          email:     "Email is required",
+          num_seats: "Number of seats is required",
+          product:   "No product selected"
+        }
+      )
+    })
+
+    it("requires a positive number for the number of seats", () => {
+      assert.equal(
+        validate({
+          num_seats: "-2",
+          email:     "",
+          product:   ""
+        }).num_seats,
+        "Number of seats is required"
+      )
+    })
+
+    it("passes validation", () => {
+      assert.deepEqual(
+        validate({
+          num_seats: "3",
+          email:     "a@email.address",
+          product:   "4"
+        }),
+        {}
+      )
+    })
+  })
+})

--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -1,0 +1,91 @@
+// @flow
+import React from "react"
+
+import { preventDefaultAndInvoke } from "../../lib/util"
+
+import type { Product } from "../../flow/ecommerceTypes"
+
+type Props = {
+  products: Array<Product>,
+  field: {
+    name: string,
+    value: Object,
+    onChange: Function,
+    onBlur: Function
+  },
+  form: {
+    touched: boolean,
+    errors: Object,
+    values: Object
+  }
+}
+type ProductType = "courserun" | "program"
+type State = {
+  productType: ProductType
+}
+export default class ProductSelector extends React.Component<Props, State> {
+  state = {
+    productType: "courserun"
+  }
+
+  updateProductType = (productType: ProductType) => {
+    const {
+      field: { name, onChange }
+    } = this.props
+    if (this.state.productType === productType) {
+      return
+    }
+    this.setState({ productType })
+    onChange({ target: { value: "", name } })
+  }
+
+  render() {
+    const {
+      field: { onChange, name, value },
+      products
+    } = this.props
+    const { productType } = this.state
+
+    return (
+      <div className="product-selector">
+        <div className="row">
+          <div className="col-12">
+            <button
+              className={productType === "courserun" ? "selected" : ""}
+              onClick={preventDefaultAndInvoke(() =>
+                this.updateProductType("courserun")
+              )}
+            >
+              Course
+            </button>
+            <button
+              className={productType === "program" ? "selected" : ""}
+              onClick={preventDefaultAndInvoke(() =>
+                this.updateProductType("program")
+              )}
+            >
+              Program
+            </button>
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col-12">
+            <select onChange={onChange} name={name} value={value.product}>
+              <option value={""} key={"null"}>
+                Select a product
+              </option>
+              {products
+                .filter(product => product.product_type === productType)
+                .map(product => (
+                  <option value={product.id} key={product.id}>
+                    {product.title}
+                  </option>
+                ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/static/js/components/input/ProductSelector_test.js
+++ b/static/js/components/input/ProductSelector_test.js
@@ -1,0 +1,129 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import casual from "casual-browserify"
+
+import ProductSelector from "./ProductSelector"
+
+import { makeProduct } from "../../factories/ecommerce"
+import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants"
+
+describe("ProductSelector", () => {
+  let sandbox, products, value, name, onChangeStub
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    name = casual.text
+    onChangeStub = sandbox.stub()
+    products = [
+      makeProduct(PRODUCT_TYPE_COURSERUN),
+      makeProduct(PRODUCT_TYPE_PROGRAM),
+      makeProduct(PRODUCT_TYPE_COURSERUN)
+    ]
+    value = {}
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const render = () =>
+    shallow(
+      <ProductSelector
+        products={products}
+        field={{
+          onChange: onChangeStub,
+          onBlur:   sandbox.stub(),
+          name,
+          value
+        }}
+        form={{
+          touched: false,
+          errors:  {},
+          values:  {}
+        }}
+      />
+    )
+
+  ;["courserun", "program"].forEach(productType => {
+    it(`renders a button with ${productType} selected`, () => {
+      const wrapper = render()
+      wrapper.setState({ productType })
+      const [courseButton, programButton] = wrapper.find("button")
+      const [courseWrapper, programWrapper] = [
+        shallow(courseButton),
+        shallow(programButton)
+      ]
+      assert.equal(courseWrapper.text(), "Course")
+      assert.equal(programWrapper.text(), "Program")
+      assert.equal(
+        courseWrapper.prop("className"),
+        productType === "courserun" ? "selected" : ""
+      )
+      assert.equal(
+        programWrapper.prop("className"),
+        productType === "program" ? "selected" : ""
+      )
+    })
+
+    it(`changes state to ${productType} on click`, () => {
+      const wrapper = render()
+      const [courseButton, programButton] = wrapper.find("button")
+      const button = productType === "courserun" ? courseButton : programButton
+      shallow(button).prop("onClick")({ preventDefault: sandbox.stub() })
+      wrapper.update()
+      assert.equal(wrapper.state().productType, productType)
+    })
+
+    it(`shows a list of products for ${productType}`, () => {
+      const wrapper = render()
+      wrapper.setState({ productType })
+      const [pickOption, ...options] = wrapper.find("option")
+      assert.equal(shallow(pickOption).text(), "Select a product")
+      assert.equal(shallow(pickOption).prop("value"), "")
+      const filteredProducts = products.filter(
+        product => product.product_type === productType
+      )
+      assert.equal(options.length, filteredProducts.length)
+      filteredProducts.forEach((product, i) => {
+        const option = shallow(options[i])
+        assert.equal(option.text(), product.title)
+        assert.equal(option.prop("value"), product.id)
+      })
+    })
+
+    it(`clears the selection when ${productType} is set but a different button is clicked`, () => {
+      const wrapper = render()
+      wrapper.setState({ productType })
+      const [courseButton, programButton] = wrapper.find("button")
+      const otherButton =
+        productType === PRODUCT_TYPE_COURSERUN ? programButton : courseButton
+      shallow(otherButton).prop("onClick")({ preventDefault: sandbox.stub() })
+      sinon.assert.calledWith(onChangeStub, { target: { value: "", name } })
+    })
+
+    it(`does not clear the selection when ${productType} is set but a different button is clicked`, () => {
+      const wrapper = render()
+      wrapper.setState({ productType })
+      const [courseButton, programButton] = wrapper.find("button")
+      const sameButton =
+        productType === PRODUCT_TYPE_COURSERUN ? courseButton : programButton
+      shallow(sameButton).prop("onClick")({ preventDefault: sandbox.stub() })
+      sinon.assert.notCalled(onChangeStub)
+    })
+  })
+
+  it("uses the value for the selected product", () => {
+    value.product = 98765
+    const wrapper = render()
+    assert.equal(wrapper.find("select").prop("value"), value.product)
+    assert.equal(wrapper.find("select").prop("name"), name)
+  })
+
+  it("updates the selected option", () => {
+    const wrapper = render()
+    assert.equal(wrapper.find("select").prop("onChange"), onChangeStub)
+  })
+})

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -20,6 +20,7 @@ import DashboardPage from "./pages/DashboardPage"
 import LoginPages from "./pages/login/LoginPages"
 import RegisterPages from "./pages/register/RegisterPages"
 import EcommerceAdminPages from "./pages/admin/EcommerceAdminPages"
+import EcommerceBulkPages from "./pages/b2b/EcommerceBulkPages"
 import ProfilePages from "./pages/profile/ProfilePages"
 
 import type { Match, Location } from "react-router"
@@ -96,6 +97,10 @@ export class App extends React.Component<Props, void> {
           <Route
             path={urljoin(match.url, String(routes.profile))}
             component={ProfilePages}
+          />
+          <Route
+            path={urljoin(match.url, String(routes.ecommerceBulk))}
+            component={EcommerceBulkPages}
           />
         </Switch>
       </div>

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -37,8 +37,8 @@ type Props = {
   updateBasket: (payload: BasketPayload) => Promise<*>
 }
 type State = {
-  appliedInitialCoupon: false,
-  errors: null
+  appliedInitialCoupon: boolean,
+  errors: string | Object | null
 }
 
 export const calcSelectedRunIds = (

--- a/static/js/containers/pages/b2b/B2BPurchasePage.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage.js
@@ -1,0 +1,110 @@
+// @flow
+import React from "react"
+import { connect } from "react-redux"
+import { compose } from "redux"
+import { pathOr } from "ramda"
+import { connectRequest, mutateAsync } from "redux-query"
+
+import B2BPurchaseForm from "../../../components/forms/B2BPurchaseForm"
+
+import { createCyberSourceForm } from "../../../lib/form"
+import queries from "../../../lib/queries"
+
+import type {
+  BulkCheckoutPayload,
+  ProductDetail
+} from "../../../flow/ecommerceTypes"
+
+type Props = {
+  checkout: (payload: BulkCheckoutPayload) => Promise<*>,
+  products: Array<ProductDetail>,
+  requestPending: boolean
+}
+type State = {
+  errors: string | Object | null
+}
+type Values = {
+  // these are form fields so they all start off as strings
+  num_seats: string,
+  product: string,
+  email: string
+}
+export class B2BPurchasePage extends React.Component<Props, State> {
+  onSubmit = async (values: Values, { setErrors, setSubmitting }: Object) => {
+    const { products, checkout } = this.props
+    const numSeats = parseInt(values.num_seats)
+    const product = products.find(
+      _product => _product.id === parseInt(values.product)
+    )
+    if (!product) {
+      throw new Error(
+        "No product found. This should have been caught in validation."
+      )
+    }
+
+    const productVersion = product.latest_version
+
+    try {
+      const checkoutResponse = await checkout({
+        num_seats:          numSeats,
+        email:              values.email,
+        product_version_id: productVersion.id
+      })
+
+      if (checkoutResponse.status !== 200) {
+        if (checkoutResponse.body.errors) {
+          setErrors(checkoutResponse.body.errors)
+        }
+        return
+      }
+
+      const { method, url, payload } = checkoutResponse.body
+      if (method === "GET") {
+        window.location = url
+      } else {
+        const form = createCyberSourceForm(url, payload)
+        const body: HTMLElement = (document.querySelector("body"): any)
+        body.appendChild(form)
+        form.submit()
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  render() {
+    const { checkout, products, requestPending } = this.props
+
+    return (
+      <B2BPurchaseForm
+        onSubmit={this.onSubmit}
+        products={products}
+        checkout={checkout}
+        requestPending={requestPending}
+      />
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  products:       state.entities.products || [],
+  requestPending: pathOr(
+    false,
+    ["queries", "b2bCheckoutMutation", "isPending"],
+    state
+  )
+})
+const mapDispatchToProps = dispatch => ({
+  checkout: (payload: BulkCheckoutPayload) =>
+    dispatch(mutateAsync(queries.ecommerce.b2bCheckoutMutation(payload)))
+})
+
+const mapPropsToConfig = () => [queries.ecommerce.productsQuery()]
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  connectRequest(mapPropsToConfig)
+)(B2BPurchasePage)

--- a/static/js/containers/pages/b2b/B2BPurchasePage_test.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage_test.js
@@ -1,0 +1,174 @@
+// @flow
+import sinon from "sinon"
+import { assert } from "chai"
+
+import IntegrationTestHelper from "../../../util/integration_test_helper"
+import B2BPurchasePage, {
+  B2BPurchasePage as InnerB2BPurchasePage
+} from "./B2BPurchasePage"
+
+import * as formFuncs from "../../../lib/form"
+import { makeProduct } from "../../../factories/ecommerce"
+
+describe("B2BPurchasePage", () => {
+  let helper, renderPage, products
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    products = [makeProduct(), makeProduct(), makeProduct()]
+    renderPage = helper.configureHOCRenderer(
+      B2BPurchasePage,
+      InnerB2BPurchasePage,
+      {
+        entities: {
+          products
+        }
+      },
+      {
+        location: {
+          search: ""
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("loads products on mount", async () => {
+    await renderPage()
+    helper.handleRequestStub.withArgs("/api/products/", "POST").returns({
+      body:   undefined,
+      status: 200
+    })
+  })
+
+  it("renders a form", async () => {
+    const { inner } = await renderPage()
+    const props = inner.find("B2BPurchaseForm").props()
+    assert.deepEqual(props.products, products)
+  })
+
+  it("submits the form to Cybersource", async () => {
+    const { inner } = await renderPage()
+
+    const url = "/api/b2b/checkout/"
+    const payload = { pay: "load" }
+    helper.handleRequestStub.withArgs("/api/b2b/checkout/", "POST").returns({
+      body: {
+        url,
+        payload
+      },
+      status: 200
+    })
+    const submitStub = helper.sandbox.stub()
+    const form = document.createElement("form")
+    // $FlowFixMe: need to overwrite this function to mock it
+    form.submit = submitStub
+    const createFormStub = helper.sandbox
+      .stub(formFuncs, "createCyberSourceForm")
+      .returns(form)
+    const selectedProduct = products[1]
+    const values = {
+      product:   selectedProduct.id,
+      num_seats: 5,
+      email:     "email@example.com"
+    }
+    const actions = {
+      setSubmitting: helper.sandbox.stub(),
+      setErrors:     helper.sandbox.stub()
+    }
+    await inner.find("B2BPurchaseForm").prop("onSubmit")(values, actions)
+    sinon.assert.calledWith(createFormStub, url, payload)
+    sinon.assert.calledWith(submitStub)
+    sinon.assert.calledWith(
+      helper.handleRequestStub,
+      "/api/b2b/checkout/",
+      "POST",
+      {
+        body: {
+          email:              values.email,
+          product_version_id: selectedProduct.latest_version.id,
+          num_seats:          values.num_seats
+        },
+        headers: {
+          "X-CSRFTOKEN": null
+        },
+        credentials: undefined
+      }
+    )
+    sinon.assert.calledWith(actions.setSubmitting, false)
+    sinon.assert.notCalled(actions.setErrors)
+  })
+
+  it("submits the form but redirects to a location instead of submitting a form to CyberSource", async () => {
+    const { inner } = await renderPage()
+
+    const url = "/a/b/c/"
+    const payload = { pay: "load" }
+    helper.handleRequestStub.withArgs("/api/b2b/checkout/", "POST").returns({
+      body: {
+        url,
+        payload,
+        method: "GET"
+      },
+      status: 200
+    })
+    const submitStub = helper.sandbox.stub()
+    const form = document.createElement("form")
+    // $FlowFixMe: need to overwrite this function to mock it
+    form.submit = submitStub
+    const actions = {
+      setSubmitting: helper.sandbox.stub(),
+      setErrors:     helper.sandbox.stub()
+    }
+    const selectedProduct = products[1]
+    const values = {
+      product:   selectedProduct.id,
+      num_seats: 5,
+      email:     "email@example.com"
+    }
+    await inner.find("B2BPurchaseForm").prop("onSubmit")(values, actions)
+
+    sinon.assert.notCalled(actions.setErrors)
+    sinon.assert.calledWith(actions.setSubmitting, false)
+    assert.isTrue(window.location.toString().endsWith(url))
+  })
+
+  it("submits the form but receives an error", async () => {
+    const { inner } = await renderPage()
+
+    const errors = "some errors 😩"
+    helper.handleRequestStub.withArgs("/api/b2b/checkout/", "POST").returns({
+      body: {
+        errors
+      },
+      status: 500
+    })
+    const selectedProduct = products[1]
+    const values = {
+      product:   selectedProduct.id,
+      num_seats: 5,
+      email:     "email@example.com"
+    }
+    const actions = {
+      setSubmitting: helper.sandbox.stub(),
+      setErrors:     helper.sandbox.stub()
+    }
+    await inner.find("B2BPurchaseForm").prop("onSubmit")(values, actions)
+    sinon.assert.calledWith(actions.setErrors, errors)
+    sinon.assert.calledWith(actions.setSubmitting, false)
+  })
+
+  it("sets requestPending when a request is in progress", async () => {
+    const { inner } = await renderPage({
+      queries: {
+        b2bCheckoutMutation: {
+          isPending: true
+        }
+      }
+    })
+    assert.isTrue(inner.find("B2BPurchaseForm").prop("requestPending"))
+  })
+})

--- a/static/js/containers/pages/b2b/B2BReceiptPage.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage.js
@@ -1,0 +1,187 @@
+/* global SETTINGS: false */
+// @flow
+import React from "react"
+import { connect } from "react-redux"
+import { compose } from "redux"
+import { connectRequest } from "redux-query"
+import qs from "query-string"
+import moment from "moment"
+import Decimal from "decimal.js-light"
+
+import B2BPurchaseSummary from "../../../components/B2BPurchaseSummary"
+
+import queries from "../../../lib/queries"
+import { addUserNotification } from "../../../actions"
+import { wait } from "../../../lib/util"
+import { formatPrice } from "../../../lib/ecommerce"
+import { ALERT_TYPE_TEXT } from "../../../constants"
+
+import type { B2BOrderStatus } from "../../../flow/ecommerceTypes"
+import type { Location } from "react-router"
+import type Moment from "moment"
+
+type Props = {
+  addUserNotification: Function,
+  orderStatus: B2BOrderStatus,
+  location: Location,
+  forceRequest: () => Promise<void>,
+  requestPending: boolean
+}
+type State = {
+  now: Moment,
+  timeoutActive: boolean
+}
+
+const NUM_MINUTES_TO_POLL = 2
+const NUM_MILLIS_PER_POLL = 3000
+
+export class B2BReceiptPage extends React.Component<Props, State> {
+  state = {
+    now:           moment(),
+    timeoutActive: false
+  }
+
+  componentDidMount() {
+    this.handleOrderStatus()
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // This is meant to be an identity check, not a deep equality check. This shows whether we received an update
+    // for enrollments based on the forceReload
+    if (prevProps.orderStatus !== this.props.orderStatus) {
+      this.handleOrderStatus()
+    }
+  }
+
+  handleOrderStatus = async () => {
+    const { orderStatus } = this.props
+
+    if (!orderStatus) {
+      // wait until we have a order status
+      return
+    }
+
+    this.handleOrderPending()
+  }
+
+  handleOrderPending = async () => {
+    const { addUserNotification, orderStatus, forceRequest } = this.props
+    const { timeoutActive, now: initialTime } = this.state
+
+    if (timeoutActive) {
+      return
+    }
+
+    if (orderStatus.status === "fulfilled") {
+      // all set
+      return
+    }
+
+    this.setState({ timeoutActive: true })
+    await wait(NUM_MILLIS_PER_POLL)
+    this.setState({ timeoutActive: false })
+
+    const deadline = moment(initialTime).add(NUM_MINUTES_TO_POLL, "minutes")
+    const now = moment()
+    if (now.isBefore(deadline)) {
+      await forceRequest()
+    } else {
+      addUserNotification({
+        "b2b-order-status": {
+          type:  ALERT_TYPE_TEXT,
+          color: "danger",
+          props: {
+            text: `Something went wrong. Please contact support at ${SETTINGS.support_email}.`
+          }
+        }
+      })
+    }
+  }
+
+  render() {
+    const {
+      orderStatus,
+      location: { search }
+    } = this.props
+
+    const hash = qs.parse(search).hash
+
+    if (!orderStatus || orderStatus.status !== "fulfilled") {
+      return <div className="b2b-receipt-page">Loading...</div>
+    }
+
+    const totalPrice = new Decimal(orderStatus.total_price)
+    const itemPrice = new Decimal(orderStatus.item_price)
+    const {
+      num_seats: numSeats,
+      email,
+      product_version: { content_title: title, readable_id: readableId }
+    } = orderStatus
+
+    return (
+      <div className="b2b-receipt-page container">
+        <div className="row">
+          <div className="col-lg-12">
+            <div className="title">Bulk Seats Receipt</div>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-lg-8">
+            <p>
+              Thank you! You have purchased one or more seats for your team.
+            </p>
+            <h3>Purchase Summary (Order Number):</h3>
+            <p className="course-or-program">
+              <span className="description">Course or program:</span>
+              {title}
+              <span className="description">{readableId}</span>
+            </p>
+            <p className="seats">
+              <span className="description">Seats:</span>
+              {numSeats} (at {formatPrice(itemPrice)} per seat)
+            </p>
+            <p className="email">
+              <span className="description">Email Address:</span>
+              {email}
+            </p>
+            If you encounter any issues please email {SETTINGS.support_email} to
+            contact customer support.
+          </div>
+          <div className="col-lg-4">
+            <B2BPurchaseSummary
+              itemPrice={itemPrice}
+              totalPrice={totalPrice}
+              numSeats={numSeats}
+            />
+            <a
+              href={`/api/b2b/orders/${hash}/codes/`}
+              className="enrollment-codes-link"
+            >
+              Download codes <i className="material-icons">save_alt</i>
+            </a>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  orderStatus: state.entities.b2b_order_status
+})
+
+const mapDispatchToProps = {
+  addUserNotification
+}
+
+const mapPropsToConfig = props => [
+  queries.ecommerce.b2bOrderStatus(qs.parse(props.location.search).hash)
+]
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  connectRequest(mapPropsToConfig)
+)(B2BReceiptPage)

--- a/static/js/containers/pages/b2b/B2BReceiptPage_test.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage_test.js
@@ -1,0 +1,172 @@
+/* global SETTINGS: false */
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+// $FlowFixMe: flow doesn't see fn
+import { fn as momentProto } from "moment"
+import qs from "query-string"
+import casual from "casual-browserify"
+
+import B2BReceiptPage, {
+  B2BReceiptPage as InnerB2BReceiptPage
+} from "./B2BReceiptPage"
+
+import * as utilFuncs from "../../../lib/util"
+import IntegrationTestHelper from "../../../util/integration_test_helper"
+import { makeB2BOrderStatus } from "../../../factories/ecommerce"
+import { formatPrice } from "../../../lib/ecommerce"
+
+describe("B2BReceiptPage", () => {
+  let helper, renderPage, orderStatus, orderHash
+
+  beforeEach(() => {
+    orderHash = casual.uuid
+    helper = new IntegrationTestHelper()
+    orderStatus = { ...makeB2BOrderStatus(), status: "fulfilled" }
+    helper.handleRequestStub
+      .withArgs(`/api/b2b/orders/${orderHash}/status/`, "GET")
+      .returns({
+        body:   orderStatus,
+        status: 200
+      })
+    renderPage = helper.configureHOCRenderer(
+      B2BReceiptPage,
+      InnerB2BReceiptPage,
+      {
+        entities: {
+          b2b_order_status: orderStatus
+        }
+      },
+      {
+        location: {
+          search: qs.stringify({ hash: orderHash })
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("renders a receipt", async () => {
+    const { inner } = await renderPage()
+    assert.isTrue(
+      inner
+        .find(".course-or-program")
+        .text()
+        .includes(orderStatus.product_version.content_title)
+    )
+    assert.isTrue(
+      inner
+        .find(".course-or-program")
+        .text()
+        .includes(orderStatus.product_version.readable_id)
+    )
+    assert.isTrue(
+      inner
+        .find(".seats")
+        .text()
+        .includes(
+          `${orderStatus.num_seats} (at ${formatPrice(
+            orderStatus.item_price
+          )} per seat)`
+        )
+    )
+    assert.isTrue(
+      inner
+        .find(".email")
+        .text()
+        .includes(orderStatus.email)
+    )
+    const summaryProps = inner.find("B2BPurchaseSummary").props()
+    assert.equal(String(summaryProps.itemPrice), orderStatus.item_price)
+    assert.equal(String(summaryProps.totalPrice), orderStatus.total_price)
+    assert.equal(summaryProps.numSeats, orderStatus.num_seats)
+  })
+
+  it("has a link to download enrollment codes", async () => {
+    const { inner } = await renderPage()
+    const link = inner.find(".enrollment-codes-link")
+    assert.equal(link.prop("href"), `/api/b2b/orders/${orderHash}/codes/`)
+    assert.isTrue(link.text().startsWith("Download codes"))
+  })
+
+  it("reads from the order status API", async () => {
+    const newOrderStatus = makeB2BOrderStatus()
+    const newHash = "a-different-order-hash"
+    helper.handleRequestStub
+      .withArgs(`/api/b2b/orders/${newHash}/status/`, "GET")
+      .returns({
+        status: 200,
+        body:   newOrderStatus
+      })
+
+    const { wrapper } = await renderPage(
+      {},
+      {
+        location: {
+          search: qs.stringify({ hash: newHash })
+        }
+      }
+    )
+    sinon.assert.calledWith(
+      helper.handleRequestStub,
+      `/api/b2b/orders/${newHash}/status/`,
+      "GET"
+    )
+    assert.equal(wrapper.prop("orderStatus"), newOrderStatus)
+  })
+
+  //
+  ;[true, false].forEach(outOfTime => {
+    it(`if a run or program is not immediately found it waits 3 seconds and ${
+      outOfTime ? "errors" : "force reloads"
+    }`, async () => {
+      let waitResolve = null
+      const waitPromise = new Promise(resolve => {
+        waitResolve = resolve
+      })
+      const waitStub = helper.sandbox
+        .stub(utilFuncs, "wait")
+        .returns(waitPromise)
+
+      orderStatus.status = "created"
+      const fulfilledOrderStatus = {
+        ...orderStatus,
+        status: "fulfilled"
+      }
+      const { store } = await renderPage()
+      helper.handleRequestStub.resetHistory()
+
+      sinon.assert.calledWith(waitStub, 3000)
+      helper.handleRequestStub
+        .withArgs(`/api/b2b/orders/${orderHash}/status/`, "GET")
+        .returns({
+          body:   fulfilledOrderStatus,
+          status: 200
+        })
+      helper.sandbox.stub(momentProto, "isBefore").returns(!outOfTime)
+      // $FlowFixMe
+      waitResolve()
+      await waitPromise
+
+      if (outOfTime) {
+        assert.deepEqual(store.getState().ui.userNotifications, {
+          "b2b-order-status": {
+            color: "danger",
+            type:  "text",
+            props: {
+              text: `Something went wrong. Please contact support at ${SETTINGS.support_email}.`
+            }
+          }
+        })
+      } else {
+        sinon.assert.calledWith(
+          helper.handleRequestStub,
+          `/api/b2b/orders/${orderHash}/status/`
+        )
+      }
+    })
+  })
+})

--- a/static/js/containers/pages/b2b/EcommerceBulkPages.js
+++ b/static/js/containers/pages/b2b/EcommerceBulkPages.js
@@ -1,0 +1,27 @@
+// @flow
+import React from "react"
+import { Route, Switch } from "react-router-dom"
+
+import { routes } from "../../../lib/urls"
+
+import B2BPurchasePage from "./B2BPurchasePage"
+import B2BReceiptPage from "./B2BReceiptPage"
+
+const EcommerceBulkPages = () => (
+  <React.Fragment>
+    <Switch>
+      <Route
+        exact
+        path={routes.ecommerceBulk.bulkPurchase}
+        component={B2BPurchasePage}
+      />
+      <Route
+        exact
+        path={routes.ecommerceBulk.receipt}
+        component={B2BReceiptPage}
+      />
+    </Switch>
+  </React.Fragment>
+)
+
+export default EcommerceBulkPages

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -27,7 +27,7 @@ export type CheckoutPayload = {
   "unsigned_field_names": string,
 };
 
-export type BasketItem = {
+export type ProductVersion = {
   type: PRODUCT_TYPE_COURSERUN | PRODUCT_TYPE_PROGRAM,
   courses: Array<Course>,
   thumbnail_url: string,
@@ -37,6 +37,10 @@ export type BasketItem = {
   object_id: number,
   product_id: number,
   id: number,
+  readable_id: string,
+}
+
+export type BasketItem = ProductVersion & {
   run_ids: Array<number>,
 }
 
@@ -51,6 +55,15 @@ export type DataConsentUser = {
   consent_text: string,
   id: number,
   company: Company
+}
+
+export type B2BOrderStatus = {
+  status: string,
+  num_seats: number,
+  total_price: string,
+  item_price: string,
+  email: string,
+  product_version: ProductVersion,
 }
 
 export type BasketResponse = {
@@ -113,10 +126,10 @@ export type Product = {
   id: number,
   title: string,
   product_type: string,
-  created_on: Date,
-  updated_on: Date,
-  object_id: number,
-  content_type: number,
+}
+
+export type ProductDetail = Product & {
+  latest_version: BasketItem,
 }
 
 export type ProductMap = {
@@ -136,4 +149,10 @@ export type BulkCouponPaymentsResponse = Array<BulkCouponPayment>
 
 export type BulkCouponSendResponse = {
   emails: Array<string>
+}
+
+export type BulkCheckoutPayload = {
+  num_seats: number,
+  product_version_id: number,
+  email: string,
 }

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -129,7 +129,7 @@ export type Product = {
 }
 
 export type ProductDetail = Product & {
-  latest_version: BasketItem,
+  latest_version: ProductVersion,
 }
 
 export type ProductMap = {

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -4,10 +4,12 @@ import { pathOr, objOf } from "ramda"
 import { getCookie } from "../api"
 
 import type {
+  B2BOrderStatus,
   BasketResponse,
+  BulkCheckoutPayload,
   Company,
   CouponPaymentVersion,
-  Product
+  ProductDetail
 } from "../../flow/ecommerceTypes"
 
 const DEFAULT_POST_OPTIONS = {
@@ -58,11 +60,11 @@ export default {
   productsSelector: pathOr(null, ["entities", "products"]),
   productsQuery:    () => ({
     url:       "/api/products/",
-    transform: (json: Array<Product>) => ({
+    transform: (json: Array<ProductDetail>) => ({
       products: json
     }),
     update: {
-      products: (prev: Array<Product>, next: Array<Product>) => next
+      products: (prev: Array<ProductDetail>, next: Array<ProductDetail>) => next
     }
   }),
   companiesSelector: pathOr(null, ["entities", "companies"]),
@@ -94,6 +96,30 @@ export default {
     },
     options: {
       ...DEFAULT_POST_OPTIONS
+    }
+  }),
+  b2bCheckoutMutation: (payload: BulkCheckoutPayload) => ({
+    queryKey: "b2bCheckoutMutation",
+    url:      "/api/b2b/checkout/",
+    update:   {
+      b2b_checkout: () => null
+    },
+    body: {
+      ...payload
+    },
+    options: {
+      force: true,
+      ...DEFAULT_POST_OPTIONS
+    }
+  }),
+  b2bOrderStatus: (orderHash: string) => ({
+    queryKey:  "b2bOrderStatus",
+    url:       `/api/b2b/orders/${orderHash}/status/`,
+    transform: (json: B2BOrderStatus) => ({
+      b2b_order_status: json
+    }),
+    update: {
+      b2b_order_status: (prev: B2BOrderStatus, next: B2BOrderStatus) => next
     }
   })
 }

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -40,5 +40,10 @@ export const routes = {
     index:      "",
     bulkEnroll: "enroll/",
     coupons:    "coupons/"
+  }),
+
+  ecommerceBulk: include("/ecommerce/bulk/", {
+    bulkPurchase: "",
+    receipt:      "receipt/"
   })
 }

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -139,21 +139,6 @@
         font-size: 28px;
         margin-top: 25px;
       }
-
-      .bar {
-        @include media-breakpoint-up(lg) {
-          background-size: 24px 1px;
-          margin-top: 75px;
-        }
-
-        height: 1px;
-        width: 100%;
-        background-image: linear-gradient(to right, black 50%, rgba(255,255,255,0) 0%);
-        background-position: bottom;
-        background-size: 10px 1px;
-        background-repeat: repeat-x;
-        margin-top: 25px;
-      }
     }
   }
 
@@ -171,10 +156,6 @@
       text-decoration: underline;
       cursor: pointer;
     }
-  }
-
-  .error {
-    color: $primary;
   }
 
   button {
@@ -228,4 +209,139 @@
     font-size: 60px;
     font-weight: 400;
   }
+}
+
+.b2b-purchase-form {
+  margin: 0 auto;
+  max-width: 1000px;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    margin: 40px 0;
+  }
+
+  .checkout-button {
+    background-color: $light-blue;
+    color: white;
+    font-size: 28px;
+    padding: 15px 0;
+    font-weight: 600;
+    width: 100%;
+    text-transform: uppercase;
+    border: 0;
+  }
+
+  .b2b-order-summary {
+    display: flex;
+    flex-direction: column;
+    background-color: $very-light-gray;
+    font-weight: 600;
+    padding: 20px;
+    margin-bottom: 40px;
+  }
+}
+
+.b2b-purchase-form, .checkout-page {
+  .error {
+    color: $primary;
+  }
+}
+
+.b2b-purchase-form, .b2b-receipt-page {
+  margin: 0 auto;
+  max-width: 1000px;
+  font-weight: 600;
+
+  .title {
+    font-weight: 700;
+    font-size: 32px;
+    color: $navy-blue;
+    padding: 10px 0;
+  }
+
+  .b2b-order-summary {
+    background-color: $very-light-gray;
+    padding: 20px 10px;
+
+    .total-paid {
+      font-weight: 600;
+      font-size: 24px;
+      margin-bottom: 30px;
+    }
+
+    .col-8 {
+      font-weight: 700;
+    }
+  }
+
+  .description {
+    display: block;
+    color: $light-gray;
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  .product-selector {
+    button {
+      font-size: 28px;
+      margin-right: 15px;
+      margin-bottom: 15px;
+      padding: 5px 15px;
+      border-radius: 5px;
+      background-color: white;
+      color: $soft-light-gray;
+      border: 1px solid black;
+      font-weight: 600;
+
+      &.selected {
+        background-color: $soft-light-gray;
+        color: $denim-blue;
+        border: 0;
+      }
+    }
+  }
+}
+
+.b2b-receipt-page {
+  .enrollment-codes-link {
+    display: block;
+    text-align: center;
+    background-color: $light-blue;
+    color: white;
+    font-size: 28px;
+    padding: 15px 0;
+    margin-top: 15px;
+    text-transform: uppercase;
+    width: 100%;
+  }
+}
+
+.order-summary, .b2b-order-summary {
+  font-weight: 600;
+
+  .bar {
+    @include media-breakpoint-up(lg) {
+      background-size: 24px 1px;
+      margin-top: 75px;
+    }
+
+    height: 1px;
+    width: 100%;
+    background-position: bottom;
+    background-size: 10px 1px;
+    background-repeat: repeat-x;
+  }
+}
+
+.order-summary .bar {
+  margin-top: 25px;
+  background-image: linear-gradient(to right, black 50%, rgba(255,255,255,0) 0%);
+}
+
+.b2b-order-summary .bar {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  color: grey;
+  background-image: linear-gradient(to right, $soft-light-gray 50%, rgba(255,255,255,0) 0%);
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #858 

#### What's this PR do?
Implements the site where b2b customers can purchase enrollment codes which would be used by end users to enroll in the course run or program bundle of course runs.

#### How should this be manually tested?
First note that the functionality should work exactly the same with or without login.

For the purchase page, select a product and enter the number of seats and your email address. Click 'Place Order' and you will be directed to Cybersource. Fill in the fake credit card information and you should be redirected to the receipt page. You should see a simple "Loading..." message. If you look at the network tab you should see a request made every three seconds to the new order status API.

To test the receipt page we need to fulfill the order in the backend. You could try to fulfill the order via the order fulfillment REST API but this is a lot of work so we may want to skip this and test that on RC instead. At this point a `B2BOrder` with `status = created` should be created in the database. It's probably easiest to just set `status = fulfilled` manually, via the Django admin or shell. Once the status is updated the receipt page should automatically show the right data along with a link to download coupon codes.

Click the link to download the enrollment codes and verify that the browser sees that it's a CSV file. The CSV file should be very simple, just a list of codes.

#### Not included in this PR but will be worked on for a follow-up PR
 - email to purchaser
 - modal select of courses and programs

#### Screenshots
Purchase page
Desktop:
![purchase](https://user-images.githubusercontent.com/863262/62960795-6dd0fe00-bdc9-11e9-9e57-77902fd932d7.png)

Mobile:
![mobile_purchase](https://user-images.githubusercontent.com/863262/62960783-6a3d7700-bdc9-11e9-9cfe-5d836495d2ed.png)

Receipt page
Desktop:
![receipt](https://user-images.githubusercontent.com/863262/62960774-63166900-bdc9-11e9-9bab-064535c6e063.png)

Mobile:
![mobile_receipt](https://user-images.githubusercontent.com/863262/62960765-5d208800-bdc9-11e9-8a81-6f1765a2bb1b.png)

Error message:
![error](https://user-images.githubusercontent.com/863262/62960759-58f46a80-bdc9-11e9-931c-0378a8043b58.png)
