### PR TITLE
Fix profile edit form

### DIFF
--- a/static/js/containers/pages/profile/EditProfilePage.js
+++ b/static/js/containers/pages/profile/EditProfilePage.js
@@ -54,11 +54,7 @@ export class EditProfilePage extends React.Component<Props> {
             years_experience:
                 profileData.profile.years_experience === ""
                   ? null
-                  : profileData.profile.years_experience,
-            highest_education:
-                profileData.profile.highest_education === ""
-                  ? null
-                  : profileData.profile.highest_education
+                  : profileData.profile.years_experience
           }
         }
         : {})

--- a/static/js/containers/pages/profile/EditProfilePage_test.js
+++ b/static/js/containers/pages/profile/EditProfilePage_test.js
@@ -100,7 +100,7 @@ describe("EditProfilePage", () => {
           // $FlowFixMe
           expectedPayload.profile.years_experience = null
           // $FlowFixMe
-          expectedPayload.profile.highest_education = null
+          expectedPayload.profile.highest_education = ""
         }
 
         sinon.assert.calledWith(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #987 

#### What's this PR do?
Fixes the 'Highest education' field on the profile edit page

#### How should this be manually tested?
Go to the 'Edit Profile' page.  Make some changes to several fields but set 'Highest education' to '----'.  Submit the form.  Your changes should be saved with no errors.
