### PR TITLE
Enabled case-insensitive email search in management commands

### DIFF
--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -167,6 +167,32 @@ def partition(items, predicate=bool):
     return ((item for pred, item in a if not pred), (item for pred, item in b if pred))
 
 
+def unique(iterable):
+    """
+    Returns a generator containing all unique items in an iterable
+
+    Args:
+        iterable (iterable): An iterable of any hashable items
+    Returns:
+        generator: Unique items in the given iterable
+    """
+    seen = set()
+    return (x for x in iterable if x not in seen and not seen.add(x))
+
+
+def unique_ignore_case(strings):
+    """
+    Returns a generator containing all unique strings (coerced to lowercase) in a given iterable
+
+    Args:
+        strings (iterable of str): An iterable of strings
+    Returns:
+        generator: Unique lowercase strings in the given iterable
+    """
+    seen = set()
+    return (s for s in map(str.lower, strings) if s not in seen and not seen.add(s))
+
+
 class ValidateOnSaveMixin(models.Model):
     """Mixin that calls field/model validation methods before saving a model object"""
 

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -16,6 +16,8 @@ from mitxpro.utils import (
     has_equal_properties,
     remove_password_from_url,
     first_or_none,
+    unique,
+    unique_ignore_case,
 )
 
 
@@ -117,3 +119,19 @@ def test_first_or_none():
     assert first_or_none(set()) is None
     assert first_or_none([1, 2, 3]) == 1
     assert first_or_none(range(1, 5)) == 1
+
+
+def test_unique():
+    """
+    Assert that unique() returns a generator of unique elements from a provided iterable
+    """
+    assert list(unique([1, 2, 2, 3, 3, 0, 3])) == [1, 2, 3, 0]
+    assert list(unique(("a", "b", "a", "c", "C", None))) == ["a", "b", "c", "C", None]
+
+
+def test_unique_ignore_case():
+    """
+    Assert that unique_ignore_case() returns a generator of unique lowercase strings from a
+    provided iterable
+    """
+    assert list(unique_ignore_case(["ABC", "def", "AbC", "DEf"])) == ["abc", "def"]

--- a/users/api.py
+++ b/users/api.py
@@ -1,11 +1,17 @@
 """Users api"""
+from functools import reduce
+import operator
+
+from django.db.models import Q
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.contrib.auth import get_user_model
 
-from mitxpro.utils import first_or_none
+from mitxpro.utils import first_or_none, unique, unique_ignore_case
 
 User = get_user_model()
+
+CASE_INSENSITIVE_SEARCHABLE_FIELDS = {"email"}
 
 
 def get_user_by_id(user_id):
@@ -21,58 +27,118 @@ def get_user_by_id(user_id):
     return User.objects.get(id=user_id)
 
 
-def fetch_user(user_property):
+def _is_case_insensitive_searchable(field_name):
+    """
+    Indicates whether or not a given field in the User model is a string field
+
+    Args:
+        field_name (str): The name of the User field
+    Return:
+        bool: True if the given User field is a string field
+    """
+    return field_name in CASE_INSENSITIVE_SEARCHABLE_FIELDS
+
+
+def _determine_filter_field(user_property):
+    """
+    Assesses the value provided to search for a User and returns the field name that should
+    be used for the query (e.g.: "id", "username", "email")
+
+    Args:
+        user_property (str): The id/username/email value being used to find Users
+    Returns:
+        str: User field name that should be used for a query based on the value provided
+    """
+    if isinstance(user_property, int) or user_property.isdigit():
+        return "id"
+    else:
+        try:
+            validate_email(user_property)
+            return "email"
+        except ValidationError:
+            return "username"
+
+
+def fetch_user(filter_value, ignore_case=True):
     """
     Attempts to fetch a user based on several properties
 
     Args:
-        user_property (Union[str, int]): The id, email, or username of some User
+        filter_value (Union[str, int]): The id, email, or username of some User
+        ignore_case (bool): If True, the User query will be case-insensitive
     Returns:
         User: A user that matches the given property
     """
-    if isinstance(user_property, int):
-        return User.objects.get(id=user_property)
-    elif user_property.isdigit():
-        return User.objects.get(id=int(user_property))
+    filter_field = _determine_filter_field(filter_value)
+
+    if _is_case_insensitive_searchable(filter_field) and ignore_case:
+        query = {"{}__iexact".format(filter_field): filter_value}
     else:
-        try:
-            validate_email(user_property)
-            return User.objects.get(email=user_property)
-        except ValidationError:
-            return User.objects.get(username=user_property)
+        query = {filter_field: filter_value}
+    try:
+        return User.objects.get(**query)
+    except User.DoesNotExist as e:
+        raise User.DoesNotExist(
+            "Could not find User with {}={} ({})".format(
+                filter_field,
+                filter_value,
+                "case-insensitive" if ignore_case else "case-sensitive",
+            )
+        ) from e
 
 
-def fetch_users(user_properties):
+def fetch_users(filter_values, ignore_case=True):
     """
     Attempts to fetch a set of users based on several properties. The property being searched
     (i.e.: id, email, or username) is assumed to be the same for all of the given values, so the
     property type is determined for the first element, then used for all of the values provided.
 
     Args:
-        user_properties (iterable of Union[str, int]): The ids, emails, or usernames of the target Users
+        filter_values (iterable of Union[str, int]): The ids, emails, or usernames of the target Users
+        ignore_case (bool): If True, the User query will be case-insensitive
     Returns:
-        User queryset: Users that match the given properties
+        User queryset or None: Users that match the given properties
     """
-    first_user_property = first_or_none(user_properties)
+
+    first_user_property = first_or_none(filter_values)
     if not first_user_property:
         return None
-    if isinstance(first_user_property, int):
-        filter_prop, filter_values = ("id", user_properties)
-    elif first_user_property.isdigit():
-        filter_prop, filter_values = ("id", map(int, user_properties))
+    filter_field = _determine_filter_field(first_user_property)
+    is_case_insensitive_searchable = _is_case_insensitive_searchable(filter_field)
+
+    unique_filter_values = set(
+        unique_ignore_case(filter_values)
+        if is_case_insensitive_searchable and ignore_case
+        else unique(filter_values)
+    )
+    if len(filter_values) > len(unique_filter_values):
+        raise ValidationError(
+            "Duplicate values provided ({})".format(
+                set(filter_values).intersection(unique_filter_values)
+            )
+        )
+
+    if is_case_insensitive_searchable and ignore_case:
+        query = reduce(
+            operator.or_,
+            (
+                Q(**{"{}__iexact".format(filter_field): filter_value})
+                for filter_value in filter_values
+            ),
+        )
+        user_qset = User.objects.filter(query)
     else:
-        try:
-            validate_email(first_user_property)
-            filter_prop, filter_values = ("email", user_properties)
-        except ValidationError:
-            filter_prop, filter_values = ("username", user_properties)
-    user_qset = User.objects.filter(**{"{}__in".format(filter_prop): filter_values})
-    if not user_qset.count() == len(user_properties):
-        valid_values = user_qset.values_list(filter_prop, flat=True)
+        user_qset = User.objects.filter(
+            **{"{}__in".format(filter_field): filter_values}
+        )
+    if not user_qset.count() == len(filter_values):
+        valid_values = user_qset.values_list(filter_field, flat=True)
         invalid_values = set(filter_values) - set(valid_values)
         raise User.DoesNotExist(
-            "Could not find Users with these '{}' values: {}".format(
-                filter_prop, sorted(list(invalid_values))
+            "Could not find Users with these '{}' values ({}): {}".format(
+                filter_field,
+                "case-insensitive" if ignore_case else "case-sensitive",
+                sorted(list(invalid_values)),
             )
         )
     return user_qset

--- a/users/api_test.py
+++ b/users/api_test.py
@@ -36,6 +36,17 @@ def test_fetch_user(prop, value, db_value):
 
 
 @pytest.mark.django_db
+def test_fetch_user_case_sens():
+    """fetch_user should be able to fetch a User with a case-insensitive filter"""
+    email = "abc@example.com"
+    user = UserFactory.create(email=email)
+    upper_email = email.upper()
+    with pytest.raises(User.DoesNotExist):
+        fetch_user(upper_email, ignore_case=False)
+    assert fetch_user(upper_email, ignore_case=True) == user
+
+
+@pytest.mark.django_db
 def test_fetch_user_fail():
     """fetch_user should raise an exception if a matching User was not found"""
     with pytest.raises(User.DoesNotExist):
@@ -62,6 +73,17 @@ def test_fetch_users(prop, values, db_values):
     )
     found_users = fetch_users(values)
     assert set(users) == set(found_users)
+
+
+@pytest.mark.django_db
+def test_fetch_users_case_sens():
+    """fetch_users should be able to fetch Users with a case-insensitive filter"""
+    emails = ["abc@example.com", "def@example.com", "ghi@example.com"]
+    users = UserFactory.create_batch(len(emails), email=factory.Iterator(emails))
+    upper_emails = list(map(str.upper, emails))
+    with pytest.raises(User.DoesNotExist):
+        fetch_users(upper_emails, ignore_case=False)
+    assert set(fetch_users(upper_emails, ignore_case=True)) == set(users)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #993 

#### What's this PR do?
Enables case-insensitive email search in management commands such as `defer_`/`transfer_`/`refund_enrollment` and `retry_edx_enrollment`

#### How should this be manually tested?
Run the commands mentioned above and provide email values with randomly capitalized characters. You should not see a `User.DoesNotExist` error
