### PR TITLE
Add payment_type and payment_transaction for coupons created by B2B purchases

### DIFF
--- a/b2b_ecommerce/api.py
+++ b/b2b_ecommerce/api.py
@@ -32,6 +32,8 @@ def complete_b2b_order(order):
             amount=Decimal("1"),
             num_coupon_codes=order.num_seats,
             coupon_type=CouponPaymentVersion.SINGLE_USE,
+            payment_type=CouponPaymentVersion.PAYMENT_SALE,
+            payment_transaction=order.reference_number,
         )
         order.coupon_payment_version = payment_version
         order.save()

--- a/b2b_ecommerce/api_test.py
+++ b/b2b_ecommerce/api_test.py
@@ -123,6 +123,8 @@ def test_complete_b2b_order(mocker):
         amount=Decimal("1"),
         num_coupon_codes=order.num_seats,
         coupon_type=CouponPaymentVersion.SINGLE_USE,
+        payment_type=CouponPaymentVersion.PAYMENT_SALE,
+        payment_transaction=order.reference_number,
     )
     send_email_mock.assert_called_once_with(order)
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1114 

#### What's this PR do?
Sets a `payment_transaction` and `payment_type` for created coupons

#### How should this be manually tested?
Create enrollment codes and check that they have a `payment_transaction` set on the `CouponPaymentVersion` instance
