### PR TITLE
Fixed DATABASE_URL inheritance for CI

### DIFF
--- a/app.json
+++ b/app.json
@@ -107,10 +107,6 @@
       "description": "The URL to the cybersource WSDL",
       "required": false
     },
-    "DATABASE_URL": {
-      "description": "The connection url to the Postgres database",
-      "required": true
-    },
     "DJANGO_LOG_LEVEL": {
       "description": "The log level for django",
       "required": false

--- a/mitxpro/envs.py
+++ b/mitxpro/envs.py
@@ -12,7 +12,16 @@ class EnvironmentVariableParseException(ImproperlyConfigured):
 
 
 EnvVariable = namedtuple(
-    "EnvVariable", ["name", "default", "description", "required", "dev_only", "value"]
+    "EnvVariable",
+    [
+        "name",
+        "default",
+        "description",
+        "required",
+        "dev_only",
+        "value",
+        "write_app_json",
+    ],
 )
 
 
@@ -28,7 +37,15 @@ def var_parser(parser_func):
 
     # pylint: disable=too-many-arguments
     @wraps(parser_func)
-    def wrapper(self, name, default, description=None, required=False, dev_only=False):
+    def wrapper(
+        self,
+        name,
+        default,
+        description=None,
+        required=False,
+        dev_only=False,
+        write_app_json=True,
+    ):
         """
         Get an environment variable
 
@@ -38,6 +55,7 @@ def var_parser(parser_func):
             description (str): The description of how this variable is used
             required (bool): Whether this variable is required at runtime
             dev_only (bool): Whether this variable is only applicable in dev environments
+            write_app_json (bool): Whether this variable is written to app.json
 
         Raises:
             ValueError:
@@ -60,7 +78,7 @@ def var_parser(parser_func):
         value = parser_func(name, value, default)
 
         configured_envs[name] = EnvVariable(
-            name, default, description, required, dev_only, value
+            name, default, description, required, dev_only, value, write_app_json
         )
 
         return value
@@ -243,7 +261,7 @@ def generate_app_json():
         config = json.load(app_template_json)
 
     for env_var in list_environment_vars():
-        if env_var.dev_only:
+        if env_var.dev_only or not env_var.write_app_json:
             continue
 
         if env_var.name not in config["env"]:

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -216,6 +216,7 @@ DEFAULT_DATABASE_CONFIG = dj_database_url.parse(
         "sqlite:///{0}".format(os.path.join(BASE_DIR, "db.sqlite3")),
         description="The connection url to the Postgres database",
         required=True,
+        write_app_json=False,
     )
 )
 DEFAULT_DATABASE_CONFIG["CONN_MAX_AGE"] = get_int(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #1051

#### What's this PR do?
Ensures that `DATABASE_URL` doesn't get written to `app.json`
