### PR TITLE
Make ProductVersion.text_id a read-only field in django admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -217,6 +217,7 @@ class ProductVersionAdmin(admin.ModelAdmin):
     save_as = True
     save_as_continue = False
     save_on_top = True
+    readonly_fields = ("text_id",)
 
     def has_delete_permission(self, request, obj=None):
         return False


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #1060

#### What's this PR do?
Makes `ProductVersion.text_id` read-only in Django Admin

#### How should this be manually tested?
Try creating and updating (save as new) ProductVersions in Django Admin.  The `text_id` field should not be editable.

<img width="756" alt="Screen Shot 2019-09-11 at 2 26 01 PM" src="https://user-images.githubusercontent.com/187676/64725204-1f834d80-d4a2-11e9-99c0-307503eeaa6d.png">
