### PR TITLE
Do not check for hubspot errors without an api key

### DIFF
--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 import celery
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 from ecommerce.models import Order, Line
@@ -69,6 +70,8 @@ def sync_line_item_with_hubspot(line_id):
 @app.task
 def check_hubspot_api_errors():
     """Check for and log any errors that occurred since the last time this was run"""
+    if not settings.HUBSPOT_API_KEY:
+        return
     last_check, _ = HubspotErrorCheck.objects.get_or_create(
         defaults={"checked_on": now_in_utc()}
     )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #791

#### What's this PR do?
Skips making an API call to Hubspot for error-checking if the API key is not set.

#### How should this be manually tested?
Set `HUBSPOTAPI_KEY=None` and `HUBSPOT_ERROR_CHECK_FREQUENCY=10`  in your `.env` file.  The task should run every 10 seconds but not throw any errors as a consequence of trying to make API calls without a key.
