### PR TITLE
Add id to Hubspot product title

### DIFF
--- a/ecommerce/__init__.py
+++ b/ecommerce/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-docstring,invalid-name
+default_app_config = "ecommerce.apps.EcommerceConfig"

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -20,7 +20,6 @@ from ecommerce.models import (
     Company,
     ProductCouponAssignment,
 )
-import ecommerce.signals  # pylint:disable=unused-import
 
 from hubspot.task_helpers import sync_hubspot_deal
 from mitxpro.utils import get_field_names

--- a/ecommerce/apps.py
+++ b/ecommerce/apps.py
@@ -6,3 +6,7 @@ class EcommerceConfig(AppConfig):
     """AppConfig for Ecommerce"""
 
     name = "ecommerce"
+
+    def ready(self):
+        """Application is ready"""
+        import ecommerce.signals  # pylint:disable=unused-import, unused-variable

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -1,4 +1,6 @@
 """ Serializers for HubSpot"""
+import re
+
 from rest_framework import serializers
 
 from ecommerce import models
@@ -190,10 +192,13 @@ class ProductSerializer(serializers.ModelSerializer):
     description = serializers.SerializerMethodField()
 
     def get_title(self, instance):
-        """ Return the product title """
-        return instance.content_type.get_object_for_this_type(
+        """ Return the product title and course-run or id"""
+        product_obj = instance.content_type.get_object_for_this_type(
             pk=instance.object_id
-        ).title
+        )
+        title_run_id = re.findall(r'\+R(\d+)$', product_obj.text_id)
+        title_suffix = f"Run {title_run_id[0]}" if title_run_id else product_obj.text_id
+        return f"{product_obj.title}: {title_suffix}"
 
     def get_product_type(self, instance):
         """ Return the product type """

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -196,7 +196,7 @@ class ProductSerializer(serializers.ModelSerializer):
         product_obj = instance.content_type.get_object_for_this_type(
             pk=instance.object_id
         )
-        title_run_id = re.findall(r'\+R(\d+)$', product_obj.text_id)
+        title_run_id = re.findall(r"\+R(\d+)$", product_obj.text_id)
         title_suffix = f"Run {title_run_id[0]}" if title_run_id else product_obj.text_id
         return f"{product_obj.title}: {title_suffix}"
 

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -192,7 +192,7 @@ class ProductSerializer(serializers.ModelSerializer):
     description = serializers.SerializerMethodField()
 
     def get_title(self, instance):
-        """ Return the product title and course-run or id"""
+        """ Return the product title and Courserun number or ProductVersion text_id"""
         product_obj = instance.content_type.get_object_for_this_type(
             pk=instance.object_id
         )

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -12,7 +12,8 @@ from ecommerce.factories import (
     OrderFactory,
     CouponRedemptionFactory,
     ProductVersionFactory,
-    ProductFactory)
+    ProductFactory,
+)
 from ecommerce.models import Product, Order
 from hubspot.api import format_hubspot_id
 from hubspot.serializers import (
@@ -27,15 +28,20 @@ from hubspot.serializers import (
 pytestmark = [pytest.mark.django_db]
 
 
-@pytest.mark.parametrize("text_id, expected", [
-    ["course-v1:xPRO+SysEngxNAV+R1", "Run 1"],
-    ["course-v1:xPRO+SysEngxNAV+R10", "Run 10"],
-    ["course-v1:xPRO+SysEngxNAV", "course-v1:xPRO+SysEngxNAV"],
-])
+@pytest.mark.parametrize(
+    "text_id, expected",
+    [
+        ["course-v1:xPRO+SysEngxNAV+R1", "Run 1"],
+        ["course-v1:xPRO+SysEngxNAV+R10", "Run 10"],
+        ["course-v1:xPRO+SysEngxNAV", "course-v1:xPRO+SysEngxNAV"],
+    ],
+)
 def test_serialize_product(text_id, expected):
     """ Test that ProductSerializer has correct data """
     product_version = ProductVersionFactory.create(
-        product=ProductFactory.create(content_object=CourseRunFactory.create(courseware_id=text_id))
+        product=ProductFactory.create(
+            content_object=CourseRunFactory.create(courseware_id=text_id)
+        )
     )
     product = Product.objects.get(id=product_version.product.id)
     run = product.content_object


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1019

#### What's this PR do?
Adds ": Run _n_" to the product title if there is a courseware id ending with +Rn, otherwise adds the entire `ProductVersion.text_id` value to the title.

#### How should this be manually tested?
- Set `API_HUBSPOT_KEY` to the value for the sandbox Hubspot instance (I can send it to you).
- Make sure some of your course runs have a courseware id ending in `+R1` or `+R2`, etc
- Run `docker-compose run web python manage.py sync_hubspot --products`
- Log in to hubspot ( I can give you credentials ), search for your products, and verify that the they appear in the same format as the screenshots below.
- If you create new `ProductVersion`s, Hubspot should be updated shortly.

#### Screenshots
<img width="678" alt="Screen Shot 2019-08-23 at 12 23 14 PM" src="https://user-images.githubusercontent.com/187676/63610970-ca41d380-c5a8-11e9-9627-56b2112004f0.png">

<img width="632" alt="Screen Shot 2019-08-23 at 1 19 48 PM" src="https://user-images.githubusercontent.com/187676/63610975-ce6df100-c5a8-11e9-8b54-8311c961a52b.png">

