### PR TITLE
Remove B2B order fulfillment API, merge with ecommerce order fulfillment API

### DIFF
--- a/b2b_ecommerce/models.py
+++ b/b2b_ecommerce/models.py
@@ -1,6 +1,7 @@
 """Models for business to business ecommerce"""
 import uuid
 
+from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 
@@ -32,8 +33,12 @@ class B2BOrder(OrderAbstract, AuditableModel):
         CouponPaymentVersion, null=True, on_delete=models.PROTECT
     )
 
-    reference_number_prefix = REFERENCE_NUMBER_PREFIX
     objects = OrderManager()
+
+    @staticmethod
+    def get_reference_number_prefix():
+        """The reference number prefix used to match a CyberSource order fulfillment HTTP request with an order"""
+        return f"{REFERENCE_NUMBER_PREFIX}{settings.CYBERSOURCE_REFERENCE_PREFIX}"
 
     def __str__(self):
         """Description for CouponOrder"""

--- a/b2b_ecommerce/urls.py
+++ b/b2b_ecommerce/urls.py
@@ -3,7 +3,6 @@ from django.urls import path
 
 from b2b_ecommerce.views import (
     B2BCheckoutView,
-    B2BOrderFulfillmentView,
     B2BEnrollmentCodesView,
     B2BOrderStatusView,
 )
@@ -12,11 +11,6 @@ from mitxpro.views import index
 
 urlpatterns = [
     path("api/b2b/checkout/", B2BCheckoutView.as_view(), name="b2b-checkout"),
-    path(
-        "api/b2b/order_fulfillment/",
-        B2BOrderFulfillmentView.as_view(),
-        name="b2b-order-fulfillment",
-    ),
     path(
         "api/b2b/orders/<uuid:hash>/codes/",
         B2BEnrollmentCodesView.as_view(),

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -145,7 +145,7 @@ class OrderManager(models.Manager):
         """
         order_id = get_order_id_by_reference_number(
             reference_number=reference_number,
-            prefix=f"{self.model.reference_number_prefix}{settings.CYBERSOURCE_REFERENCE_PREFIX}",
+            prefix=self.model.get_reference_number_prefix(),
         )
 
         return self.get(id=order_id)
@@ -171,7 +171,7 @@ class OrderAbstract(TimestampedModel):
     @property
     def reference_number(self):
         """Create a string with the order id and a unique prefix so we can lookup the order during order fulfillment"""
-        return f"{self.reference_number_prefix}{settings.CYBERSOURCE_REFERENCE_PREFIX}-{self.id}"
+        return f"{self.get_reference_number_prefix()}-{self.id}"
 
     class Meta:
         abstract = True
@@ -186,9 +186,13 @@ class Order(OrderAbstract, AuditableModel):
     purchaser = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.PROTECT, related_name="orders"
     )
-    reference_number_prefix = REFERENCE_NUMBER_PREFIX
 
     objects = OrderManager()
+
+    @staticmethod
+    def get_reference_number_prefix():
+        """The reference number prefix used to match a CyberSource order fulfillment HTTP request with an order"""
+        return f"{REFERENCE_NUMBER_PREFIX}{settings.CYBERSOURCE_REFERENCE_PREFIX}"
 
     def __str__(self):
         """Description for Order"""

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -15,7 +15,7 @@ import factory
 
 from courses.factories import CourseRunFactory, CourseRunEnrollmentFactory
 from ecommerce.api import create_unfulfilled_order, get_readable_id, make_receipt_url
-from ecommerce.exceptions import EcommerceException
+from ecommerce.exceptions import EcommerceException, ParseException
 from ecommerce.factories import (
     CouponEligibilityFactory,
     LineFactory,
@@ -271,11 +271,11 @@ def test_missing_fields(basket_client, mocker):
         "ecommerce.views.IsSignedByCyberSource.has_permission", return_value=True
     )
     try:
-        # Missing fields from Cybersource POST will cause the KeyError.
+        # Missing fields from Cybersource POST will cause a ParseException.
         # In this test we just care that we saved the data in Receipt for later
         # analysis.
         basket_client.post(reverse("order-fulfillment"), data=data)
-    except KeyError:
+    except ParseException:
         pass
 
     assert Order.objects.count() == 0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1027 
part of #858 

#### What's this PR do?
Merges the two CyberSource order fulfillment APIs. CyberSource will only contact one of these APIs for a given account and environment so we will need to combine the APIs and add logic to tell from the reference number which request should be handled by the regular ecommerce workflow and which by the b2b ecommerce workflow.

If the reference number prefix is missing, which sometimes happens on CyberSource error cases, the value will be stored in `Receipt`, not `B2BReceipt`, since there is no easy way to tell which one was intended. An exception will be raised in that case and reported to Sentry.

#### How should this be manually tested?
You should be able to go through the B2B workflow (see instructions in #1003) and feed the order fulfillment data to `/api/order_fulfillment/` instead of `/api/b2b/order_fulfillment/`. If you're testing this on RC everything should just work as is :crossed_fingers:  