### PR TITLE
Coupons for refunded orders should not be valid

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -322,7 +322,12 @@ def get_valid_coupon_versions(
                     "couponredemption",
                     filter=(
                         Q(couponredemption__order__purchaser=user)
-                        & Q(couponredemption__order__status=Order.FULFILLED)
+                        & Q(
+                            couponredemption__order__status__in=(
+                                Order.FULFILLED,
+                                Order.REFUNDED,
+                            )
+                        )
                     ),
                 )
             )
@@ -331,7 +336,14 @@ def get_valid_coupon_versions(
             global_redemptions=(
                 Count(
                     "couponredemption",
-                    filter=(Q(couponredemption__order__status=Order.FULFILLED)),
+                    filter=(
+                        Q(
+                            couponredemption__order__status__in=(
+                                Order.FULFILLED,
+                                Order.REFUNDED,
+                            )
+                        )
+                    ),
                 )
             )
         )

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -356,7 +356,9 @@ def test_get_valid_coupon_versions_by_company(basket_and_coupons):
     ) == [basket_and_coupons.coupongroup_worst.coupon_version]
 
 
-@pytest.mark.parametrize("order_status", [Order.FULFILLED, Order.FAILED])
+@pytest.mark.parametrize(
+    "order_status", [Order.FULFILLED, Order.FAILED, Order.REFUNDED]
+)
 def test_get_valid_coupon_versions_over_redeemed(basket_and_coupons, order_status):
     """
     Verify that CouponPaymentVersions that have exceeded redemption limits are not returned
@@ -387,7 +389,7 @@ def test_get_valid_coupon_versions_over_redeemed(basket_and_coupons, order_statu
             basket_and_coupons.basket_item.basket.user,
         )
     )
-    if order_status == Order.FULFILLED:
+    if order_status in (Order.FULFILLED, Order.REFUNDED):
         assert best_versions == []
     else:
         assert best_versions == [


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1025 

#### What's this PR do?
Adjusts the filter so that refunded orders are treated the same as fulfilled orders when determining coupon validity.

#### How should this be manually tested?
Create a coupon, then use it in a purchase in the checkout page (probably easiest to do a 100% off coupon). In the Django admin change the order status to "refunded" for the newest order. Try using the coupon again and it should error.
