### PR TITLE
Adding TLS verification for Fastly

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -7,6 +7,10 @@ server {
         return 204;
     }
 
+    location = /.well-known/pki-validation/gsdv.txt {
+        return 200 '<meta name="_globalsign-domain-verification" content="38nrGyq0UF7YrbaQ_MryPfiEEvb_3nx_BbuEPyehVH" />';
+    }
+
     location = /favicon.ico {
         try_files /static/images/favicon.ico /favicon.ico;
     }


### PR DESCRIPTION
In order to enable Fastly for xPRO we need to verify domain ownership to set up TLS by returning a text output for a `.well-known` domain

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds domain verification for Fastly TLS setup

#### How should this be manually tested?
request the /.well-known/pki-validation/gsdv.txt endpoint on the app and verify that it returns a 200 response with the specified text.

#### Any background context you want to provide?
In order to set up an MX record of xpro.mit.edu we need to move the apex record for that subdomain to an A record instead of a CNAME, meaning that we are going to use Fastly's anycast IP functionality.