### PR TITLE
Added cron job to repair courseware users

### DIFF
--- a/app.json
+++ b/app.json
@@ -329,6 +329,10 @@
       "description": "RedisCloud connection url",
       "required": false
     },
+    "REPAIR_COURSEWARE_USERS_FREQUENCY": {
+      "description": "How many seconds between repairing courseware records for faulty users",
+      "required": false
+    },
     "RETRY_FAILED_EDX_ENROLLMENT_FREQUENCY": {
       "description": "How many seconds between retrying failed edX enrollments",
       "required": false

--- a/courseware/factories.py
+++ b/courseware/factories.py
@@ -5,12 +5,24 @@ from factory import Faker, SubFactory, Trait, LazyAttribute
 from factory.django import DjangoModelFactory
 import pytz
 
-from courseware.models import OpenEdxApiAuth
+from courseware.models import OpenEdxApiAuth, CoursewareUser
+from courseware.constants import PLATFORM_EDX
 from mitxpro.utils import now_in_utc
 
 
+class CoursewareUserFactory(DjangoModelFactory):
+    """Factory for CoursewareUser"""
+
+    user = SubFactory("users.factories.UserFactory")
+    platform = PLATFORM_EDX
+    has_been_synced = True
+
+    class Meta:
+        model = CoursewareUser
+
+
 class OpenEdxApiAuthFactory(DjangoModelFactory):
-    """Factory for Users"""
+    """Factory for OpenEdxApiAuth"""
 
     user = SubFactory("users.factories.UserFactory")
     refresh_token = Faker("pystr", max_chars=30)

--- a/courseware/tasks.py
+++ b/courseware/tasks.py
@@ -26,3 +26,10 @@ def retry_failed_edx_enrollments():
         (enrollment.user.email, enrollment.run.courseware_id)
         for enrollment in successful_enrollments
     ]
+
+
+@app.task(acks_late=True)
+def repair_faulty_courseware_users():
+    """Calls the API method to repair faulty courseware users"""
+    repaired_users = api.repair_faulty_courseware_users()
+    return [user.email for user in repaired_users]

--- a/mitxpro/envs.py
+++ b/mitxpro/envs.py
@@ -2,8 +2,10 @@
 import json
 import os
 from collections import namedtuple
+from datetime import timedelta
 from functools import wraps
 
+from celery.schedules import schedule
 from django.core.exceptions import ImproperlyConfigured
 
 
@@ -272,3 +274,29 @@ def generate_app_json():
         )
 
     return config
+
+
+class OffsettingSchedule(schedule):
+    """
+    Specialized celery schedule class that allows for easy definition of an offset time for a
+    scheduled task (e.g.: the task should run every 30, but it should start after a 15 second offset)
+
+    Inspired by this SO answer: https://stackoverflow.com/a/41700962
+    """
+
+    def __init__(self, run_every=None, offset=None):
+        self._run_every = run_every
+        self._offset = offset
+        self._apply_offset = offset is not None
+        super().__init__(run_every=self._run_every + (offset or timedelta(seconds=0)))
+
+    def is_due(self, last_run_at):
+        retval = super().is_due(last_run_at)
+        if self._apply_offset is not None and retval.is_due:
+            self._apply_offset = False
+            self.run_every = self._run_every
+            retval = super().is_due(last_run_at)
+        return retval
+
+    def __reduce__(self):
+        return self.__class__, (self._run_every, self._offset)

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -128,6 +128,23 @@ def first_matching_item(iterable, predicate):
     return next(filter(predicate, iterable), None)
 
 
+def find_object_with_matching_attr(iterable, attr_name, value):
+    """
+    Finds the first item in an iterable that has an attribute with the given name and value. Returns
+    None otherwise.
+
+    Returns:
+        Matching item or None
+    """
+    for item in iterable:
+        try:
+            if getattr(item, attr_name) == value:
+                return item
+        except AttributeError:
+            pass
+    return None
+
+
 def has_equal_properties(obj, property_dict):
     """
     Returns True if the given object has the properties indicated by the keys of the given dict, and the values

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -19,6 +19,7 @@ from mitxpro.utils import (
     has_equal_properties,
     remove_password_from_url,
     first_or_none,
+    find_object_with_matching_attr,
     unique,
     unique_ignore_case,
 )
@@ -85,6 +86,24 @@ def test_has_equal_properties():
     assert has_equal_properties(obj, dict(a=1, b=2, c=3)) is True
     assert has_equal_properties(obj, dict(a=2)) is False
     assert has_equal_properties(obj, dict(d=4)) is False
+
+
+def test_find_object_with_matching_attr():
+    """
+    Assert that find_object_with_matching_attr returns the first object in an iterable that has the given
+    attribute value (or None if there is no match)
+    """
+    objects = [
+        SimpleNamespace(a=0),
+        SimpleNamespace(a=1),
+        SimpleNamespace(a=2),
+        SimpleNamespace(a=3),
+        SimpleNamespace(a=None),
+    ]
+    assert find_object_with_matching_attr(objects, "a", 3) == objects[3]
+    assert find_object_with_matching_attr(objects, "a", None) == objects[4]
+    assert find_object_with_matching_attr(objects, "a", "bad value") is None
+    assert find_object_with_matching_attr(objects, "b", None) is None
 
 
 def test_partition():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #984 
Related to #985 (PR #1058)

#### What's this PR do?
Adds cron job to loop through users that aren't correctly configured in edX, and, as necessary, creates `CoursewareUser` and `OpenEdxApiAuth` records

#### How should this be manually tested?

**Happy path:**
- Set the `REPAIR_COURSEWARE_USERS_FREQUENCY` setting to something like `30` so the task will be run frequently
- Delete some local `CoursewareUser` record and also delete the same user in edX (can be done via Django admin in both cases)
- Delete some `OpenEdxApiAuth` record for that same user
- Delete some `OpenEdxApiAuth` record for a different user

Within the time frame you provided in `REPAIR_COURSEWARE_USERS_FREQUENCY`, the `repair_faulty_courseware_users` task should run successfully, and in the task results you should see the emails of the users associated with the deleted `CoursewareUser` and `OpenEdxApiAuth`. The appropriate `CoursewareUser` and `OpenEdxApiAuth` records should also be created as a result

**Unhappy path:**
- Delete a `CoursewareUser` record, but don't delete the corresponding user in edX

The task should run and log an exception indicating that the user already exists, and the task should continue executing after that exception is logged

#### Any background context you want to provide?
A separate issue has been created to prevent potential alarm fatigue from this task (https://github.com/mitodl/mitxpro/issues/1065)

