### PR TITLE
#980 Coupons: product selection improvement

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -41,6 +41,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
     thumbnail_url = serializers.SerializerMethodField()
     content_title = serializers.SerializerMethodField()
     readable_id = serializers.SerializerMethodField()
+    start_date = serializers.SerializerMethodField()
 
     def get_type(self, instance):
         """ Return the product version type """
@@ -83,6 +84,15 @@ class ProductVersionSerializer(serializers.ModelSerializer):
         """Return the readable_id of the program or course run"""
         return get_readable_id(instance.product.content_object)
 
+    def get_start_date(self, instance):
+        """Returns the start date of the program or course run"""
+        content_object = instance.product.content_object
+        if isinstance(content_object, CourseRun) and content_object.start_date:
+            return content_object.start_date.isoformat()
+        elif isinstance(content_object, Program) and content_object.next_run_date:
+            return content_object.next_run_date.isoformat()
+        return None
+
     class Meta:
         fields = [
             "id",
@@ -96,6 +106,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             "product_id",
             "readable_id",
             "created_on",
+            "start_date",
         ]
         model = models.ProductVersion
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -70,6 +70,9 @@ def test_serialize_basket_product_version_courserun(mock_context):
         "product_id": product_version.product.id,
         "readable_id": get_readable_id(product_version.product.content_object),
         "created_on": product_version.created_on.strftime(datetime_millis_format),
+        "start_date": product_version.product.content_object.start_date.isoformat()
+        if product_version.product.content_object.start_date
+        else None,
     }
 
 
@@ -97,6 +100,9 @@ def test_serialize_basket_product_version_program(mock_context):
         "product_id": product_version.product.id,
         "readable_id": get_readable_id(product_version.product.content_object),
         "created_on": product_version.created_on.strftime(datetime_millis_format),
+        "start_date": product_version.product.content_object.next_run_date.isoformat()
+        if product_version.product.content_object.next_run_date
+        else None,
     }
 
 

--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -15,13 +15,14 @@ import {
   PRODUCT_TYPE_PROGRAM
 } from "../../constants"
 import { isPromo } from "../../lib/ecommerce"
+import { getProductSelectLabel } from "../../lib/util"
 
-import type { Company, Product } from "../../flow/ecommerceTypes"
+import type { Company, ProductDetail } from "../../flow/ecommerceTypes"
 
 type CouponFormProps = {
   onSubmit: Function,
   companies: Array<Company>,
-  products: Array<Product>
+  products: Array<ProductDetail>
 }
 
 const couponValidations = yup.object().shape({
@@ -277,18 +278,25 @@ export const CouponForm = ({
           <Picky
             name="products"
             valueKey="id"
-            labelKey="title"
+            labelKey="label"
             options={filter(
               values.product_type
                 ? pathSatisfies(equals(values.product_type), ["product_type"])
                 : always(true),
-              sortBy(prop("title"), products || [])
+              sortBy(
+                prop("label"),
+                (products || []).map(product => ({
+                  ...product,
+                  label: getProductSelectLabel(product)
+                }))
+              )
             )}
             value={values.products}
             open={true}
             multiple={true}
             includeSelectAll={false}
             includeFilter={true}
+            numberDisplayed={2}
             onChange={value => {
               setFieldValue("products", value)
               setFieldTouched("products")

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -17,6 +17,7 @@ import {
   findFormikFieldByName,
   findFormikErrorByName
 } from "../../lib/test_utils"
+import { formatPrettyDate } from "../../lib/util"
 
 describe("CouponForm", () => {
   let sandbox, onSubmitStub
@@ -200,6 +201,36 @@ describe("CouponForm", () => {
         assert.ok(picky.text().includes(availableProduct[1].title))
       }
     })
+  })
+
+  //
+  it(`displays correct product labels`, async () => {
+    const wrapper = renderForm()
+    wrapper
+      .find(`input[name='product_type']`)
+      .findWhere(checkBox => checkBox.prop("value") === "")
+      .simulate("click")
+    await wait()
+    wrapper.update()
+    const picky = wrapper.find(".picky")
+    assert.ok(
+      picky
+        .text()
+        .includes(
+          `${products[0].latest_version.readable_id} | ${
+            products[0].title
+          } | ${formatPrettyDate(
+            moment(products[0].latest_version.start_date)
+          )}`
+        )
+    )
+    assert.ok(
+      picky
+        .text()
+        .includes(
+          `${products[1].latest_version.readable_id} | ${products[1].title}`
+        )
+    )
   })
 
   //

--- a/static/js/containers/pages/admin/CreateCouponPage.js
+++ b/static/js/containers/pages/admin/CreateCouponPage.js
@@ -17,7 +17,7 @@ import type { Response } from "redux-query"
 import type {
   Company,
   CouponPaymentVersion,
-  Product
+  ProductDetail
 } from "../../../flow/ecommerceTypes"
 import { createStructuredSelector } from "reselect"
 import { COUPON_TYPE_SINGLE_USE } from "../../../constants"
@@ -27,7 +27,7 @@ type State = {
 }
 
 type StateProps = {|
-  products: Array<Product>,
+  products: Array<ProductDetail>,
   companies: Array<Company>,
   coupons: Map<string, CouponPaymentVersion>
 |}

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -68,7 +68,8 @@ export const makeItem = (productType: ?string): BasketItem => {
     // $FlowFixMe: flow doesn't understand generators well
     product_id:    genProductId.next().value,
     readable_id:   casual.text,
-    created_on:    casual.moment.format()
+    created_on:    casual.moment.format(),
+    start_date:    casual.moment.format()
   }
 }
 

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -39,6 +39,7 @@ export type ProductVersion = {
   id: number,
   readable_id: string,
   created_on: string,
+  start_date: ?string,
 }
 
 export type BasketItem = ProductVersion & {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -26,6 +26,10 @@ import type {
   UserEnrollments
 } from "../flow/courseTypes"
 
+import type { ProductDetail } from "../flow/ecommerceTypes"
+
+import { PRODUCT_TYPE_COURSERUN } from "../constants"
+
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed
  */
@@ -214,4 +218,17 @@ export const findItemWithTextId = (
   }
 
   return null
+}
+
+export const getProductSelectLabel = (product: ProductDetail) => {
+  if (
+    product.product_type === PRODUCT_TYPE_COURSERUN &&
+    product.latest_version.start_date !== null
+  ) {
+    return `${product.latest_version.readable_id} | ${
+      product.title
+    } | ${formatPrettyDate(moment(product.latest_version.start_date))}`
+  } else {
+    return `${product.latest_version.readable_id} | ${product.title}`
+  }
 }

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -23,9 +23,13 @@ import {
   getMaxDate,
   newSetWith,
   newSetWithout,
-  timeoutPromise
+  timeoutPromise,
+  getProductSelectLabel
 } from "./util"
 import { makeUserEnrollments } from "../factories/course"
+import { makeProduct } from "../factories/ecommerce"
+
+import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../constants"
 
 describe("utility functions", () => {
   it("waits some milliseconds", done => {
@@ -105,6 +109,22 @@ describe("utility functions", () => {
     ].forEach(([val, exp]) => {
       assert.equal(notNil(val), exp)
     })
+  })
+
+  it("getProductSelectLabel works as expected", () => {
+    const program = makeProduct(PRODUCT_TYPE_PROGRAM)
+    const courseRun = makeProduct(PRODUCT_TYPE_COURSERUN)
+
+    assert.equal(
+      getProductSelectLabel(courseRun),
+      `${courseRun.latest_version.readable_id} | ${
+        courseRun.title
+      } | ${formatPrettyDate(moment(courseRun.latest_version.start_date))}`
+    )
+    assert.equal(
+      getProductSelectLabel(program),
+      `${program.latest_version.readable_id} | ${program.title}`
+    )
   })
 
   it("getTokenFromUrl gets a token value from a url match or the querystring", () => {

--- a/static/scss/ecommerce-admin.scss
+++ b/static/scss/ecommerce-admin.scss
@@ -51,10 +51,14 @@
 
   .product-selection {
     height: 250px;
+
+    div {
+      padding-right: unset;
+    }
   }
 
   .picky {
-    max-width: 600px;
+    max-width: 992px;
   }
 
   .picky__dropdown {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #980 

#### What's this PR do?
Increases width of product selection dropdown to max `992px` (same as bootstrap medium device width) and updates the product label in the dropdown with the format:
```
<readable_id> | <title>
```

For course runs with start dates, the format is:

```
<readable_id> | <title> | <start_date>
```

Because the new format includes both the title and readable id (as well as start date for course runs) any of these values may be used for a partial or full filter.

#### How should this be manually tested?
Go to `/ecommerce/admin/coupons/` and verify the UI is as expected.

#### Screenshots (if appropriate)
![Screenshot from 2019-09-17 14-55-16](https://user-images.githubusercontent.com/45350418/65038354-3aa20180-d969-11e9-9b07-83eba6a1cc65.png)
