### PR TITLE
Changed edX enrollment mode from audit to professional

### DIFF
--- a/app.json
+++ b/app.json
@@ -283,6 +283,10 @@
       "description": "The OAuth2 client secret to connect to Open edX with",
       "required": true
     },
+    "OPENEDX_API_KEY": {
+      "description": "edX API key (EDX_API_KEY setting in Open edX)",
+      "required": true
+    },
     "OPENEDX_BASE_REDIRECT_URL": {
       "description": "The base redirect URL for an OAuth Application for the Open edX API",
       "required": false

--- a/courseware/constants.py
+++ b/courseware/constants.py
@@ -1,6 +1,14 @@
 """Courseware constants"""
 
 PLATFORM_EDX = "edx"
+EDX_ENROLLMENT_PRO_MODE = "no-id-professional"
+EDX_ENROLLMENT_AUDIT_MODE = "audit"
+PRO_ENROLL_MODE_ERROR_TEXTS = (
+    "The [{}] course mode is expired or otherwise unavailable for course run".format(
+        EDX_ENROLLMENT_PRO_MODE
+    ),
+    "Specified course mode '{}' unavailable for course".format(EDX_ENROLLMENT_PRO_MODE),
+)
 # List of all currently-supported courseware platforms
 COURSEWARE_PLATFORMS = (PLATFORM_EDX,)
 # Currently-supported courseware platforms in a ChoiceField-friendly format

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ x-environment:
   CELERY_RESULT_BACKEND: redis://redis:6379/4
   DOCKER_HOST: ${DOCKER_HOST:-missing}
   WEBPACK_DEV_SERVER_HOST: ${WEBPACK_DEV_SERVER_HOST:-localhost}
+  OPENEDX_API_KEY: ${OPENEDX_API_KEY:-PUT_YOUR_API_KEY_HERE}
 
 x-extra-hosts:
   &default-extra-hosts

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -710,6 +710,12 @@ OPENEDX_API_CLIENT_SECRET = get_string(
     description="The OAuth2 client secret to connect to Open edX with",
     required=True,
 )
+OPENEDX_API_KEY = get_string(
+    "OPENEDX_API_KEY",
+    None,
+    description="edX API key (EDX_API_KEY setting in Open edX)",
+    required=True,
+)
 
 MITXPRO_REGISTRATION_ACCESS_TOKEN = get_string(
     "MITXPRO_REGISTRATION_ACCESS_TOKEN",

--- a/mitxpro/test_utils.py
+++ b/mitxpro/test_utils.py
@@ -50,13 +50,16 @@ class MockResponse:
     Mock requests.Response
     """
 
-    def __init__(self, content, status_code):
-        self.content = content
+    def __init__(self, content, status_code=200):
+        if isinstance(content, str):
+            self.content = json.loads(content)
+        else:
+            self.content = content
         self.status_code = status_code
 
     def json(self):
-        """ Return content as json """
-        return json.loads(self.content)
+        """ Return json content"""
+        return self.content
 
 
 def drf_datetime(dt):

--- a/mitxpro/test_utils_test.py
+++ b/mitxpro/test_utils_test.py
@@ -46,12 +46,19 @@ def test_assert_not_raises_failure():
             assert 1 == 2
 
 
-def test_mock_response():
+@pytest.mark.parametrize(
+    "content,expected_content",
+    [
+        ['{"test": "content"}', {"test": "content"}],
+        [{"test": "content"}, {"test": "content"}],
+    ],
+)
+def test_mock_response(content, expected_content):
     """ assert MockResponse returns correct values """
-    content = "test"
     response = MockResponse(content, 404)
     assert response.status_code == 404
-    assert response.content == content
+    assert response.content == expected_content
+    assert response.json() == expected_content
 
 
 def test_pickleable_mock():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #375 

#### What's this PR do?
Changes edX enrollment mode from `audit` to `no-id-professional`

#### How should this be manually tested?
1. You will need a course that exists in xpro and in your Open edX instance. The edX demo course (course id `course-v1:edX+DemoX+Demo_Course`) exists in all local devstack instances, but any course that exists in both apps should work.
    1. You can use a course that you're already enrolled in with the default `audit` mode. That enrollment will just be updated/overwritten.
1. (__Might be optional! This might only be needed to make the professional mode the default. You can skip this and try applying it if there's a failure__) Make sure LMS has the `no-id-professional` enrollment mode enabled. This can be done by adding this to the top level of your `lms.env.json` file (the server will need to be restarted):
    
    ```json
    "COURSE_MODE_DEFAULTS": {
        "name": "Professional",
        "slug": "no-id-professional",
        "currency": "usd",
        "min_price": 0,
        "bulk_sku": null,
        "description": null,
        "expiration_datetime": null,
        "sku": null,
        "suggested_prices": ""
    }
    ```
1. Make sure your course is configured with the `no-id-professional` enrollment in Open edX. This can be done in Django admin: `/admin/course_modes/coursemode/`. If your course doesn't have a record with the `no-id-professional` mode, add a new record with that mode, and set price: 0, currency: usd, display name: "No-ID Professional". All other values can be blank
1. Use the app to enroll in your course. Alternately, run the following in a Django shell/notebook:
    ```python
    courseware_id = "YOUR_EDX_COURSE_ID" # e.g.: "course-v1:edX+DemoX+Demo_Course"
    user_email = "YOUR_USER_EMAIL" 
    #
    from django.contrib.auth import get_user_model
    User = get_user_model()
    from courseware.api import enroll_in_edx_course_runs
    from courses.models import CourseRun
    user = User.objects.get(email=user_email)
    course_run = CourseRun.objects.get(courseware_id=courseware_id)
    enroll_results = enroll_in_edx_course_runs(user, [course_run])
    print([(res.course_id, res.mode) for res in enroll_results])
    ```

After these steps, you should be successfully enrolled in the edX course with the `no-id-professional` mode.

This PR also includes a failover to try enrolling the user in `audit` mode if the `no-id-professional` enrollment fails and the error says that mode isn't allowed/available. You can test that failover by deleting the `CourseMode` record you created above and trying enrollment again. You should see an error logged, and the `audit` enrollment should succeed
