### PR TITLE
Certificates: create program certificate

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -15,6 +15,7 @@ from .models import (
     ProgramEnrollment,
     CourseRunEnrollment,
     CourseRunCertificate,
+    ProgramCertificate,
 )
 
 FAKE = faker.Factory.create()
@@ -99,6 +100,16 @@ class CourseRunCertificateFactory(DjangoModelFactory):
 
     class Meta:
         model = CourseRunCertificate
+
+
+class ProgramCertificateFactory(DjangoModelFactory):
+    """Factory for CourseRunCertificate"""
+
+    program = factory.SubFactory(ProgramFactory)
+    user = factory.SubFactory(UserFactory)
+
+    class Meta:
+        model = ProgramCertificate
 
 
 class CourseRunEnrollmentFactory(DjangoModelFactory):

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -1,0 +1,26 @@
+"""
+Signals for micromasters course certificates
+"""
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from courses.models import CourseRunCertificate
+from courses.utils import generate_program_certificate
+
+
+@receiver(
+    post_save,
+    sender=CourseRunCertificate,
+    dispatch_uid="courseruncertificate_post_save",
+)
+def handle_create_course_run_certificate(
+    sender, instance, created, **kwargs
+):  # pylint: disable=unused-argument
+    """
+    When a CourseRunCertificate model is created.
+    """
+    if created:
+        user = instance.user
+        program = instance.course_run.course.program
+        transaction.on_commit(lambda: generate_program_certificate(user, program))

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -1,0 +1,29 @@
+"""
+Tests for signals
+"""
+from unittest.mock import patch
+import pytest
+from courses.factories import CourseRunFactory, CourseRunCertificateFactory, UserFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+# pylint: disable=unused-argument
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("courses.signals.generate_program_certificate", autospec=True)
+def test_create_course_certificate(generate_program_cert_mock, mock_on_commit):
+    """
+    Test that generate_program_certificate is called when a course
+    certificate is created
+    """
+    user = UserFactory.create()
+    course_run = CourseRunFactory.create()
+    cert = CourseRunCertificateFactory.create(user=user, course_run=course_run)
+    generate_program_cert_mock.assert_called_once_with(
+        user, cert.course_run.course.program
+    )
+    cert.save()
+    generate_program_cert_mock.assert_called_once_with(
+        user, cert.course_run.course.program
+    )

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -1,0 +1,68 @@
+# pylint:disable=redefined-outer-name
+"""
+Tests for signals
+"""
+import pytest
+from courses.factories import (
+    UserFactory,
+    ProgramFactory,
+    CourseFactory,
+    CourseRunFactory,
+    CourseRunCertificateFactory,
+    ProgramCertificateFactory,
+)
+from courses.utils import generate_program_certificate
+from courses.models import ProgramCertificate
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def user():
+    """User object fixture"""
+    return UserFactory.create()
+
+
+@pytest.fixture()
+def program():
+    """User object fixture"""
+    return ProgramFactory.create()
+
+
+def test_generate_program_certificate_already_exist(user, program):
+    """
+    Test that generate_program_certificate return (None, False) and not create program certificate
+    if program certificate already exist.
+    """
+    program_certificate = ProgramCertificateFactory.create(program=program, user=user)
+    result = generate_program_certificate(user=user, program=program)
+    assert result == (program_certificate, False)
+    assert len(ProgramCertificate.objects.all()) == 1
+
+
+def test_generate_program_certificate_failure(user, program):
+    """
+    Test that generate_program_certificate return (None, False) and not create program certificate
+    if there is not any course_run certificate for the given course.
+    """
+    course = CourseFactory.create(program=program)
+    CourseRunFactory.create_batch(3, course=course)
+
+    result = generate_program_certificate(user=user, program=program)
+    assert result == (None, False)
+    assert len(ProgramCertificate.objects.all()) == 0
+
+
+def test_generate_program_certificate_success(user, program):
+    """
+    Test that generate_program_certificate generate a program certificate
+    """
+    course = CourseFactory.create(program=program)
+    course_run = CourseRunFactory.create(course=course)
+
+    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+
+    result = generate_program_certificate(user=user, program=program)
+    assert result[1] is True
+    assert isinstance(result[0], ProgramCertificate)
+    assert len(ProgramCertificate.objects.all()) == 1


### PR DESCRIPTION
#### Task: #1030 
Certificates: create program certificate when user has certificates in all courses in a program 

#### Acceptance Criteria:

- [ ] fire a django-signal whenever a course certificate is generated
- [ ] when the signal is fired, if the user has a certificate for every course in the program, generate a program certificate for them


