### PR TITLE
Added cron job to retry edx enrollments

### DIFF
--- a/app.json
+++ b/app.json
@@ -321,6 +321,10 @@
       "description": "RedisCloud connection url",
       "required": false
     },
+    "RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY": {
+      "description": "How many seconds between retrying failed edX enrollments",
+      "required": false
+    },
     "ROBOTS_CACHE_TIMEOUT": {
       "description": "How long the robots.txt file should be cached",
       "required": false

--- a/courseware/constants.py
+++ b/courseware/constants.py
@@ -1,6 +1,10 @@
 """Courseware constants"""
 
 PLATFORM_EDX = "edx"
+# List of all currently-supported courseware platforms
+COURSEWARE_PLATFORMS = (PLATFORM_EDX,)
+# Currently-supported courseware platforms in a ChoiceField-friendly format
+COURSEWARE_PLATFORM_CHOICES = zip(COURSEWARE_PLATFORMS, COURSEWARE_PLATFORMS)
 EDX_ENROLLMENT_PRO_MODE = "no-id-professional"
 EDX_ENROLLMENT_AUDIT_MODE = "audit"
 PRO_ENROLL_MODE_ERROR_TEXTS = (
@@ -9,7 +13,5 @@ PRO_ENROLL_MODE_ERROR_TEXTS = (
     ),
     "Specified course mode '{}' unavailable for course".format(EDX_ENROLLMENT_PRO_MODE),
 )
-# List of all currently-supported courseware platforms
-COURSEWARE_PLATFORMS = (PLATFORM_EDX,)
-# Currently-supported courseware platforms in a ChoiceField-friendly format
-COURSEWARE_PLATFORM_CHOICES = zip(COURSEWARE_PLATFORMS, COURSEWARE_PLATFORMS)
+# The amount of minutes after creation that a courseware model record should be eligible for repair
+COURSEWARE_REPAIR_GRACE_PERIOD_MINS = 5

--- a/courseware/exceptions.py
+++ b/courseware/exceptions.py
@@ -11,3 +11,57 @@ class OpenEdXOAuth2Error(Exception):
 
 class NoEdxApiAuthError(Exception):
     """The user was expected to have an OpenEdxApiAuth object but does not"""
+
+
+class EdxApiEnrollErrorException(Exception):
+    """An edX enrollment API call resulted in an error response"""
+
+    def __init__(self, user, course_run, http_error, msg=None):
+        """
+        Sets exception properties and adds a default message
+
+        Args:
+            user (users.models.User): The user for which the enrollment failed
+            course_run (courses.models.CourseRun): The course run for which the enrollment failed
+            http_error (requests.exceptions.HTTPError): The exception from the API call which contains
+                request and response data.
+        """
+        self.user = user
+        self.course_run = course_run
+        self.http_error = http_error
+        if msg is None:
+            # Set some default useful error message
+            msg = "EdX API error enrolling user {} ({}) in course run '{}':\n(Status code: {}) {}".format(
+                self.user.username,
+                self.user.email,
+                self.course_run.courseware_id,
+                self.http_error.response.status_code,
+                self.http_error.response.json(),
+            )
+        super().__init__(msg)
+
+
+class UnknownEdxApiEnrollException(Exception):
+    """An edX enrollment API call failed for an unknown reason"""
+
+    def __init__(self, user, course_run, base_exc, msg=None):
+        """
+        Sets exception properties and adds a default message
+
+        Args:
+            user (users.models.User): The user for which the enrollment failed
+            course_run (courses.models.CourseRun): The course run for which the enrollment failed
+            base_exc (Exception): The unexpected exception
+        """
+        self.user = user
+        self.course_run = course_run
+        self.base_exc = base_exc
+        if msg is None:
+            msg = "Unexpected error enrolling user {} ({}) in course run '{}' ({}: {})".format(
+                self.user.username,
+                self.user.email,
+                self.course_run.courseware_id,
+                type(base_exc).__name__,
+                str(base_exc),
+            )
+        super().__init__(msg)

--- a/courseware/management/commands/retry_edx_enrollment.py
+++ b/courseware/management/commands/retry_edx_enrollment.py
@@ -3,7 +3,6 @@ Management command to retry edX enrollment for a user's course run enrollments
 """
 from django.core.management import BaseCommand
 from django.contrib.auth import get_user_model
-from requests.exceptions import HTTPError
 
 from users.api import fetch_users
 from courseware.api import enroll_in_edx_course_runs
@@ -68,30 +67,8 @@ class Command(BaseCommand):
             course_run = enrollment.run
             try:
                 enroll_in_edx_course_runs(user, [course_run])
-            except HTTPError as exc:
-                self.stderr.write(
-                    self.style.ERROR(
-                        "API error enrolling user {} ({}) in course run '{}':\n(Status code: {}) {}".format(
-                            user.username,
-                            user.email,
-                            course_run.courseware_id,
-                            exc.response.status_code,
-                            exc.response.json(),
-                        )
-                    )
-                )
             except Exception as exc:  # pylint: disable=broad-except
-                self.stderr.write(
-                    self.style.ERROR(
-                        "Unexpected error enrolling user {} ({}) in course run '{}':\n({}) {}".format(
-                            user.username,
-                            user.email,
-                            course_run.courseware_id,
-                            type(exc).__name__,
-                            str(exc),
-                        )
-                    )
-                )
+                self.stderr.write(self.style.ERROR(str(exc)))
             else:
                 enrollment.edx_enrolled = True
                 enrollment.save_and_log(None)

--- a/courseware/tasks_test.py
+++ b/courseware/tasks_test.py
@@ -8,7 +8,7 @@ from courseware import tasks
 @pytest.mark.django_db
 def test_create_edx_user_from_id(mocker):
     """Test that create_edx_user_from_id loads a user and calls the API method to create an edX user"""
-    patch_create_user = mocker.patch("courseware.tasks.create_user")
+    patch_create_user = mocker.patch("courseware.tasks.api.create_user")
     user = UserFactory.create()
     tasks.create_edx_user_from_id.delay(user.id)
     patch_create_user.assert_called_once_with(user)

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -612,7 +612,15 @@ CELERY_BEAT_SCHEDULE = {
             600,
             description="How many seconds between Hubspot API error checks",
         ),
-    }
+    },
+    "retry-failed-edx-enrollments": {
+        "task": "courseware.tasks.retry_failed_edx_enrollments",
+        "schedule": get_int(
+            "RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY",
+            60 * 30,
+            description="How many seconds between retrying failed edX enrollments",
+        ),
+    },
 }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #985

#### What's this PR do?
Adds cron job to retry edx enrollments (+ a couple sensible refactors). edX enrollments are retried every 30m by default, and that time period can be adjusted via the `RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY` setting

#### How should this be manually tested?
**Happy path:**
- Set the `RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY` setting to something like `30` so the task will be run frequently
- Pick some course run that exists in your edX instance (probably `course-v1:edX+DemoX+Demo_Course`)
- Enroll a user in that course run, then set `edx_enrolled` to `False`

Within the time frame you provided in `RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY`, the `retry_failed_edx_enrollments` task should run successfully, you should see that your user's enrollment was set to `edx_enrolled=True`, and the command log line should contain a tuple of your user's email and the course run's text id

**Unhappy path:**
- Enroll in a course run that doesn't exist in edX or with a user that isn't correctly set up in edX

The `retry_failed_edx_enrollments` task should run and log a detailed exception for that enrollment attempt

#### Any background context you want to provide?
- I moved the `retry_edx_enrollment` task to the `courseware` app
- I changed the exception handling around edX enrollment API calls to be a little clearer and to cut out some repetitive handling
- The issue touches on this, but this has the potential to create some noisy logs locally and possibly in production. A separate issue has been created to address this (https://github.com/mitodl/mitxpro/issues/1065)
