### PR TITLE
Set coupon expiration to end of specified day

### DIFF
--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -81,6 +81,12 @@ const zeroHour = value => {
   }
 }
 
+const finalHour = value => {
+  if (value instanceof Date) {
+    value.setHours(23, 59, 59, 999)
+  }
+}
+
 export const CouponForm = ({
   onSubmit,
   companies,
@@ -220,7 +226,7 @@ export const CouponForm = ({
                 formatDate={formatDate}
                 parseDate={parseDate}
                 onDayChange={value => {
-                  zeroHour(value)
+                  finalHour(value)
                   setFieldValue("expiration_date", value)
                 }}
                 onDayPickerHide={() => setFieldTouched("expiration_date")}

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -106,7 +106,9 @@ describe("CouponForm", () => {
     [
       "expiration_date",
       1,
-      moment().format("MM/DD/YYYY"),
+      moment()
+        .subtract(1, "days")
+        .format("MM/DD/YYYY"),
       "Expiration date must be after today/activation date"
     ]
   ].forEach(([name, idx, value, errorMessage]) => {
@@ -134,7 +136,7 @@ describe("CouponForm", () => {
   //
   ;[
     ["activation_date", 0, "06/27/2019", "2019-06-27T00:00:00.000Z"],
-    ["expiration_date", 1, "06/27/2519", "2519-06-27T00:00:00.000Z"]
+    ["expiration_date", 1, "06/27/2519", "2519-06-27T23:59:59.999Z"]
   ].forEach(([name, idx, value, formattedDate]) => {
     it(`converts the field name=${name}, value=${JSON.stringify(
       value


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Closes #991 

#### What's this PR do?
Sets the coupon expiration to the end of the specified day.

#### How should this be manually tested?
- Go to `/ecommerce/admin/coupons` and create any type of coupon.   Remember what you choose for activation and expiration dates.
- Go to Django admin and inspect the most recent CouponPaymentVersion.  The activation datetime should be at the beginning of the specified day (in UTC), and the expiration datetime should be at the end of the specified day (in UTC):

<img width="496" alt="Screen Shot 2019-08-23 at 3 05 10 PM" src="https://user-images.githubusercontent.com/187676/63617447-768ab680-c5b7-11e9-9b1e-6ac2ff297a8b.png">
