### PR TITLE
Send email after enrollment code order is fulfilled

### DIFF
--- a/b2b_ecommerce/api.py
+++ b/b2b_ecommerce/api.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import transaction
 
 from ecommerce.api import create_coupons, ISO_8601_FORMAT, sign_cybersource_payload
+from ecommerce.mail_api import send_b2b_receipt_email
 from ecommerce.models import CouponPaymentVersion
 from mitxpro.utils import now_in_utc
 
@@ -28,6 +29,8 @@ def complete_b2b_order(order):
         )
         order.coupon_payment_version = payment_version
         order.save()
+
+    send_b2b_receipt_email(order)
 
 
 def _generate_b2b_cybersource_sa_payload(*, order, receipt_url, cancel_url):

--- a/b2b_ecommerce/serializers.py
+++ b/b2b_ecommerce/serializers.py
@@ -1,1 +1,0 @@
-"""Serializers for business to business ecommerce"""

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -915,8 +915,8 @@ def create_coupons(
         company_id (int): The id for a Company object
         tag (str): The tag for the CouponPayment
         automatic (bool): Whether or not the coupon should be applied automatically
-        activation_date (datetime): The date after which the coupon is valid. If None, the coupon is valid
-        expiration_date (datetime): The date before which the coupon is valid. If None, the coupon never expires
+        activation_date (datetime.datetime): The date after which the coupon is valid. If None, the coupon is valid
+        expiration_date (datetime.datetime): The date before which the coupon is valid. If None, the coupon never expires
         amount (decimal.Decimal): The percent of the coupon, between 0 and 1 (inclusive)
         num_coupon_codes (int): The number of coupon codes which should be created for the CouponPayment
         coupon_type (str): The type of coupon

--- a/mail/constants.py
+++ b/mail/constants.py
@@ -5,10 +5,12 @@ EMAIL_PW_RESET = "password_reset"
 EMAIL_BULK_ENROLL = "bulk_enroll"
 EMAIL_COURSE_RUN_ENROLLMENT = "course_run_enrollment"
 EMAIL_COURSE_RUN_UNENROLLMENT = "course_run_unenrollment"
+EMAIL_B2B_RECEIPT = "b2b_receipt"
 
 EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_VERIFICATION: "Verify Email",
     EMAIL_PW_RESET: "Password Reset",
     EMAIL_BULK_ENROLL: "Bulk Enrollment",
     EMAIL_COURSE_RUN_ENROLLMENT: "Course Run Enrollment",
+    EMAIL_B2B_RECEIPT: "Enrollment Code Purchase Receipt",
 }

--- a/mail/templates/b2b_receipt/body.html
+++ b/mail/templates/b2b_receipt/body.html
@@ -1,0 +1,58 @@
+{% extends "email_base.html" %}
+
+{% block content %}
+<!-- 1 Column Text + Button : BEGIN -->
+  <tr>
+      <td style="background-color: #ffffff;">
+          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>
+                  <td style="padding: 20px; font-weight: 600; font-family: sans-serif; font-size: 13px; line-height: 20px; color: #2a2a2a;">
+                      <h1 style="margin: 0 0 10px; font-size: 25px; line-height: 30px; color: #03152d; font-weight: bold;">Receipt</h1>
+                      <p style="margin: 0 0 10px;">
+                          <span style="color: #8a8b8c">Date:</span><br />
+                          {{ purchase_date }}
+                      </p>
+                      <p>
+                          <span style="color: #8a8b8c">Order Number:</span><br/>
+                          {{ order_reference_id }}
+                      </p>
+                      <p>
+                          <span style="color: #8a8b8c">Email Address:</span><br />
+                          {{ email }}
+                      </p>
+
+                      <table style="background-color: #f5f5f5; width: 100%;">
+                          <tr>
+                              <td style="padding: 20px; vertical-align: top" colspan="2">
+                                  <span style="color: #8a8b8c">Order Items:</span><br />
+                                  {{ title }}<br />
+                                  {% if run_date_range %}
+                                      {{ run_date_range }}<br />
+                                  {% endif %}
+                                  {{ readable_id }}<br />
+                              </td>
+                              <td style="padding: 20px; vertical-align: top">
+                                  <span style="color: #8a8b8c">Quantity</span><br />
+                                  {{ num_seats }}
+                              </td>
+                              <td style="padding: 20px; vertical-align: top">
+                                  <span style="color: #8a8b8c">Price Per</span><br />
+                                  {{ item_price }}
+                              </td>
+                              <td style="padding: 20px; vertical-align: top">
+                                  <span style="color: #8a8b8c">Total Paid</span><br />
+                                  {{ total_price }}
+                              </td>
+                          </tr>
+                      </table>
+
+                      <p>
+                          <a href="{{ download_url }}">Download enrollment codes and view your receipt</a>
+                      </p>
+                  </td>
+              </tr>
+          </table>
+      </td>
+  </tr>
+<!-- 1 Column Text + Button : END -->
+{% endblock %}

--- a/mail/templates/b2b_receipt/subject.txt
+++ b/mail/templates/b2b_receipt/subject.txt
@@ -1,0 +1,1 @@
+Enrollment Code Purchase Receipt

--- a/mail/views.py
+++ b/mail/views.py
@@ -7,7 +7,12 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from mail import api
-from mail.constants import EMAIL_VERIFICATION, EMAIL_PW_RESET, EMAIL_BULK_ENROLL
+from mail.constants import (
+    EMAIL_VERIFICATION,
+    EMAIL_PW_RESET,
+    EMAIL_BULK_ENROLL,
+    EMAIL_B2B_RECEIPT,
+)
 from mail.forms import EmailDebuggerForm
 
 
@@ -17,6 +22,18 @@ EMAIL_DEBUG_EXTRA_CONTEXT = {
     EMAIL_BULK_ENROLL: {
         "enrollable_title": "Dummy Course Title",
         "enrollment_url": "http://www.example.com/enroll?course_id=1234",
+    },
+    EMAIL_B2B_RECEIPT: {
+        "download_url": "http://b2b.example.com",
+        "title": "Course run or Program title",
+        "run_date_range": "Jan 1, 2020 - Mar 15, 2020",
+        "item_price": "$12,345.12",
+        "total_price": "$24,690.24",
+        "num_seats": "2",
+        "order_reference_id": "XPRO-ENROLLMENT-user.mitxpro-3",
+        "readable_id": "program-v1:xPRO+AMx",
+        "email": "mitx-purchaser@example.com",
+        "purchase_date": "May 30, 2019",
     },
 }
 

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -236,3 +236,16 @@ def remove_password_from_url(url):
             fragment=pieces.fragment,
         )
     )
+
+
+def format_price(amount):
+    """
+    Format a price in USD
+
+    Args:
+        amount (decimal.Decimal): A decimal value
+
+    Returns:
+        str: A currency string
+    """
+    return f"${amount:0,.2f}"

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -1,5 +1,6 @@
 """Utils tests"""
 import datetime
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -7,6 +8,7 @@ import pytz
 
 from ecommerce.models import Order
 from mitxpro.utils import (
+    format_price,
     get_field_names,
     now_in_utc,
     is_near_now,
@@ -135,3 +137,12 @@ def test_unique_ignore_case():
     provided iterable
     """
     assert list(unique_ignore_case(["ABC", "def", "AbC", "DEf"])) == ["abc", "def"]
+
+
+@pytest.mark.parametrize(
+    "price,expected",
+    [[Decimal("0"), "$0.00"], [Decimal("1234567.89"), "$1,234,567.89"]],
+)
+def test_format_price(price, expected):
+    """Format a decimal value into a price"""
+    assert format_price(price) == expected


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #858 

#### What's this PR do?
Adds functionality to send the email with a link back to the receipt page.

#### How should this be manually tested?
 - Go to `/ecommerce/bulk/` and purchase some coupons. Complete the CyberSource transaction and you should be directed back to the receipt page which will show a loading indication while it waits for order fulfillment. 
 - I'm getting the Cybersource receipt emails for the test server. Ask me for the receipt email and I'll forward it to you. You can simulate the Cybersource order fulfillment with this script: https://gist.github.com/noisecapella/5aa1073c895d99d991b85289cb26f0d9
 - After fulfillment you should get an email with a link to the receipt page.

#### Screenshots (if appropriate)
![Screenshot from 2019-08-15 17-10-07](https://user-images.githubusercontent.com/863262/63128926-38bcdb00-bf84-11e9-99fe-162db8b7c04f.png)

