### PR TITLE
Backend work for b2b enrollment code purchases

### DIFF
--- a/b2b_ecommerce/factories.py
+++ b/b2b_ecommerce/factories.py
@@ -4,7 +4,7 @@ from factory import fuzzy
 from factory.django import DjangoModelFactory
 
 from b2b_ecommerce.models import B2BOrder
-from ecommerce.factories import ProductVersionFactory
+from ecommerce.factories import CouponPaymentVersionFactory, ProductVersionFactory
 
 
 class B2BOrderFactory(DjangoModelFactory):
@@ -14,8 +14,9 @@ class B2BOrderFactory(DjangoModelFactory):
     num_seats = fuzzy.FuzzyInteger(low=0, high=1234)
     email = factory.Faker("email")
     per_item_price = fuzzy.FuzzyDecimal(low=1, high=123)
-    total_price = factory.LazyAttribute(lambda obj: obj.per_item_price)
+    total_price = factory.LazyAttribute(lambda obj: obj.per_item_price * obj.num_seats)
     product_version = factory.SubFactory(ProductVersionFactory)
+    coupon_payment_version = factory.SubFactory(CouponPaymentVersionFactory)
 
     class Meta:
         model = B2BOrder

--- a/b2b_ecommerce/urls.py
+++ b/b2b_ecommerce/urls.py
@@ -18,12 +18,12 @@ urlpatterns = [
         name="b2b-order-fulfillment",
     ),
     path(
-        "api/b2b/codes/<uuid:hash>/",
+        "api/b2b/orders/<uuid:hash>/codes/",
         B2BEnrollmentCodesView.as_view(),
         name="b2b-enrollment-codes",
     ),
     path(
-        "api/b2b/status/<uuid:hash>/",
+        "api/b2b/orders/<uuid:hash>/status/",
         B2BOrderStatusView.as_view(),
         name="b2b-order-status",
     ),

--- a/b2b_ecommerce/urls.py
+++ b/b2b_ecommerce/urls.py
@@ -1,7 +1,12 @@
 """URLs for business to business ecommerce"""
 from django.conf.urls import url
 
-from b2b_ecommerce.views import B2BCheckoutView, B2BOrderFulfillmentView
+from b2b_ecommerce.views import (
+    B2BCheckoutView,
+    B2BOrderFulfillmentView,
+    B2BEnrollmentCodesView,
+    B2BOrderStatusView,
+)
 from mitxpro.views import index
 
 
@@ -11,6 +16,14 @@ urlpatterns = [
         "^api/b2b/order_fulfillment/$",
         B2BOrderFulfillmentView.as_view(),
         name="b2b-order-fulfillment",
+    ),
+    url(
+        "^api/b2b/order_enrollment_codes/$",
+        B2BEnrollmentCodesView.as_view(),
+        name="b2b-enrollment-codes",
+    ),
+    url(
+        "^api/b2b/order_status/$", B2BOrderStatusView.as_view(), name="b2b-order-status"
     ),
     url("^ecommerce/bulk/$", index, name="bulk-enrollment-code"),
     url("^ecommerce/bulk/receipt/$", index, name="bulk-enrollment-code-receipt"),

--- a/b2b_ecommerce/urls.py
+++ b/b2b_ecommerce/urls.py
@@ -1,5 +1,5 @@
 """URLs for business to business ecommerce"""
-from django.conf.urls import url
+from django.urls import path
 
 from b2b_ecommerce.views import (
     B2BCheckoutView,
@@ -11,20 +11,22 @@ from mitxpro.views import index
 
 
 urlpatterns = [
-    url("^api/b2b/checkout/$", B2BCheckoutView.as_view(), name="b2b-checkout"),
-    url(
-        "^api/b2b/order_fulfillment/$",
+    path("api/b2b/checkout/", B2BCheckoutView.as_view(), name="b2b-checkout"),
+    path(
+        "api/b2b/order_fulfillment/",
         B2BOrderFulfillmentView.as_view(),
         name="b2b-order-fulfillment",
     ),
-    url(
-        "^api/b2b/order_enrollment_codes/$",
+    path(
+        "api/b2b/codes/<uuid:hash>/",
         B2BEnrollmentCodesView.as_view(),
         name="b2b-enrollment-codes",
     ),
-    url(
-        "^api/b2b/order_status/$", B2BOrderStatusView.as_view(), name="b2b-order-status"
+    path(
+        "api/b2b/status/<uuid:hash>/",
+        B2BOrderStatusView.as_view(),
+        name="b2b-order-status",
     ),
-    url("^ecommerce/bulk/$", index, name="bulk-enrollment-code"),
-    url("^ecommerce/bulk/receipt/$", index, name="bulk-enrollment-code-receipt"),
+    path("^ecommerce/bulk/", index, name="bulk-enrollment-code"),
+    path("^ecommerce/bulk/receipt/", index, name="bulk-enrollment-code-receipt"),
 ]

--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -141,10 +141,7 @@ class B2BOrderStatusView(APIView):
 
     def get(self, request, *args, **kwargs):
         """Return B2B order status and other information about the order needed to display the receipt"""
-        try:
-            order_hash = request.query_params["hash"]
-        except KeyError:
-            raise ValidationError("Missing query parameter hash")
+        order_hash = kwargs["hash"]
         order = get_object_or_404(B2BOrder, unique_id=order_hash)
 
         return Response(
@@ -171,10 +168,7 @@ class B2BEnrollmentCodesView(APIView):
 
     def get(self, request, *args, **kwargs):
         """Create a CSV with enrollment codes"""
-        try:
-            order_hash = request.GET["hash"]
-        except KeyError:
-            raise ValidationError("Missing query parameter hash")
+        order_hash = kwargs["hash"]
         order = get_object_or_404(B2BOrder, unique_id=order_hash)
 
         response = HttpResponse(content_type="text/csv")

--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -151,7 +151,7 @@ class B2BOrderStatusView(APIView):
                 "total_price": str(order.total_price),
                 "item_price": str(order.per_item_price),
                 "product_version": ProductVersionSerializer(
-                    order.product_version, context={"show_all_runs": True}
+                    order.product_version, context={"all_runs": True}
                 ).data,
                 "email": order.email,
             }

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -9,6 +9,8 @@ from rest_framework import status
 from b2b_ecommerce.factories import B2BOrderFactory, ProductVersionFactory
 from b2b_ecommerce.models import B2BOrder, B2BOrderAudit, B2BReceipt
 from ecommerce.exceptions import EcommerceException
+from ecommerce.factories import CouponVersionFactory
+from ecommerce.serializers import ProductVersionSerializer
 from mitxpro.utils import dict_without_keys
 
 
@@ -50,10 +52,11 @@ def test_create_order(client, mocker):
         return_value=payload,
     )
     product_version = ProductVersionFactory.create()
+    num_seats = 10
     resp = client.post(
         reverse("b2b-checkout"),
         {
-            "num_seats": 10,
+            "num_seats": num_seats,
             "email": "b@example.com",
             "product_version_id": product_version.id,
         },
@@ -66,16 +69,21 @@ def test_create_order(client, mocker):
         "method": "POST",
     }
 
-    base_url = "http://testserver/"
-    receipt_url = urljoin(base_url, reverse("bulk-enrollment-code-receipt"))
     assert B2BOrder.objects.count() == 1
     order = B2BOrder.objects.first()
+    assert order.status == B2BOrder.CREATED
+    assert order.total_price == product_version.price * num_seats
+    assert order.per_item_price == product_version.price
+    assert order.num_seats == num_seats
+    assert order.b2breceipt_set.count() == 0
+    base_url = "http://testserver/"
+    receipt_url = f'{urljoin(base_url, reverse("bulk-enrollment-code-receipt"))}?hash={str(order.unique_id)}'
     assert generate_mock.call_count == 1
     assert generate_mock.call_args[0] == ()
     assert generate_mock.call_args[1] == {
         "order": order,
         "receipt_url": receipt_url,
-        "cancel_url": base_url,
+        "cancel_url": urljoin(base_url, reverse("bulk-enrollment-code")),
     }
 
 
@@ -126,16 +134,16 @@ def test_zero_price_checkout(client):  # pylint:disable=too-many-arguments
             "product_version_id": product_version.id,
         },
     )
+    assert B2BOrder.objects.count() == 1
+    order = B2BOrder.objects.first()
     base_url = "http://testserver"
-    receipt_url = urljoin(base_url, reverse("bulk-enrollment-code-receipt"))
+    receipt_url = f'{urljoin(base_url, reverse("bulk-enrollment-code-receipt"))}?hash={str(order.unique_id)}'
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"payload": {}, "url": receipt_url, "method": "GET"}
 
-    assert B2BOrder.objects.count() == 1
-    order = B2BOrder.objects.first()
     assert order.status == B2BOrder.FULFILLED
     assert order.total_price == 0
-    assert order.per_item_price == 0
+    assert order.per_item_price == product_version.price
     assert order.b2breceipt_set.count() == 0
     assert order.num_seats == 0
 
@@ -268,3 +276,77 @@ def test_no_permission(client, mocker):
     )
     resp = client.post(reverse("b2b-order-fulfillment"), data={})
     assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_order_status(client):
+    """
+    The order status API should provide information about the order based on its unique_id.
+    """
+    order = B2BOrderFactory.create()
+    resp = client.get(reverse("b2b-order-status"), {"hash": str(order.unique_id)})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == {
+        "email": order.email,
+        "num_seats": order.num_seats,
+        "product_version": ProductVersionSerializer(
+            order.product_version, context={"show_all_runs": True}
+        ).data,
+        "item_price": str(order.per_item_price),
+        "total_price": str(order.total_price),
+        "status": order.status,
+    }
+
+
+def test_order_status_missing(client):
+    """
+    A 404 should be returned if the hash does not match
+    """
+    resp = client.get(reverse("b2b-order-status"), {"hash": "xyz"})
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_order_status_no_key(client):
+    """
+    If the hash is not provided a 400 validation error should be returned
+    """
+    resp = client.get(reverse("b2b-order-status"), {})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json() == {"errors": ["Missing query parameter hash"]}
+
+
+def test_enrollment_codes(client):
+    """A CSV file with enrollment codes should be provided for the B2BOrder"""
+    coupon_version = CouponVersionFactory.create()
+    coupons = [coupon_version.coupon] + [
+        CouponVersionFactory.create(
+            payment_version=coupon_version.payment_version
+        ).coupon
+        for _ in range(5)
+    ]
+    order = B2BOrderFactory.create(
+        coupon_payment_version=coupon_version.payment_version
+    )
+
+    resp = client.get(reverse("b2b-enrollment-codes"), {"hash": str(order.unique_id)})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.get("Content-Type") == "text/csv"
+    assert (
+        resp.get("Content-Disposition")
+        == f'attachment; filename="enrollmentcodes-{order.unique_id}.csv"'
+    )
+    assert sorted(resp.content.decode().split()) == sorted(
+        [coupon.coupon_code for coupon in coupons]
+    )
+
+
+def test_enrollment_codes_missing(client):
+    """A 404 error should be returned for a missing B2BOrder"""
+    resp = client.get(reverse("b2b-enrollment-codes"), {"hash": "xyz"})
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_enrollment_codes_no_key(client):
+    """A 400 validation error should be returned for a missing hash key"""
+    resp = client.get(reverse("b2b-enrollment-codes"), {})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json() == {"errors": ["Missing query parameter hash"]}

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -292,7 +292,7 @@ def test_order_status(client):
         "email": order.email,
         "num_seats": order.num_seats,
         "product_version": ProductVersionSerializer(
-            order.product_version, context={"show_all_runs": True}
+            order.product_version, context={"all_runs": True}
         ).data,
         "item_price": str(order.per_item_price),
         "total_price": str(order.total_price),

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -95,8 +95,8 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_courseruns(self, instance):
         """Unexpired and unenrolled course runs"""
-        show_all_runs = self.context.get("show_all_runs", False)
-        if show_all_runs:
+        all_runs = self.context.get("all_runs", False)
+        if all_runs:
             active_runs = instance.unexpired_runs
         else:
             user = self.context["request"].user

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -95,9 +95,19 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_courseruns(self, instance):
         """Unexpired and unenrolled course runs"""
-        user = self.context["request"].user
-        active_runs = instance.available_runs(user)
-        return [CourseRunSerializer(instance=run).data for run in active_runs]
+        show_all_runs = self.context.get("show_all_runs", False)
+        if show_all_runs:
+            active_runs = instance.unexpired_runs
+        else:
+            user = self.context["request"].user
+            if user.is_anonymous:
+                active_runs = []
+            else:
+                active_runs = instance.available_runs(user)
+        return [
+            CourseRunSerializer(instance=run, context=self.context).data
+            for run in active_runs
+        ]
 
     class Meta:
         model = models.Course

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -79,14 +79,14 @@ def test_base_course_serializer():
 
 
 @pytest.mark.parametrize("is_anonymous", [True, False])
-@pytest.mark.parametrize("show_all_runs", [True, False])
-def test_serialize_course(mock_context, is_anonymous, show_all_runs):
+@pytest.mark.parametrize("all_runs", [True, False])
+def test_serialize_course(mock_context, is_anonymous, all_runs):
     """Test Course serialization"""
     if is_anonymous:
         mock_context["request"].user = AnonymousUser()
     user = mock_context["request"].user
-    if show_all_runs:
-        mock_context["show_all_runs"] = True
+    if all_runs:
+        mock_context["all_runs"] = True
     course_run = CourseRunFactory.create(course__no_program=True, live=True)
     course = course_run.course
 
@@ -109,7 +109,7 @@ def test_serialize_course(mock_context, is_anonymous, show_all_runs):
     page = CoursePageFactory.create(course=course)
     data = CourseSerializer(instance=course, context=mock_context).data
 
-    if show_all_runs:
+    if all_runs:
         expected_runs = unexpired_runs
     elif not is_anonymous:
         expected_runs = [course_run]

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -2,7 +2,7 @@
 Tests for course serializers
 """
 # pylint: disable=unused-argument, redefined-outer-name
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import factory
 from django.contrib.auth.models import AnonymousUser
@@ -82,6 +82,7 @@ def test_base_course_serializer():
 @pytest.mark.parametrize("all_runs", [True, False])
 def test_serialize_course(mock_context, is_anonymous, all_runs):
     """Test Course serialization"""
+    now = datetime.now(tz=pytz.UTC)
     if is_anonymous:
         mock_context["request"].user = AnonymousUser()
     user = mock_context["request"].user
@@ -91,14 +92,10 @@ def test_serialize_course(mock_context, is_anonymous, all_runs):
     course = course_run.course
 
     # Create expired, enrollment_ended, future, and enrolled course runs
+    CourseRunFactory.create(course=course, end_date=now - timedelta(1), live=True)
+    CourseRunFactory.create(course=course, enrollment_end=now - timedelta(1), live=True)
     CourseRunFactory.create(
-        course=course, end_date=datetime(2010, 1, 1, tzinfo=pytz.UTC), live=True
-    )
-    CourseRunFactory.create(
-        course=course, enrollment_end=datetime(2010, 1, 1, tzinfo=pytz.UTC), live=True
-    )
-    CourseRunFactory.create(
-        course=course, enrollment_start=datetime(2119, 1, 1, tzinfo=pytz.UTC), live=True
+        course=course, enrollment_start=now + timedelta(1), live=True
     )
     enrolled_run = CourseRunFactory.create(course=course, live=True)
     unexpired_runs = [enrolled_run, course_run]

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -127,6 +127,22 @@ class ProductSerializer(serializers.ModelSerializer):
         model = models.Product
 
 
+class ProductDetailSerializer(ProductSerializer):
+    """Product Serializer with ProductVersion detail included"""
+
+    latest_version = serializers.SerializerMethodField()
+
+    def get_latest_version(self, instance):
+        """Serialize and return the latest ProductVersion for the Product"""
+        return ProductVersionSerializer(
+            instance.latest_version, context={**self.context, "all_runs": True}
+        ).data
+
+    class Meta:
+        fields = ProductSerializer.Meta.fields + ["latest_version"]
+        model = models.Product
+
+
 class CouponSelectionSerializer(serializers.ModelSerializer):
     """CouponSelection serializer for viewing/updating coupons in basket"""
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -119,7 +119,7 @@ class ProductSerializer(serializers.ModelSerializer):
     def get_latest_version(self, instance):
         """Serialize and return the latest ProductVersion for the Product"""
         return ProductVersionSerializer(
-            instance.latest_version, context={**self.context, "show_all_runs": True}
+            instance.latest_version, context={**self.context, "all_runs": True}
         ).data
 
     class Meta:

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -11,14 +11,13 @@ from cms.factories import CoursePageFactory, ProgramPageFactory
 from courses.factories import CourseFactory, ProgramFactory, CourseRunFactory
 from courses.serializers import CourseSerializer
 from courses.constants import CATALOG_COURSE_IMG_WAGTAIL_FILL
-from ecommerce.api import round_half_up
+from ecommerce.api import get_readable_id, round_half_up
 from ecommerce.factories import (
     ProductVersionFactory,
     ProductFactory,
     CompanyFactory,
     DataConsentUserFactory,
     CouponFactory,
-    CouponEligibilityFactory,
     CouponPaymentVersionFactory,
     CouponPaymentFactory,
 )
@@ -42,7 +41,6 @@ from ecommerce.serializers import (
     CompanySerializer,
     DataConsentUserSerializer,
     CouponSerializer,
-    ProductCouponSerializer,
 )
 
 pytestmark = [pytest.mark.django_db]
@@ -70,6 +68,7 @@ def test_serialize_basket_product_version_courserun(mock_context):
         "thumbnail_url": "/static/images/mit-dome.png",
         "object_id": product_version.product.object_id,
         "product_id": product_version.product.id,
+        "readable_id": get_readable_id(product_version.product.content_object),
     }
 
 
@@ -95,6 +94,7 @@ def test_serialize_basket_product_version_program(mock_context):
         "thumbnail_url": "/static/images/mit-dome.png",
         "object_id": product_version.product.object_id,
         "product_id": product_version.product.id,
+        "readable_id": get_readable_id(product_version.product.content_object),
     }
 
 
@@ -340,15 +340,4 @@ def test_serialize_coupon():
         "name": name,
         "coupon_code": code,
         "enabled": True,
-    }
-
-
-def test_serialize_product_coupon():
-    """Test that ProductCouponSerializer produces the correct serialized data"""
-    product_coupon = CouponEligibilityFactory.create()
-    serialized_data = ProductCouponSerializer(instance=product_coupon).data
-    assert serialized_data == {
-        "id": product_coupon.id,
-        "coupon": CouponSerializer(instance=product_coupon.coupon).data,
-        "product": ProductSerializer(instance=product_coupon.product).data,
     }

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -42,6 +42,7 @@ from ecommerce.serializers import (
     CouponPaymentVersionDetailSerializer,
     CompanySerializer,
     ProductSerializer,
+    ProductDetailSerializer,
     PromoCouponSerializer,
     SingleUseCouponSerializer,
     CurrentCouponPaymentSerializer,
@@ -57,7 +58,7 @@ class ProductViewSet(ReadOnlyModelViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    serializer_class = ProductSerializer
+    serializer_class = ProductDetailSerializer
     queryset = Product.objects.all()
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -54,6 +54,9 @@ log = logging.getLogger(__name__)
 class ProductViewSet(ReadOnlyModelViewSet):
     """API view set for Products"""
 
+    authentication_classes = ()
+    permission_classes = ()
+
     serializer_class = ProductSerializer
     queryset = Product.objects.all()
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
Part of #858 

#### What's this PR do?
Adds miscellaneous backend work left out of the previous PR:
 - `total_price` calculation is fixed
 - views for downloading coupon codes and for viewing order information, both using the order hash for lookup
 - Cybersource receipt URL updated to include the order hash as a query parameter
 - Cybersource cancel URL changed to the b2b checkout page (Cybersource errors if this value is the home page)
 - Course serializer will return an empty list of runs for anonymous users. Logged in users get a list of available runs for that user. There is also a context value `show_all_runs` which will show all unexpired runs instead of just the ones for a user.
 - `ProductVersionSerializer` now used by `ProductSerializer` to show more product info
 - `ProductViewSet` now visible to anonymous users

#### How should this be manually tested?
No manual testing yet since there is no frontend
