### PR TITLE
Pdpinch/raw user admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -107,6 +107,7 @@ class CouponVersionInline(admin.StackedInline):
 
     model = CouponVersion
     readonly_fields = get_field_names(CouponVersion)
+    raw_id_fields = ("coupon","payment_version")
     extra = 0
     show_change_link = True
     can_delete = False
@@ -120,6 +121,7 @@ class CouponAdmin(admin.ModelAdmin):
     list_display = ("id", "coupon_code", "get_payment_name")
     search_fields = ("coupon_code", "payment__name")
     list_filter = ("payment",)
+    raw_id_fields = ("payment",)
 
     model = Coupon
     save_on_top = True
@@ -152,6 +154,7 @@ class CouponPaymentVersionAdmin(admin.ModelAdmin):
     save_as = True
     save_as_continue = False
     save_on_top = True
+    raw_id_fields = ("coupon","payment")
 
     def has_delete_permission(self, request, obj=None):
         return False
@@ -167,6 +170,7 @@ class CouponVersionAdmin(admin.ModelAdmin):
     save_as = True
     save_as_continue = False
     save_on_top = True
+    raw_id_fields = ("coupon","payment_version")
 
     def has_delete_permission(self, request, obj=None):
         return False
@@ -179,6 +183,8 @@ class CouponSelectionAdmin(admin.ModelAdmin):
     """Admin for CouponSelections"""
 
     model = CouponSelection
+    raw_id_fields = ("coupon","basket")
+
 
 
 class CouponEligibilityAdmin(admin.ModelAdmin):
@@ -187,7 +193,7 @@ class CouponEligibilityAdmin(admin.ModelAdmin):
     list_display = ("id", "coupon", "product")
     search_fields = ("coupon__coupon_code", "coupon__payment__name")
     list_filter = ("product",)
-    raw_id_fields = ("coupon",)
+    raw_id_fields = ("coupon","product")
 
     model = CouponEligibility
 
@@ -203,6 +209,7 @@ class CouponRedemptionAdmin(admin.ModelAdmin):
     """Admin for CouponRedemptions"""
 
     model = CouponRedemption
+    raw_id_fields = ("coupon_version","order")
 
 
 class ProductVersionAdmin(admin.ModelAdmin):
@@ -244,7 +251,7 @@ class DataConsentUserAdmin(admin.ModelAdmin):
 
     list_display = ("id", "user", "created_on")
     search_fields = ("user__username", "user__email")
-    raw_id_fields = ('user', )
+    raw_id_fields = ("user","coupon",)
 
     model = DataConsentUser
 
@@ -253,6 +260,7 @@ class DataConsentUserInline(admin.StackedInline):
     """Admin Inline for DataConsentUser objects"""
 
     model = DataConsentUser
+    raw_id_fields = ("user","coupon",)
     extra = 1
     show_change_link = True
 
@@ -263,6 +271,7 @@ class DataConsentAgreementAdmin(admin.ModelAdmin):
     list_filter = ("company",)
     list_display = ("id", "company", "created_on")
     search_fields = ("company", "content")
+    raw_id_fields = ("coupon","payment_version")
     inlines = [DataConsentUserInline]
 
     model = DataConsentAgreement

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -107,7 +107,7 @@ class CouponVersionInline(admin.StackedInline):
 
     model = CouponVersion
     readonly_fields = get_field_names(CouponVersion)
-    raw_id_fields = ("coupon","payment_version")
+    raw_id_fields = ("coupon","payment_version",)
     extra = 0
     show_change_link = True
     can_delete = False
@@ -154,7 +154,7 @@ class CouponPaymentVersionAdmin(admin.ModelAdmin):
     save_as = True
     save_as_continue = False
     save_on_top = True
-    raw_id_fields = ("coupon","payment")
+    raw_id_fields = ("coupon","payment",)
 
     def has_delete_permission(self, request, obj=None):
         return False
@@ -170,7 +170,7 @@ class CouponVersionAdmin(admin.ModelAdmin):
     save_as = True
     save_as_continue = False
     save_on_top = True
-    raw_id_fields = ("coupon","payment_version")
+    raw_id_fields = ("coupon","payment_version",)
 
     def has_delete_permission(self, request, obj=None):
         return False
@@ -183,7 +183,7 @@ class CouponSelectionAdmin(admin.ModelAdmin):
     """Admin for CouponSelections"""
 
     model = CouponSelection
-    raw_id_fields = ("coupon","basket")
+    raw_id_fields = ("coupon","basket",)
 
 
 
@@ -193,7 +193,7 @@ class CouponEligibilityAdmin(admin.ModelAdmin):
     list_display = ("id", "coupon", "product")
     search_fields = ("coupon__coupon_code", "coupon__payment__name")
     list_filter = ("product",)
-    raw_id_fields = ("coupon","product")
+    raw_id_fields = ("coupon","product",)
 
     model = CouponEligibility
 
@@ -209,7 +209,7 @@ class CouponRedemptionAdmin(admin.ModelAdmin):
     """Admin for CouponRedemptions"""
 
     model = CouponRedemption
-    raw_id_fields = ("coupon_version","order")
+    raw_id_fields = ("coupon_version","order",)
 
 
 class ProductVersionAdmin(admin.ModelAdmin):
@@ -271,7 +271,7 @@ class DataConsentAgreementAdmin(admin.ModelAdmin):
     list_filter = ("company",)
     list_display = ("id", "company", "created_on")
     search_fields = ("company", "content")
-    raw_id_fields = ("coupon","payment_version")
+    raw_id_fields = ("coupon","payment_version",)
     inlines = [DataConsentUserInline]
 
     model = DataConsentAgreement

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -244,6 +244,7 @@ class DataConsentUserAdmin(admin.ModelAdmin):
 
     list_display = ("id", "user", "created_on")
     search_fields = ("user__username", "user__email")
+    raw_id_fields = ('user', )
 
     model = DataConsentUser
 


### PR DESCRIPTION
#### Pre-Flight checklist

- ~~Screenshots and design review for any changes that affect layout or styling~~
- ~~Migrations~~
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- ~~Settings~~

#### What are the relevant tickets?

fixes #902 
fixes #574 

#### What's this PR do?

Configures the django admin to use "raw fields" for some admin views, to avoid performing a query for all users (for example) to populate a drop-down. 

#### How should this be manually tested?

Take a look at all the modified admins and see if they load at all. 

Unfortunately, we won't really know this has worked until it's deployed and used in production, with larger volumes of data. 

#### Where should the reviewer start?

/admin/ecommerce and then just load one of each admin. 

