### PR TITLE
Make checkbox CSS rule more specific to catalog page

### DIFF
--- a/static/scss/collapsible.scss
+++ b/static/scss/collapsible.scss
@@ -4,7 +4,7 @@
   margin-bottom: 0;
 }
 
-input[type='checkbox'] {
+input[type='checkbox'].toggle {
   display: none;
 }
 

--- a/static/scss/collapsible.scss
+++ b/static/scss/collapsible.scss
@@ -1,9 +1,5 @@
 // Adapted from an example on alligator.io (https://alligator.io/css/collapsible/)
 
-.wrap-collapsible {
-  margin-bottom: 0;
-}
-
 input[type='checkbox'].toggle {
   display: none;
 }
@@ -23,19 +19,4 @@ input[type='checkbox'].toggle {
 
 .toggle:checked + .lbl-toggle::before {
   content: "\FF0D";
-}
-
-.collapsible-content {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height .25s ease-in-out;
-}
-
-.toggle:checked + .lbl-toggle + .collapsible-content {
-  max-height: 350px;
-}
-
-.toggle:checked + .lbl-toggle {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #966 

#### What's this PR do?
Updates a CSS rule which made checkboxes invisible by default. Other CSS rules made the checkboxes visible so we didn't see this issue on Chrome or Firefox. My guess is that IE11 has a bug or two with its CSS implementation.

#### How should this be manually tested?
View the checkbox in IE11
