### PR TITLE
Add modal selection widget for enrollment code purchase form

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -95,6 +95,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             "object_id",
             "product_id",
             "readable_id",
+            "created_on",
         ]
         model = models.ProductVersion
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -69,6 +69,7 @@ def test_serialize_basket_product_version_courserun(mock_context):
         "object_id": product_version.product.object_id,
         "product_id": product_version.product.id,
         "readable_id": get_readable_id(product_version.product.content_object),
+        "created_on": product_version.created_on.strftime(datetime_millis_format),
     }
 
 
@@ -95,6 +96,7 @@ def test_serialize_basket_product_version_program(mock_context):
         "object_id": product_version.product.object_id,
         "product_id": product_version.product.id,
         "readable_id": get_readable_id(product_version.product.content_object),
+        "created_on": product_version.created_on.strftime(datetime_millis_format),
     }
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -62,7 +62,7 @@ class ProductViewSet(ReadOnlyModelViewSet):
     permission_classes = ()
 
     serializer_class = ProductDetailSerializer
-    queryset = Product.objects.all()
+    queryset = Product.objects.exclude(productversions=None)
 
 
 class CompanyViewSet(ReadOnlyModelViewSet):

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -985,6 +985,15 @@ def test_products_viewset_list(user_drf_client, coupon_product_ids):
         )
 
 
+def test_products_viewset_list_missing_versions(user_drf_client):
+    """ProductViewSet should exclude Product without any ProductVersion"""
+    product = ProductVersionFactory.create().product
+    assert len(user_drf_client.get(reverse("products_api-list")).json()) == 1
+    with unprotect_version_tables():
+        product.latest_version.delete()
+    assert len(user_drf_client.get(reverse("products_api-list")).json()) == 0
+
+
 def test_products_viewset_detail(user_drf_client, coupon_product_ids):
     """ Test that the ProductViewSet returns details for a product """
     response = user_drf_client.get(

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -65,8 +65,10 @@ const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
             </div>
           </div>
           <div className="row">
-            <div className="col-lg-6">
-              <p>Purchase one or more seats for your team.</p>
+            <div className="col-lg-5">
+              <p className="purchase-title">
+                Purchase one or more seats for your team.
+              </p>
               <label htmlFor="product">
                 <span className="description">
                   Select to view available courses or programs:
@@ -80,13 +82,13 @@ const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
               </label>
 
               <label htmlFor="num_seats">
-                <span className="description">* Number of Seats:</span>
+                <span className="description">*Number of Seats:</span>
                 <Field type="text" name="num_seats" className="num-seats" />
                 <ErrorMessage name="num_seats" render={errorMessageRenderer} />
               </label>
 
               <label htmlFor="email">
-                <span className="description">* Email Address:</span>
+                <span className="description">*Email Address:</span>
                 <Field type="text" name="email" />
                 <span className="explanation">
                   * We will email the link to the enrollment codes to this
@@ -95,7 +97,7 @@ const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
                 <ErrorMessage name="email" render={errorMessageRenderer} />
               </label>
             </div>
-            <div className="col-lg-2" />
+            <div className="col-lg-3" />
             <div className="col-lg-4">
               <B2BPurchaseSummary
                 itemPrice={itemPrice}

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -65,10 +65,12 @@ const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
             </div>
           </div>
           <div className="row">
-            <div className="col-lg-8">
+            <div className="col-lg-6">
               <p>Purchase one or more seats for your team.</p>
               <label htmlFor="product">
-                <h5>Select to view available courses or programs:</h5>
+                <span className="description">
+                  Select to view available courses or programs:
+                </span>
                 <Field
                   component={ProductSelector}
                   products={products}
@@ -89,6 +91,7 @@ const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
                 <ErrorMessage name="email" render={errorMessageRenderer} />
               </label>
             </div>
+            <div className="col-lg-2" />
             <div className="col-lg-4">
               <B2BPurchaseSummary
                 itemPrice={itemPrice}

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -21,7 +21,7 @@ export const validate = (values: Object) => {
 
   const numSeats = parseInt(values.num_seats)
   if (isNaN(numSeats) || numSeats <= 0) {
-    errors.num_seats = "Number of seats is required"
+    errors.num_seats = "Number of Seats is required"
   }
 
   if (!values.email.includes("@")) {
@@ -80,14 +80,18 @@ const B2BPurchaseForm = ({ onSubmit, products, requestPending }: Props) => (
               </label>
 
               <label htmlFor="num_seats">
-                *Number of seats:
+                <span className="description">* Number of Seats:</span>
                 <Field type="text" name="num_seats" className="num-seats" />
                 <ErrorMessage name="num_seats" render={errorMessageRenderer} />
               </label>
 
               <label htmlFor="email">
-                *Email Address:
+                <span className="description">* Email Address:</span>
                 <Field type="text" name="email" />
+                <span className="explanation">
+                  * We will email the link to the enrollment codes to this
+                  address.
+                </span>
                 <ErrorMessage name="email" render={errorMessageRenderer} />
               </label>
             </div>

--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -107,7 +107,7 @@ describe("B2BPurchaseForm", () => {
         }),
         {
           email:     "Email is required",
-          num_seats: "Number of seats is required",
+          num_seats: "Number of Seats is required",
           product:   "No product selected"
         }
       )
@@ -120,7 +120,7 @@ describe("B2BPurchaseForm", () => {
           email:     "",
           product:   ""
         }).num_seats,
-        "Number of seats is required"
+        "Number of Seats is required"
       )
     })
 

--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -31,7 +31,7 @@ type State = {
 }
 export default class ProductSelector extends React.Component<Props, State> {
   state = {
-    productType:  "courserun",
+    productType:  PRODUCT_TYPE_COURSERUN,
     dropdownOpen: false
   }
 
@@ -68,6 +68,8 @@ export default class ProductSelector extends React.Component<Props, State> {
         selectedRun = findRunInProduct(selectedProduct)
       }
     }
+    const productTypeText =
+      productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"
 
     return (
       <div className="product-selector">
@@ -78,7 +80,7 @@ export default class ProductSelector extends React.Component<Props, State> {
                 productType === PRODUCT_TYPE_COURSERUN ? "selected" : ""
               } select-product-type`}
               onClick={preventDefaultAndInvoke(() =>
-                this.updateProductType("courserun")
+                this.updateProductType(PRODUCT_TYPE_COURSERUN)
               )}
             >
               Course
@@ -99,8 +101,7 @@ export default class ProductSelector extends React.Component<Props, State> {
         <div className="row">
           <div className="col-12">
             <span className="description choose-description">
-              *Choose a{" "}
-              {productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"}:
+              *Choose a {productTypeText}:
             </span>
             <button
               className="select-product"
@@ -108,8 +109,7 @@ export default class ProductSelector extends React.Component<Props, State> {
                 this.toggleDropdownVisibility()
               )}
             >
-              Click to select{" "}
-              {productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"}
+              Click to select {productTypeText}
             </button>
             <br />
             <Dropdown

--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -98,8 +98,8 @@ export default class ProductSelector extends React.Component<Props, State> {
 
         <div className="row">
           <div className="col-12">
-            <span className="description">
-              * Choose a{" "}
+            <span className="description choose-description">
+              *Choose a{" "}
               {productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"}:
             </span>
             <button
@@ -130,7 +130,7 @@ export default class ProductSelector extends React.Component<Props, State> {
               </DropdownMenu>
             </Dropdown>
             {selectedProduct ? (
-              <React.Fragment>
+              <div className="selected-product-title">
                 {selectedProduct.title}
                 <br />
                 {selectedRun ? (
@@ -142,7 +142,7 @@ export default class ProductSelector extends React.Component<Props, State> {
                 <span className="description">
                   {selectedProduct.latest_version.readable_id}
                 </span>
-              </React.Fragment>
+              </div>
             ) : null}
           </div>
         </div>

--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -99,7 +99,7 @@ export default class ProductSelector extends React.Component<Props, State> {
         <div className="row">
           <div className="col-12">
             <span className="description">
-              Choose{" "}
+              * Choose a{" "}
               {productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"}:
             </span>
             <button

--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -1,12 +1,17 @@
 // @flow
 import React from "react"
+import { Dropdown, DropdownToggle, DropdownMenu } from "reactstrap"
+
+import ProductSelectorMenu from "./ProductSelectorMenu"
 
 import { preventDefaultAndInvoke } from "../../lib/util"
+import { findRunInProduct, formatRunTitle } from "../../lib/ecommerce"
+import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants"
 
-import type { Product } from "../../flow/ecommerceTypes"
+import type { ProductDetail } from "../../flow/ecommerceTypes"
 
 type Props = {
-  products: Array<Product>,
+  products: Array<ProductDetail>,
   field: {
     name: string,
     value: Object,
@@ -21,11 +26,13 @@ type Props = {
 }
 type ProductType = "courserun" | "program"
 type State = {
-  productType: ProductType
+  productType: ProductType,
+  dropdownOpen: boolean
 }
 export default class ProductSelector extends React.Component<Props, State> {
   state = {
-    productType: "courserun"
+    productType:  "courserun",
+    dropdownOpen: false
   }
 
   updateProductType = (productType: ProductType) => {
@@ -39,19 +46,37 @@ export default class ProductSelector extends React.Component<Props, State> {
     onChange({ target: { value: "", name } })
   }
 
+  toggleDropdownVisibility = () => {
+    this.setState({
+      dropdownOpen: !this.state.dropdownOpen
+    })
+  }
+
   render() {
     const {
       field: { onChange, name, value },
       products
     } = this.props
-    const { productType } = this.state
+    const { dropdownOpen, productType } = this.state
+    let selectedProduct, selectedRun
+    if (value) {
+      selectedProduct = products.find(_product => _product.id === value)
+      if (
+        selectedProduct &&
+        selectedProduct.product_type === PRODUCT_TYPE_COURSERUN
+      ) {
+        selectedRun = findRunInProduct(selectedProduct)
+      }
+    }
 
     return (
       <div className="product-selector">
         <div className="row">
           <div className="col-12">
             <button
-              className={productType === "courserun" ? "selected" : ""}
+              className={`${
+                productType === PRODUCT_TYPE_COURSERUN ? "selected" : ""
+              } select-product-type`}
               onClick={preventDefaultAndInvoke(() =>
                 this.updateProductType("courserun")
               )}
@@ -59,9 +84,11 @@ export default class ProductSelector extends React.Component<Props, State> {
               Course
             </button>
             <button
-              className={productType === "program" ? "selected" : ""}
+              className={`${
+                productType === PRODUCT_TYPE_PROGRAM ? "selected" : ""
+              } select-product-type`}
               onClick={preventDefaultAndInvoke(() =>
-                this.updateProductType("program")
+                this.updateProductType(PRODUCT_TYPE_PROGRAM)
               )}
             >
               Program
@@ -71,18 +98,52 @@ export default class ProductSelector extends React.Component<Props, State> {
 
         <div className="row">
           <div className="col-12">
-            <select onChange={onChange} name={name} value={value.product}>
-              <option value={""} key={"null"}>
-                Select a product
-              </option>
-              {products
-                .filter(product => product.product_type === productType)
-                .map(product => (
-                  <option value={product.id} key={product.id}>
-                    {product.title}
-                  </option>
-                ))}
-            </select>
+            <span className="description">
+              Choose{" "}
+              {productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"}:
+            </span>
+            <button
+              className="select-product"
+              onClick={preventDefaultAndInvoke(() =>
+                this.toggleDropdownVisibility()
+              )}
+            >
+              Click to select{" "}
+              {productType === PRODUCT_TYPE_PROGRAM ? "Program" : "Course"}
+            </button>
+            <br />
+            <Dropdown
+              isOpen={dropdownOpen}
+              toggle={this.toggleDropdownVisibility}
+            >
+              <DropdownToggle tag="span" />
+              <DropdownMenu>
+                <div className="triangle" />
+                <ProductSelectorMenu
+                  products={products}
+                  productType={productType}
+                  onChange={onChange}
+                  name={name}
+                  selectedProductId={value}
+                  toggleDropdown={this.toggleDropdownVisibility}
+                />
+              </DropdownMenu>
+            </Dropdown>
+            {selectedProduct ? (
+              <React.Fragment>
+                {selectedProduct.title}
+                <br />
+                {selectedRun ? (
+                  <React.Fragment>
+                    {formatRunTitle(selectedRun)}
+                    <br />
+                  </React.Fragment>
+                ) : null}
+                <span className="description">
+                  {selectedProduct.latest_version.readable_id}
+                </span>
+              </React.Fragment>
+            ) : null}
           </div>
         </div>
       </div>

--- a/static/js/components/input/ProductSelectorMenu.js
+++ b/static/js/components/input/ProductSelectorMenu.js
@@ -52,10 +52,12 @@ const ProductSelectorMenu = ({
               toggleDropdown()
             })}
           >
-            <img
-              src={product.latest_version.thumbnail_url}
-              alt={`Image for ${product.title}`}
-            />
+            <div>
+              <img
+                src={product.latest_version.thumbnail_url}
+                alt={`Image for ${product.title}`}
+              />
+            </div>
             <div className="menu-item-description">
               <span className="product-title">{product.title}</span>
               <br />

--- a/static/js/components/input/ProductSelectorMenu.js
+++ b/static/js/components/input/ProductSelectorMenu.js
@@ -1,0 +1,72 @@
+// @flow
+import React from "react"
+import { sortBy } from "ramda"
+
+import { preventDefaultAndInvoke } from "../../lib/util"
+import { findRunInProduct, formatRunTitle } from "../../lib/ecommerce"
+import { PRODUCT_TYPE_COURSERUN } from "../../constants"
+
+import type { ProductDetail } from "../../flow/ecommerceTypes"
+
+type ProductType = "courserun" | "program"
+type Props = {
+  products: Array<ProductDetail>,
+  productType: ProductType,
+  onChange: Function,
+  name: string,
+  toggleDropdown: () => void,
+  selectedProductId: ?number
+}
+
+const ProductSelectorMenu = ({
+  name,
+  productType,
+  products,
+  onChange,
+  selectedProductId,
+  toggleDropdown
+}: Props) => (
+  <div className="product-selector-menu">
+    <div className="header">
+      {productType === PRODUCT_TYPE_COURSERUN ? "Courses" : "Programs"}
+    </div>
+    <div className="product-selector-menu-items">
+      {sortBy(
+        product => `${product.title}-${product.latest_version.created_on}`,
+        products
+      )
+        .filter(product => product.product_type === productType)
+        .map(product => (
+          <div
+            key={product.id}
+            className={`menu-item ${
+              product.id === selectedProductId ? "selected" : ""
+            }`}
+            onClick={preventDefaultAndInvoke(() => {
+              onChange({
+                target: {
+                  value: product.id,
+                  name:  name
+                }
+              })
+              toggleDropdown()
+            })}
+          >
+            <img
+              src={product.latest_version.thumbnail_url}
+              alt={`Image for ${product.title}`}
+            />
+            <div className="menu-item-description">
+              {product.title}
+              <br />
+              {productType === PRODUCT_TYPE_COURSERUN
+                ? formatRunTitle(findRunInProduct(product))
+                : null}
+            </div>
+          </div>
+        ))}
+    </div>
+  </div>
+)
+
+export default ProductSelectorMenu

--- a/static/js/components/input/ProductSelectorMenu.js
+++ b/static/js/components/input/ProductSelectorMenu.js
@@ -57,11 +57,12 @@ const ProductSelectorMenu = ({
               alt={`Image for ${product.title}`}
             />
             <div className="menu-item-description">
-              {product.title}
+              <span className="product-title">{product.title}</span>
               <br />
               {productType === PRODUCT_TYPE_COURSERUN
                 ? formatRunTitle(findRunInProduct(product))
-                : null}
+                : `(Consists of ${product.latest_version.courses.length} courses)`
+              }
             </div>
           </div>
         ))}

--- a/static/js/components/input/ProductSelectorMenu.js
+++ b/static/js/components/input/ProductSelectorMenu.js
@@ -61,8 +61,7 @@ const ProductSelectorMenu = ({
               <br />
               {productType === PRODUCT_TYPE_COURSERUN
                 ? formatRunTitle(findRunInProduct(product))
-                : `(Consists of ${product.latest_version.courses.length} courses)`
-              }
+                : `(Consists of ${product.latest_version.courses.length} courses)`}
             </div>
           </div>
         ))}

--- a/static/js/components/input/ProductSelectorMenu_test.js
+++ b/static/js/components/input/ProductSelectorMenu_test.js
@@ -1,0 +1,102 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import { sortBy } from "ramda"
+
+import ProductSelectorMenu from "./ProductSelectorMenu"
+
+import { makeProduct } from "../../factories/ecommerce"
+import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants"
+import type { ProductDetail } from "../../flow/ecommerceTypes"
+
+describe("ProductSelectorMenu", () => {
+  let sandbox,
+    products,
+    productType,
+    onChangeStub,
+    name,
+    selectedProductId,
+    toggleDropdownStub
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+
+    products = [makeProduct(), makeProduct(), makeProduct()]
+    productType = PRODUCT_TYPE_COURSERUN
+    onChangeStub = sandbox.stub()
+    name = "the product selector menu field name"
+    selectedProductId = null
+    toggleDropdownStub = sandbox.stub()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const render = (props = {}) =>
+    shallow(
+      <ProductSelectorMenu
+        products={products}
+        productType={productType}
+        onChange={onChangeStub}
+        name={name}
+        toggleDropdown={toggleDropdownStub}
+        selectedProductId={selectedProductId}
+        {...props}
+      />
+    )
+
+  const sortKeyFunc = (product: ProductDetail) =>
+    `${product.title}-${product.latest_version.created_on}`
+
+  ;[PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM].forEach(_productType => {
+    it(`renders a product selector menu with ${_productType} selected`, () => {
+      productType = _productType
+
+      const product = makeProduct(productType)
+      products = [...products, product]
+      selectedProductId = product.id
+      const wrapper = render()
+      assert.equal(
+        wrapper.find(".header").text(),
+        productType === PRODUCT_TYPE_PROGRAM ? "Programs" : "Courses"
+      )
+
+      const filteredProducts = sortBy(
+        sortKeyFunc,
+        products.filter(_product => _product.product_type === productType)
+      )
+      assert.equal(filteredProducts.length, wrapper.find(".menu-item").length)
+      filteredProducts.forEach((product, i) => {
+        const div = wrapper.find(".menu-item").at(i)
+        if (product.id === selectedProductId) {
+          assert.equal(div.prop("className"), "menu-item selected")
+        } else {
+          assert.equal(div.prop("className"), "menu-item ")
+        }
+
+        assert.equal(div.find("img").prop("alt"), `Image for ${product.title}`)
+        assert.equal(
+          div.find("img").prop("src"),
+          product.latest_version.thumbnail_url
+        )
+        assert.isTrue(
+          div
+            .find(".menu-item-description")
+            .text()
+            .includes(product.title)
+        )
+        onChangeStub.resetHistory()
+        div.prop("onClick")({ preventDefault: sandbox.stub() })
+        sinon.assert.calledWith(onChangeStub, {
+          target: {
+            value: product.id,
+            name:  name
+          }
+        })
+      })
+    })
+  })
+})

--- a/static/js/components/input/ProductSelector_test.js
+++ b/static/js/components/input/ProductSelector_test.js
@@ -11,7 +11,7 @@ import { makeProduct } from "../../factories/ecommerce"
 import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants"
 
 describe("ProductSelector", () => {
-  let sandbox, products, value, name, onChangeStub
+  let sandbox, products, fieldValue, name, onChangeStub
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -22,7 +22,7 @@ describe("ProductSelector", () => {
       makeProduct(PRODUCT_TYPE_PROGRAM),
       makeProduct(PRODUCT_TYPE_COURSERUN)
     ]
-    value = {}
+    fieldValue = null
   })
 
   afterEach(() => {
@@ -37,7 +37,7 @@ describe("ProductSelector", () => {
           onChange: onChangeStub,
           onBlur:   sandbox.stub(),
           name,
-          value
+          value:    fieldValue
         }}
         form={{
           touched: false,
@@ -47,83 +47,89 @@ describe("ProductSelector", () => {
       />
     )
 
-  ;["courserun", "program"].forEach(productType => {
-    it(`renders a button with ${productType} selected`, () => {
-      const wrapper = render()
-      wrapper.setState({ productType })
-      const [courseButton, programButton] = wrapper.find("button")
-      const [courseWrapper, programWrapper] = [
-        shallow(courseButton),
-        shallow(programButton)
-      ]
-      assert.equal(courseWrapper.text(), "Course")
-      assert.equal(programWrapper.text(), "Program")
-      assert.equal(
-        courseWrapper.prop("className"),
-        productType === "courserun" ? "selected" : ""
-      )
-      assert.equal(
-        programWrapper.prop("className"),
-        productType === "program" ? "selected" : ""
-      )
-    })
+  ;[PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM].forEach(productType => {
+    describe(`for productType ${productType}`, () => {
+      it("renders a button", () => {
+        const wrapper = render()
+        wrapper.setState({ productType })
+        const [courseButton, programButton] = wrapper.find("button")
+        const [courseWrapper, programWrapper] = [
+          shallow(courseButton),
+          shallow(programButton)
+        ]
+        assert.equal(courseWrapper.text(), "Course")
+        assert.equal(programWrapper.text(), "Program")
+        assert.equal(
+          courseWrapper.prop("className"),
+          productType === PRODUCT_TYPE_COURSERUN
+            ? "selected select-product-type"
+            : " select-product-type"
+        )
+        assert.equal(
+          programWrapper.prop("className"),
+          productType === PRODUCT_TYPE_PROGRAM
+            ? "selected select-product-type"
+            : " select-product-type"
+        )
+      })
 
-    it(`changes state to ${productType} on click`, () => {
-      const wrapper = render()
-      const [courseButton, programButton] = wrapper.find("button")
-      const button = productType === "courserun" ? courseButton : programButton
-      shallow(button).prop("onClick")({ preventDefault: sandbox.stub() })
-      wrapper.update()
-      assert.equal(wrapper.state().productType, productType)
-    })
+      it("changes productType on click", () => {
+        const wrapper = render()
+        const [courseButton, programButton] = wrapper.find("button")
+        const button =
+          productType === "courserun" ? courseButton : programButton
+        shallow(button).prop("onClick")({ preventDefault: sandbox.stub() })
+        wrapper.update()
+        assert.equal(wrapper.state().productType, productType)
+      })
 
-    it(`shows a list of products for ${productType}`, () => {
-      const wrapper = render()
-      wrapper.setState({ productType })
-      const [pickOption, ...options] = wrapper.find("option")
-      assert.equal(shallow(pickOption).text(), "Select a product")
-      assert.equal(shallow(pickOption).prop("value"), "")
-      const filteredProducts = products.filter(
-        product => product.product_type === productType
-      )
-      assert.equal(options.length, filteredProducts.length)
-      filteredProducts.forEach((product, i) => {
-        const option = shallow(options[i])
-        assert.equal(option.text(), product.title)
-        assert.equal(option.prop("value"), product.id)
+      it("clears the selection when the a different button is clicked", () => {
+        const wrapper = render()
+        wrapper.setState({ productType })
+        const [courseButton, programButton] = wrapper.find("button")
+        const otherButton =
+          productType === PRODUCT_TYPE_COURSERUN ? programButton : courseButton
+        shallow(otherButton).prop("onClick")({ preventDefault: sandbox.stub() })
+        sinon.assert.calledWith(onChangeStub, { target: { value: "", name } })
+      })
+
+      it("does not clear the selection when a button already selected is clicked", () => {
+        const wrapper = render()
+        wrapper.setState({ productType })
+        const [courseButton, programButton] = wrapper.find("button")
+        const sameButton =
+          productType === PRODUCT_TYPE_COURSERUN ? courseButton : programButton
+        shallow(sameButton).prop("onClick")({ preventDefault: sandbox.stub() })
+        sinon.assert.notCalled(onChangeStub)
+      })
+
+      it("renders a dropdown menu", () => {
+        fieldValue = 98765
+        const wrapper = render()
+        wrapper.setState({ productType })
+        const props = wrapper.find("ProductSelectorMenu").props()
+
+        assert.equal(props.onChange, onChangeStub)
+        assert.equal(props.productType, productType)
+        assert.deepEqual(props.products, products)
+        assert.equal(props.name, name)
+        assert.equal(props.selectedProductId, fieldValue)
+      })
+
+      //
+      ;[true, false].forEach(dropdownOpen => {
+        it(`turns ${dropdownOpen ? "off" : "on"} dropdown visibility`, () => {
+          const wrapper = render()
+          wrapper.setState({ dropdownOpen })
+          assert.equal(wrapper.find("Dropdown").prop("isOpen"), dropdownOpen)
+          const toggleDropdown = wrapper
+            .find("ProductSelectorMenu")
+            .prop("toggleDropdown")
+          toggleDropdown()
+          assert.equal(wrapper.state().dropdownOpen, !dropdownOpen)
+          assert.equal(wrapper.find("Dropdown").prop("isOpen"), !dropdownOpen)
+        })
       })
     })
-
-    it(`clears the selection when ${productType} is set but a different button is clicked`, () => {
-      const wrapper = render()
-      wrapper.setState({ productType })
-      const [courseButton, programButton] = wrapper.find("button")
-      const otherButton =
-        productType === PRODUCT_TYPE_COURSERUN ? programButton : courseButton
-      shallow(otherButton).prop("onClick")({ preventDefault: sandbox.stub() })
-      sinon.assert.calledWith(onChangeStub, { target: { value: "", name } })
-    })
-
-    it(`does not clear the selection when ${productType} is set but a different button is clicked`, () => {
-      const wrapper = render()
-      wrapper.setState({ productType })
-      const [courseButton, programButton] = wrapper.find("button")
-      const sameButton =
-        productType === PRODUCT_TYPE_COURSERUN ? courseButton : programButton
-      shallow(sameButton).prop("onClick")({ preventDefault: sandbox.stub() })
-      sinon.assert.notCalled(onChangeStub)
-    })
-  })
-
-  it("uses the value for the selected product", () => {
-    value.product = 98765
-    const wrapper = render()
-    assert.equal(wrapper.find("select").prop("value"), value.product)
-    assert.equal(wrapper.find("select").prop("name"), name)
-  })
-
-  it("updates the selected option", () => {
-    const wrapper = render()
-    assert.equal(wrapper.find("select").prop("onChange"), onChangeStub)
   })
 })

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -20,8 +20,8 @@ import type {
 import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../constants"
 
 const genBasketItemId = incrementer()
+const genBasketItemObjectId = incrementer()
 const genProductId = incrementer()
-
 const genDataConsentUserId = incrementer()
 
 export const makeDataConsent = (): DataConsentUser => ({
@@ -40,7 +40,7 @@ export const makeItem = (productType: ?string): BasketItem => {
   const courses = range(0, numCourses).map(() => makeCourse())
   const runIds = courses.map(course => course.courseruns[0].id)
 
-  let objectId = casual.integer(0, 99999)
+  let objectId = genBasketItemObjectId.next().value
   if (productType === PRODUCT_TYPE_COURSERUN) {
     const choices = []
     for (const course of courses) {
@@ -61,6 +61,7 @@ export const makeItem = (productType: ?string): BasketItem => {
     price:         String(casual.double(0, 100)),
     thumbnail_url: casual.url,
     run_ids:       runIds,
+    // $FlowFixMe: flow doesn't understand generators well
     object_id:     objectId,
     // $FlowFixMe: flow doesn't understand generators well
     product_id:    genProductId.next().value,

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -38,6 +38,7 @@ export type ProductVersion = {
   product_id: number,
   id: number,
   readable_id: string,
+  created_on: string,
 }
 
 export type BasketItem = ProductVersion & {

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -7,6 +7,7 @@ import moment from "moment"
 import type {
   BasketItem,
   CouponSelection,
+  ProductDetail,
   ProductMap,
   BulkCouponPayment
 } from "../flow/ecommerceTypes"
@@ -53,8 +54,10 @@ export const formatPrice = (price: ?string | number | Decimal): string => {
 const formatDateForRun = (dateString: ?string) =>
   dateString ? moment(dateString).format("ll") : "?"
 
-export const formatRunTitle = (run: CourseRun) =>
-  `${formatDateForRun(run.start_date)} - ${formatDateForRun(run.end_date)}`
+export const formatRunTitle = (run: ?CourseRun) =>
+  run
+    ? `${formatDateForRun(run.start_date)} - ${formatDateForRun(run.end_date)}`
+    : ""
 
 export const isPromo = equals(COUPON_TYPE_PROMO)
 
@@ -71,3 +74,24 @@ export const createProductMap = (
     R.flatten,
     R.pluck("products")
   )(bulkCouponPayments)
+
+export const findRunInProduct = (product: ProductDetail): ?CourseRun => {
+  if (product.product_type !== PRODUCT_TYPE_COURSERUN) {
+    // Calling functions are responsible for checking this
+    throw new Error("Expected a run product")
+  }
+
+  const productVersion = product.latest_version
+  const runId = productVersion.object_id
+
+  for (const course of productVersion.courses) {
+    for (const run of course.courseruns) {
+      if (run.id === runId) {
+        return run
+      }
+    }
+  }
+
+  // This should be prevented by the REST API
+  return null
+}

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -339,7 +339,7 @@
         margin-left: 20px;
         border-left: 35px solid transparent;
         border-right: 35px solid transparent;
-        border-bottom: 25px solid white;
+        border-bottom: 25px solid $very-light-gray;
         filter: drop-shadow(0 15px 15px black);
         // move drop shadow at bottom below menu
         z-index: -1;
@@ -347,7 +347,7 @@
 
       .product-selector-menu {
         .header {
-          background-color: white;
+          background-color: $very-light-gray;
           text-transform: uppercase;
           height: 50px;
           align-items: center;

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -285,19 +285,88 @@
   .product-selector {
     button {
       font-size: 28px;
-      margin-right: 15px;
-      margin-bottom: 15px;
       padding: 5px 15px;
       border-radius: 5px;
       background-color: white;
       color: $soft-light-gray;
       border: 1px solid black;
       font-weight: 600;
+      text-transform: uppercase;
 
-      &.selected {
+      &.selected, &.select-product {
         background-color: $soft-light-gray;
         color: $denim-blue;
         border: 0;
+      }
+
+      &.select-product-type {
+        margin-right: 15px;
+        margin-bottom: 15px;
+      }
+
+      &.select-product {
+        font-size: 24px;
+        padding: 5px 25px;
+      }
+    }
+
+    .dropdown-menu {
+      padding: 0;
+      transform: unset !important;
+      margin-top: 25px;
+
+      .triangle {
+        position: absolute;
+        width: 0;
+        height: 0;
+        top: -25px;
+        margin-left: 20px;
+        border-left: 35px solid transparent;
+        border-right: 35px solid transparent;
+        border-bottom: 25px solid white;
+        filter: drop-shadow(0 15px 15px black);
+        // move drop shadow at bottom below menu
+        z-index: -1;
+      }
+
+      .product-selector-menu {
+        .header {
+          background-color: white;
+          text-transform: uppercase;
+          height: 50px;
+          align-items: center;
+        }
+
+        .header, .menu-item {
+          display: flex;
+          flex-direction: row;
+          padding: 15px;
+        }
+
+        .product-selector-menu-items {
+          max-height: 350px;
+          overflow: scroll;
+
+          .menu-item {
+            cursor: pointer;
+            height: 115px;
+            border-top: 1px solid black;
+            background-color: white;
+            overflow: hidden;
+
+            &.selected {
+              background-color: $soft-light-gray;
+            }
+
+            img {
+              height: 100%;
+            }
+
+            .menu-item-description {
+              padding-left: 15px;
+            }
+          }
+        }
       }
     }
   }

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -375,9 +375,9 @@
             }
 
             img {
-              min-width: 140px;
-              max-width: 140px;
-              height: 100%;
+              display: block;
+              width: 140px;
+              height: auto;
             }
 
             .menu-item-description {

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -218,7 +218,7 @@
   label {
     display: flex;
     flex-direction: column;
-    margin: 40px 0;
+    margin-top: 30px;
     color: $light-gray;
   }
 
@@ -244,8 +244,12 @@
 
   input {
     border-radius: 5px;
-    border: 1px solid $soft-light-gray;
-    padding: 5px;
+    border: 1px solid $tab-color;
+    padding: 5px 5px 0 5px;
+    font-weight: 500;
+    font-size: 16px;
+    margin-top: 5px;
+    margin-bottom: 10px;
   }
 }
 
@@ -284,7 +288,7 @@
 
   .description, .explanation {
     display: block;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: 600;
   }
 
@@ -300,18 +304,19 @@
     color: black;
 
     button {
-      font-size: 24px;
+      font-size: 22px;
       padding: 5px 20px;
-      border-radius: 8px;
+      border-radius: 7px;
       background-color: white;
-      color: $soft-light-gray;
-      border: 1px solid black;
+      color: $tab-color;
+      border: 1px solid $link-blue;
       font-weight: 600;
       text-transform: uppercase;
+      letter-spacing: 1.28px;
 
       &.selected, &.select-product {
-        background-color: $soft-light-gray;
-        color: $denim-blue;
+        background-color: #e2e2e2;
+        color: $link-blue;
         border: 0;
       }
 
@@ -321,8 +326,9 @@
       }
 
       &.select-product {
-        font-size: 24px;
-        padding: 5px 25px;
+        font-size: 19px;
+        padding: 7px 25px 5px 25px;
+        letter-spacing: 1.1px;
       }
     }
 
@@ -390,6 +396,10 @@
           }
         }
       }
+    }
+
+    .selected-product-title {
+      margin-top: 24px;
     }
   }
 }

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -382,6 +382,10 @@
 
             .menu-item-description {
               padding-left: 15px;
+
+              .product-title {
+                font-weight: 700;
+              }
             }
           }
         }

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -365,7 +365,7 @@
 
           .menu-item {
             cursor: pointer;
-            height: 115px;
+            min-height: 115px;
             border-top: 1px solid black;
             background-color: white;
             overflow: hidden;
@@ -375,6 +375,8 @@
             }
 
             img {
+              min-width: 140px;
+              max-width: 140px;
               height: 100%;
             }
 

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -219,6 +219,7 @@
     display: flex;
     flex-direction: column;
     margin: 40px 0;
+    color: $light-gray;
   }
 
   .checkout-button {
@@ -239,6 +240,12 @@
     font-weight: 600;
     padding: 20px;
     margin-bottom: 40px;
+  }
+
+  input {
+    border-radius: 5px;
+    border: 1px solid $soft-light-gray;
+    padding: 5px;
   }
 }
 
@@ -275,18 +282,27 @@
     }
   }
 
-  .description {
+  .description, .explanation {
     display: block;
+    font-size: 17px;
+    font-weight: 600;
+  }
+
+  .description {
     color: $light-gray;
-    font-size: 16px;
-    font-weight: 700;
+  }
+
+  .explanation {
+    color: $navy-blue;
   }
 
   .product-selector {
+    color: black;
+
     button {
-      font-size: 28px;
-      padding: 5px 15px;
-      border-radius: 5px;
+      font-size: 24px;
+      padding: 5px 20px;
+      border-radius: 8px;
       background-color: white;
       color: $soft-light-gray;
       border: 1px solid black;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #858 

#### What's this PR do?
Replaces the standard HTML select with a modal dropdown element

#### How should this be manually tested?
Go to `/ecommerce/bulk/` and select some courses and programs. It should look similar to the mockup in the linked issue. Please comment if the UI feels strange or if you notice anything which should be changed.

#### Screenshots (if appropriate)
Desktop:
![Screenshot from 2019-08-20 13-47-49](https://user-images.githubusercontent.com/863262/63371082-64a7da00-c351-11e9-8eae-705e62ab076d.png)

Mobile:
![Screenshot from 2019-08-20 13-48-12](https://user-images.githubusercontent.com/863262/63371089-68d3f780-c351-11e9-8df8-5abdab58bb03.png)
