### PR TITLE
Add checkout URL to B2B enrollment code checkout CSV

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -7,7 +7,7 @@ import hashlib
 import hmac
 import logging
 from traceback import format_exc
-from urllib.parse import quote_plus, urljoin
+from urllib.parse import quote_plus, urljoin, urlencode
 import uuid
 
 from django.conf import settings
@@ -999,3 +999,26 @@ def determine_order_status_change(order, decision):
         return Order.FAILED
 
     return Order.FULFILLED
+
+
+def make_checkout_url(*, product_id=None, code=None):
+    """
+    Helper function to create a checkout URL with appropriate query parameters.
+
+    Args:
+        product_id (int): A Product ID
+        code (str): The coupon code
+
+    Returns:
+        str: The URL for the checkout page, including product and coupon code if available
+    """
+    base_checkout_url = urljoin(settings.SITE_BASE_URL, reverse("checkout-page"))
+    if product_id is None and code is None:
+        return base_checkout_url
+
+    query_params = {}
+    if product_id is not None:
+        query_params["product"] = product_id
+    if code is not None:
+        query_params["code"] = code
+    return f"{base_checkout_url}?{urlencode(query_params)}"

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -1,12 +1,13 @@
 """Ecommerce mail API"""
-from urllib.parse import urljoin, urlencode
 import itertools
 import logging
+from urllib.parse import urlencode, urljoin
 
 from django.conf import settings
 from django.urls import reverse
 
 from courses.models import CourseRun
+from ecommerce.models import ProductCouponAssignment
 from mail import api
 from mail.constants import (
     EMAIL_B2B_RECEIPT,
@@ -14,7 +15,6 @@ from mail.constants import (
     EMAIL_COURSE_RUN_ENROLLMENT,
     EMAIL_COURSE_RUN_UNENROLLMENT,
 )
-from ecommerce.models import ProductCouponAssignment
 from mitxpro.utils import format_price
 
 log = logging.getLogger()
@@ -22,16 +22,10 @@ log = logging.getLogger()
 
 def get_bulk_enroll_email_context(product_coupon):
     """Gets the bulk enrollment email template context for one CouponEligibility object"""
-    enrollment_url = "?".join(
-        [
-            urljoin(settings.SITE_BASE_URL, reverse("checkout-page")),
-            urlencode(
-                {
-                    "product": product_coupon.product.id,
-                    "code": product_coupon.coupon.coupon_code,
-                }
-            ),
-        ]
+    from ecommerce.api import make_checkout_url
+
+    enrollment_url = make_checkout_url(
+        product_id=product_coupon.product.id, code=product_coupon.coupon.coupon_code
     )
     company_name = (
         product_coupon.coupon.payment.versions.values_list("company__name", flat=True)

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -950,15 +950,11 @@ def test_coupon_csv_view(admin_client, admin_drf_client, single_use_coupon_json)
         reverse("coupons_csv", kwargs={"version_id": cpv.id})
     )
     assert csv_response.status_code == 200
-    assert (
-        csv_response.content
-        == b"\r\n".join(
-            [
-                bytes(cv.coupon.coupon_code, encoding="utf8")
-                for cv in cpv.couponversion_set.all()
-            ]
-        )
-        + b"\r\n"
+    rows = [line.split(",") for line in csv_response.content.decode().split()]
+    assert rows[0] == ["code"]
+    codes = [row[0] for row in rows[1:]]
+    assert sorted(codes) == sorted(
+        cpv.couponversion_set.values_list("coupon__coupon_code", flat=True)
     )
 
 

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -14,6 +14,7 @@ from mitxpro.utils import (
     is_near_now,
     dict_without_keys,
     filter_dict_by_key_set,
+    make_csv_http_response,
     partition,
     has_equal_properties,
     remove_password_from_url,
@@ -146,3 +147,26 @@ def test_unique_ignore_case():
 def test_format_price(price, expected):
     """Format a decimal value into a price"""
     assert format_price(price) == expected
+
+
+def test_make_csv_http_response():
+    """
+    make_csv_http_response should make a HttpResponse object suitable for serving a CSV file.
+    """
+    rows = [{"a": "B", "c": "d"}, {"a": "e", "c": "f"}]
+    response = make_csv_http_response(csv_rows=rows, filename="test_filename")
+    out_rows = [line.split(",") for line in response.content.decode().splitlines()]
+    assert out_rows == [["a", "c"], ["B", "d"], ["e", "f"]]
+    assert response["Content-Disposition"] == 'attachment; filename="test_filename"'
+    assert response["Content-Type"] == "text/csv"
+
+
+def test_make_csv_http_response_empty():
+    """
+    make_csv_http_response should handle empty data sets by returning an empty response
+    """
+    response = make_csv_http_response(csv_rows=[], filename="empty_filename")
+    out_rows = [line.split(",") for line in response.content.decode().splitlines()]
+    assert out_rows == []
+    assert response["Content-Disposition"] == 'attachment; filename="empty_filename"'
+    assert response["Content-Type"] == "text/csv"

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from django.views.generic import FormView
 from django.views.generic.base import View
 
+from ecommerce.api import make_checkout_url
 from ecommerce.models import Coupon, Product
 from mitxpro.views import get_js_settings_context
 from voucher.forms import UploadVoucherForm, VOUCHER_PARSE_ERROR
@@ -138,7 +139,9 @@ class EnrollView(LoginRequiredMixin, View):
         voucher.coupon_id = coupon_id
         voucher.product_id = product_id
         voucher.save()
-        enroll_url = f"{reverse('checkout-page')}?product={product_id}&code={voucher.coupon.coupon_code}"
+        enroll_url = make_checkout_url(
+            product_id=product_id, code=voucher.coupon.coupon_code
+        )
         return redirect(enroll_url)
 
 

--- a/voucher/views_test.py
+++ b/voucher/views_test.py
@@ -3,6 +3,7 @@
 Test voucher views.py
 """
 import json
+from urllib.parse import urljoin
 
 from django.urls import reverse
 import pytest
@@ -178,7 +179,9 @@ def test_get_enroll_view_with_matches(
         assert coupon_choice[1] in titles
 
 
-def test_post_enroll_view_with_coupon_choice(voucher_and_exact_match_with_coupon):
+def test_post_enroll_view_with_coupon_choice(
+    voucher_and_exact_match_with_coupon, settings
+):
     """
     Test the EnrollView POST method with a valid coupon choice
     """
@@ -192,9 +195,9 @@ def test_post_enroll_view_with_coupon_choice(voucher_and_exact_match_with_coupon
         {"coupon_version": json.dumps((product.id, coupon_version.coupon.id))},
     )
     assert response.status_code == 302
-    assert (
-        response.url
-        == f"{reverse('checkout-page')}?product={product.id}&code={coupon_version.coupon.coupon_code}"
+    assert response.url == (
+        f"{urljoin(settings.SITE_BASE_URL, reverse('checkout-page'))}?"
+        f"product={product.id}&code={coupon_version.coupon.coupon_code}"
     )
     assert Voucher.objects.get(id=voucher.id).coupon == coupon_version.coupon
 
@@ -250,8 +253,8 @@ def test_post_enroll_view_with_stolen_coupon(
         {"coupon_version": json.dumps((product.id, coupon_version1.coupon.id))},
     )
     assert response.status_code == 302
-    assert (
-        response.url
-        == f"{reverse('checkout-page')}?product={product.id}&code={coupon_version2.coupon.coupon_code}"
+    assert response.url == (
+        f"{urljoin(settings.SITE_BASE_URL, reverse('checkout-page'))}?"
+        f"product={product.id}&code={coupon_version2.coupon.coupon_code}"
     )
     assert Voucher.objects.get(id=voucher.id).coupon == coupon_version2.coupon


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1034 

#### What's this PR do?
Previously the CSV file created had one column with only coupon codes. This does some refactoring and changes the CSV to also include a URL column with a link to the checkout page, with query parameters for the product and the coupon code.

This also refactors the CSV download at `/ecommerce/admin/coupons/` but there should only be a header row added here. Due to multiple possible products the URL is left out of this CSV for now.

#### How should this be manually tested?
Purchase enrollment codes if you haven't yet, then go to the receipt page and click the download link. You should see a CSV file with two columns, one is the code and the other should be a URL. Copy one of the URLs and paste it in the browser URL bar. You should see a checkout page with the coupon code created.