### PR TITLE
Add explanation text to B2B purchase and receipt pages

### DIFF
--- a/static/js/components/B2BExplanation.js
+++ b/static/js/components/B2BExplanation.js
@@ -1,0 +1,63 @@
+// @flow
+import React from "react"
+
+import Expandable from "./Expandable"
+
+type Props = {
+  alreadyPaid: boolean,
+  className?: string
+}
+const B2BExplanation = ({ alreadyPaid, className }: Props) => (
+  <div className={`container b2b-explanation ${className ? className : ""}`}>
+    <div className="row">
+      <div className="col-lg-8">
+        {alreadyPaid ? (
+          <Expandable title="Enrollment Codes">
+            <ul>
+              <li>
+                Enrollment codes act as a confirmation of purchase and gives the
+                recipient access to the course.
+              </li>
+              <li>
+                The recipient enters the enrollment code at checkout, instead of
+                paying for the course.
+              </li>
+            </ul>
+          </Expandable>
+        ) : (
+          <Expandable title="How It Works">
+            <p>
+              Step 1 - Purchase unique "enrollment codes" for your learners.
+            </p>
+            <p>
+              Step 2 - Distribute enrollment codes to each of your learners.
+            </p>
+            <p>
+              Step 3 - Your learners use the enrollment code to enroll in the
+              course.
+            </p>
+          </Expandable>
+        )}
+
+        <Expandable title="Purchase Agreement" className="last-expandable">
+          <ul>
+            <li>Each enrollment code can be used only one time.</li>
+            <li>
+              You are responsible for distributing codes to your learners in
+              your organization.
+            </li>
+            <li>
+              Each code will expire in one year from the date of purchase or, if
+              earlier, once the course is closed.
+            </li>
+            <li>You may not resell codes to third parties.</li>
+            <li>
+              All xPRO business sales are final and not eligible for refunds.
+            </li>
+          </ul>
+        </Expandable>
+      </div>
+    </div>
+  </div>
+)
+export default B2BExplanation

--- a/static/js/components/Expandable.js
+++ b/static/js/components/Expandable.js
@@ -1,0 +1,41 @@
+// @flow
+import React from "react"
+import { Button } from "reactstrap"
+
+type Props = {
+  title: string,
+  children: any,
+  className?: string
+}
+type State = {
+  expanded: boolean
+}
+export default class Expandable extends React.Component<Props, State> {
+  state = {
+    expanded: false
+  }
+
+  render() {
+    const { title, children, className } = this.props
+    const { expanded } = this.state
+
+    return (
+      <div className={`expandable ${className ? className : ""}`}>
+        <div
+          className="header"
+          onClick={() =>
+            this.setState({
+              expanded: !expanded
+            })
+          }
+        >
+          <span className="title">{title}</span>
+          <i className="material-icons toggle">
+            {expanded ? "expand_less" : "expand_more"}
+          </i>
+        </div>
+        <div className="body">{expanded ? children : null}</div>
+      </div>
+    )
+  }
+}

--- a/static/js/components/Expandable_test.js
+++ b/static/js/components/Expandable_test.js
@@ -1,0 +1,44 @@
+// @flow
+import React from "react"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import Expandable from "./Expandable"
+
+import { shouldIf } from "../lib/test_utils"
+
+describe("Expandable", () => {
+  let sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("should toggle the explanation text", () => {
+    const title = "title"
+    const children = "children"
+    const wrapper = shallow(<Expandable title={title}>{children}</Expandable>)
+
+    assert.isFalse(wrapper.state().expanded)
+    wrapper.find(".header").prop("onClick")()
+    assert.isTrue(wrapper.state().expanded)
+    wrapper.find(".header").prop("onClick")()
+    assert.isFalse(wrapper.state().expanded)
+  })
+
+  //
+  ;[true, false].forEach(expanded => {
+    it(`${shouldIf(expanded)} render the explanation text`, () => {
+      const title = "title"
+      const children = "children"
+      const wrapper = shallow(<Expandable title={title}>{children}</Expandable>)
+      wrapper.setState({ expanded })
+      assert.equal(wrapper.find(".body").text(), expanded ? children : "")
+    })
+  })
+})

--- a/static/js/containers/pages/b2b/B2BPurchasePage.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage.js
@@ -14,6 +14,7 @@ import type {
   BulkCheckoutPayload,
   ProductDetail
 } from "../../../flow/ecommerceTypes"
+import B2BExplanation from "../../../components/B2BExplanation"
 
 type Props = {
   checkout: (payload: BulkCheckoutPayload) => Promise<*>,
@@ -76,12 +77,15 @@ export class B2BPurchasePage extends React.Component<Props, State> {
     const { checkout, products, requestPending } = this.props
 
     return (
-      <B2BPurchaseForm
-        onSubmit={this.onSubmit}
-        products={products}
-        checkout={checkout}
-        requestPending={requestPending}
-      />
+      <React.Fragment>
+        <B2BPurchaseForm
+          onSubmit={this.onSubmit}
+          products={products}
+          checkout={checkout}
+          requestPending={requestPending}
+        />
+        <B2BExplanation alreadyPaid={false} />
+      </React.Fragment>
     )
   }
 }

--- a/static/js/containers/pages/b2b/B2BReceiptPage.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage.js
@@ -19,6 +19,7 @@ import { ALERT_TYPE_TEXT } from "../../../constants"
 import type { B2BOrderStatus } from "../../../flow/ecommerceTypes"
 import type { Location } from "react-router"
 import type Moment from "moment"
+import B2BExplanation from "../../../components/B2BExplanation"
 
 type Props = {
   addUserNotification: Function,
@@ -119,49 +120,55 @@ export class B2BReceiptPage extends React.Component<Props, State> {
     } = orderStatus
 
     return (
-      <div className="b2b-receipt-page container">
-        <div className="row">
-          <div className="col-lg-12">
-            <div className="title">Bulk Seats Receipt</div>
+      <React.Fragment>
+        <div className="b2b-receipt-page container">
+          <div className="row">
+            <div className="col-lg-12">
+              <div className="title">Bulk Seats Receipt</div>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-lg-8">
+              <p>
+                Thank you! You have purchased one or more seats for your team.
+              </p>
+              <h3>Purchase Summary (Order Number):</h3>
+              <p className="course-or-program">
+                <span className="description">Course or program:</span>
+                {title}
+                <span className="description">{readableId}</span>
+              </p>
+              <p className="seats">
+                <span className="description">Seats:</span>
+                {numSeats} (at {formatPrice(itemPrice)} per seat)
+              </p>
+              <p className="email">
+                <span className="description">Email Address:</span>
+                {email}
+              </p>
+              If you encounter any issues please email {SETTINGS.support_email}{" "}
+              to contact customer support.
+            </div>
+            <div className="col-lg-4">
+              <B2BPurchaseSummary
+                itemPrice={itemPrice}
+                totalPrice={totalPrice}
+                numSeats={numSeats}
+              />
+              <a
+                href={`/api/b2b/orders/${hash}/codes/`}
+                className="enrollment-codes-link"
+              >
+                Download codes <i className="material-icons">save_alt</i>
+              </a>
+            </div>
           </div>
         </div>
-        <div className="row">
-          <div className="col-lg-8">
-            <p>
-              Thank you! You have purchased one or more seats for your team.
-            </p>
-            <h3>Purchase Summary (Order Number):</h3>
-            <p className="course-or-program">
-              <span className="description">Course or program:</span>
-              {title}
-              <span className="description">{readableId}</span>
-            </p>
-            <p className="seats">
-              <span className="description">Seats:</span>
-              {numSeats} (at {formatPrice(itemPrice)} per seat)
-            </p>
-            <p className="email">
-              <span className="description">Email Address:</span>
-              {email}
-            </p>
-            If you encounter any issues please email {SETTINGS.support_email} to
-            contact customer support.
-          </div>
-          <div className="col-lg-4">
-            <B2BPurchaseSummary
-              itemPrice={itemPrice}
-              totalPrice={totalPrice}
-              numSeats={numSeats}
-            />
-            <a
-              href={`/api/b2b/orders/${hash}/codes/`}
-              className="enrollment-codes-link"
-            >
-              Download codes <i className="material-icons">save_alt</i>
-            </a>
-          </div>
-        </div>
-      </div>
+        <B2BExplanation
+          alreadyPaid={true}
+          className="b2b-receipt-explanation"
+        />
+      </React.Fragment>
     )
   }
 }

--- a/static/js/containers/pages/b2b/B2BReceiptPage.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage.js
@@ -146,8 +146,11 @@ export class B2BReceiptPage extends React.Component<Props, State> {
                 <span className="description">Email Address:</span>
                 {email}
               </p>
-              If you encounter any issues please email {SETTINGS.support_email}{" "}
-              to contact customer support.
+              If you encounter any issues please contact{" "}
+              <a href="https://xpro.zendesk.com/hc/requests/new">
+                customer support
+              </a>
+              .
             </div>
             <div className="col-lg-4">
               <B2BPurchaseSummary

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -446,3 +446,41 @@
   color: grey;
   background-image: linear-gradient(to right, $soft-light-gray 50%, rgba(255,255,255,0) 0%);
 }
+
+.b2b-explanation {
+  max-width: 1000px;
+
+  .expandable {
+    border-top: 2px solid $tab-color;
+
+    .header {
+      height: 75px;
+
+      .toggle {
+        font-size: 48px;
+        color: $navy-blue;
+      }
+
+      .title {
+        font-size: 20px;
+        color: $navy-blue;
+        font-weight: bold;
+      }
+    }
+
+    &.last-expandable {
+      border-bottom: 2px solid $tab-color;
+      margin-bottom: 20px;
+    }
+
+    .body {
+      font-size: 18px;
+      line-height: 36px;
+      font-weight: 500;
+    }
+  }
+
+  &.b2b-receipt-explanation {
+    margin-top: 30px;
+  }
+}

--- a/static/scss/expandable.scss
+++ b/static/scss/expandable.scss
@@ -1,0 +1,12 @@
+.expandable {
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    cursor: pointer;
+
+    .toggle {
+      margin-left: auto;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -38,6 +38,7 @@
 @import "error";
 @import "voucher";
 @import "certificates/certificate";
+@import "expandable";
 
 body {
   font-family: Rajdhani,"Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1073 

#### What's this PR do?
Adds explanation text on the purchase and receipt pages

#### How should this be manually tested?
Go to `/ecommerce/bulk` and verify that you see the explanation text. You should see similar explanation text for the receipt page, but note the differences in the mockups.

#### Screenshots
Purchase page
![Screenshot from 2019-09-06 11-59-51](https://user-images.githubusercontent.com/863262/64443138-4c4cf480-d09f-11e9-8970-fa5ad39bcde9.png)


Receipt page
![Screenshot from 2019-09-06 12-09-14](https://user-images.githubusercontent.com/863262/64443149-4fe07b80-d09f-11e9-8afe-425d4ec94671.png)
