### PR TITLE
Added new edX enrollment command options and refactored command helpers

### DIFF
--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -2,13 +2,10 @@
 from django.core.management.base import CommandError
 from django.contrib.auth import get_user_model
 
-from courses.management.utils import (
-    EnrollmentChangeCommand,
-    fetch_user,
-    enrollment_summary,
-)
+from courses.management.utils import EnrollmentChangeCommand, enrollment_summary
 from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
 from courses.models import CourseRun, CourseRunEnrollment
+from users.api import fetch_user
 
 User = get_user_model()
 

--- a/courses/management/commands/refund_enrollment.py
+++ b/courses/management/commands/refund_enrollment.py
@@ -1,13 +1,10 @@
 """Management command to change enrollment status"""
 from django.contrib.auth import get_user_model
 
-from courses.management.utils import (
-    EnrollmentChangeCommand,
-    fetch_user,
-    enrollment_summaries,
-)
+from courses.management.utils import EnrollmentChangeCommand, enrollment_summaries
 from courses.constants import ENROLL_CHANGE_STATUS_REFUNDED
 from ecommerce.models import Order
+from users.api import fetch_user
 
 User = get_user_model()
 

--- a/courses/management/commands/transfer_enrollment.py
+++ b/courses/management/commands/transfer_enrollment.py
@@ -2,13 +2,10 @@
 from django.core.management.base import CommandError
 from django.contrib.auth import get_user_model
 
-from courses.management.utils import (
-    EnrollmentChangeCommand,
-    fetch_user,
-    enrollment_summaries,
-)
+from courses.management.utils import EnrollmentChangeCommand, enrollment_summaries
 from courses.constants import ENROLL_CHANGE_STATUS_TRANSFERRED
 from courses.models import CourseRunEnrollment
+from users.api import fetch_user
 
 User = get_user_model()
 

--- a/courses/management/utils.py
+++ b/courses/management/utils.py
@@ -1,18 +1,13 @@
 """Utility functions/classes for course management commands"""
 from functools import partial
 
-from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
-from django.core.validators import validate_email
 from requests.exceptions import HTTPError
 
 from courses.models import CourseRun, CourseRunEnrollment, Program, ProgramEnrollment
 from courseware.api import enroll_in_edx_course_runs
 from ecommerce import mail_api
 from mitxpro.utils import has_equal_properties
-
-User = get_user_model()
 
 
 def enrollment_summary(enrollment):
@@ -40,25 +35,6 @@ def enrollment_summaries(enrollments):
         list of str: A list of string representations of enrollments
     """
     return list(map(enrollment_summary, enrollments))
-
-
-def fetch_user(user_property):
-    """
-    Attempts to fetch a user based on several properties
-
-    Args:
-        user_property (str): The id, email, or username of some User
-    Returns:
-        User: A user that matches the given property
-    """
-    if user_property.isdigit():
-        return User.objects.get(id=int(user_property))
-    else:
-        try:
-            validate_email(user_property)
-            return User.objects.get(email=user_property)
-        except ValidationError:
-            return User.objects.get(username=user_property)
 
 
 def create_or_update_enrollment(model_cls, defaults=None, **kwargs):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -51,8 +51,9 @@ from ecommerce.models import (
     Line,
     Order,
 )
+from ecommerce.utils import send_support_email
 from hubspot.task_helpers import sync_hubspot_deal
-from mitxpro.utils import now_in_utc, send_support_email
+from mitxpro.utils import now_in_utc
 
 log = logging.getLogger(__name__)
 

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -1,8 +1,10 @@
 """Utility functions for ecommerce"""
 import logging
 
-from ecommerce.exceptions import ParseException
+from django.conf import settings
+from django.core import mail
 
+from ecommerce.exceptions import ParseException
 
 log = logging.getLogger(__name__)
 
@@ -55,3 +57,24 @@ def get_order_id_by_reference_number(*, reference_number, prefix):
         raise ParseException("Unable to parse order number")
 
     return order_id
+
+
+def send_support_email(subject, message):
+    """
+    Send an email to support.
+
+    Args:
+        subject (str): The email subject.
+        message (str): The email message.
+    """
+    try:
+        with mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
+            mail.send_mail(
+                subject,
+                message,
+                settings.MAILGUN_FROM_EMAIL,
+                [settings.EMAIL_SUPPORT],
+                connection=connection,
+            )
+    except:  # pylint: disable=bare-except
+        log.exception("Exception sending email to admins")

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -5,13 +5,11 @@ import json
 import logging
 import itertools
 from urllib.parse import urlparse, urlunparse, ParseResult
-
-from django.conf import settings
-from django.core import mail
-from django.core.serializers import serialize
-from django.db import models
 import pytz
 
+from django.conf import settings
+from django.core.serializers import serialize
+from django.db import models
 
 log = logging.getLogger(__name__)
 
@@ -167,27 +165,6 @@ def partition(items, predicate=bool):
     """
     a, b = itertools.tee((predicate(item), item) for item in items)
     return ((item for pred, item in a if not pred), (item for pred, item in b if pred))
-
-
-def send_support_email(subject, message):
-    """
-    Send an email to support.
-
-    Args:
-        subject (str): The email subject.
-        message (str): The email message.
-    """
-    try:
-        with mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
-            mail.send_mail(
-                subject,
-                message,
-                settings.MAILGUN_FROM_EMAIL,
-                [settings.EMAIL_SUPPORT],
-                connection=connection,
-            )
-    except:  # pylint: disable=bare-except
-        log.exception("Exception sending email to admins regarding enrollment failure")
 
 
 class ValidateOnSaveMixin(models.Model):

--- a/users/api.py
+++ b/users/api.py
@@ -1,5 +1,11 @@
 """Users api"""
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.contrib.auth import get_user_model
+
+from mitxpro.utils import first_or_none
+
+User = get_user_model()
 
 
 def get_user_by_id(user_id):
@@ -12,4 +18,61 @@ def get_user_by_id(user_id):
     Returns:
         users.models.User: the user found by id
     """
-    return get_user_model().objects.get(id=user_id)
+    return User.objects.get(id=user_id)
+
+
+def fetch_user(user_property):
+    """
+    Attempts to fetch a user based on several properties
+
+    Args:
+        user_property (Union[str, int]): The id, email, or username of some User
+    Returns:
+        User: A user that matches the given property
+    """
+    if isinstance(user_property, int):
+        return User.objects.get(id=user_property)
+    elif user_property.isdigit():
+        return User.objects.get(id=int(user_property))
+    else:
+        try:
+            validate_email(user_property)
+            return User.objects.get(email=user_property)
+        except ValidationError:
+            return User.objects.get(username=user_property)
+
+
+def fetch_users(user_properties):
+    """
+    Attempts to fetch a set of users based on several properties. The property being searched
+    (i.e.: id, email, or username) is assumed to be the same for all of the given values, so the
+    property type is determined for the first element, then used for all of the values provided.
+
+    Args:
+        user_properties (iterable of Union[str, int]): The ids, emails, or usernames of the target Users
+    Returns:
+        User queryset: Users that match the given properties
+    """
+    first_user_property = first_or_none(user_properties)
+    if not first_user_property:
+        return None
+    if isinstance(first_user_property, int):
+        filter_prop, filter_values = ("id", user_properties)
+    elif first_user_property.isdigit():
+        filter_prop, filter_values = ("id", map(int, user_properties))
+    else:
+        try:
+            validate_email(first_user_property)
+            filter_prop, filter_values = ("email", user_properties)
+        except ValidationError:
+            filter_prop, filter_values = ("username", user_properties)
+    user_qset = User.objects.filter(**{"{}__in".format(filter_prop): filter_values})
+    if not user_qset.count() == len(user_properties):
+        valid_values = user_qset.values_list(filter_prop, flat=True)
+        invalid_values = set(filter_values) - set(valid_values)
+        raise User.DoesNotExist(
+            "Could not find Users with these '{}' values: {}".format(
+                filter_prop, sorted(list(invalid_values))
+            )
+        )
+    return user_qset

--- a/users/api_test.py
+++ b/users/api_test.py
@@ -1,7 +1,87 @@
 """Tests for user api"""
-from users.api import get_user_by_id
+import pytest
+import factory
+
+from django.contrib.auth import get_user_model
+
+from users.api import get_user_by_id, fetch_user, fetch_users
+from users.factories import UserFactory
+
+User = get_user_model()
 
 
 def test_get_user_by_id(user):
     """Tests get_user_by_id"""
     assert get_user_by_id(user.id) == user
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "prop,value,db_value",
+    [
+        ["username", "abcdefgh", None],
+        ["id", 100, None],
+        ["id", "100", 100],
+        ["email", "abc@example.com", None],
+    ],
+)
+def test_fetch_user(prop, value, db_value):
+    """
+    fetch_user should return a User that matches a provided value which represents
+    an id, email, or username
+    """
+    user = UserFactory.create(**{prop: db_value or value})
+    found_user = fetch_user(value)
+    assert user == found_user
+
+
+@pytest.mark.django_db
+def test_fetch_user_fail():
+    """fetch_user should raise an exception if a matching User was not found"""
+    with pytest.raises(User.DoesNotExist):
+        fetch_user("missingemail@example.com")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "prop,values,db_values",
+    [
+        ["username", ["abcdefgh", "ijklmnop", "qrstuvwxyz"], None],
+        ["id", [100, 101, 102], None],
+        ["id", ["100", "101", "102"], [100, 101, 102]],
+        ["email", ["abc@example.com", "def@example.com", "ghi@example.com"], None],
+    ],
+)
+def test_fetch_users(prop, values, db_values):
+    """
+    fetch_users should return a set of Users that match some provided values which represent
+    ids, emails, or usernames
+    """
+    users = UserFactory.create_batch(
+        len(values), **{prop: factory.Iterator(db_values or values)}
+    )
+    found_users = fetch_users(values)
+    assert set(users) == set(found_users)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "prop,existing_values,missing_values",
+    [
+        ["username", ["abcdefgh"], ["ijklmnop", "qrstuvwxyz"]],
+        ["id", [100], [101, 102]],
+        ["email", ["abc@example.com"], ["def@example.com", "ghi@example.com"]],
+    ],
+)
+def test_fetch_users_fail(prop, existing_values, missing_values):
+    """
+    fetch_users should raise an exception if any provided values did not match a User, and
+    the exception message should contain info about the values that did not match.
+    """
+    fetch_users_values = existing_values + missing_values
+    UserFactory.create_batch(
+        len(existing_values), **{prop: factory.Iterator(existing_values)}
+    )
+    expected_missing_value_output = str(sorted(list(missing_values)))
+    with pytest.raises(User.DoesNotExist, match=expected_missing_value_output):
+        fetch_users(fetch_users_values)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket - related to #970 

#### What's this PR do?
Adds options to the `retry_edx_enrollment` so that (a) enrollment can be retried even if `edx_enrolled=True`, (b) a specific course run can be targeted, and (c) users can be targeted based on email and id in addition to username.

#### How should this be manually tested?
- Create an enrollment for some user with `edx_enrolled=True` (probably easiest just to add in Django admin/shell), then run the retry command: `manage.py retry_edx_enrollment -f --run <YOUR_COURSE_RUN_TEXT_ID> <YOUR_USER_EMAIL>`. The output should be as expected given your enrollment state in edX (and whether or not the course exists on edX)
- Use the command as you would have before and check the results: `manage.py retry_edx_enrollment <USERNAME_1> <USERNAME_2>`

#### Any background context you want to provide?
- Part of the reason for this change is that we want to use a new edX enrollment mode (`no-id-professional` instead of `audit`). In order to protect against possible configuration failures in production that would cause the new enrollment mode to fail, we attempt to enroll the user in `audit` mode as a kind of failover. The updates to the `retry_edx_enrollment` command will allow us to easily 'upgrade' any `audit` enrollments to `no-id-professional` mode.
- The command should be backwards-compatible, i.e.: you should be able to invoke it exactly the same as you would have before this change.
