### PR TITLE
Enhancements to programs API to support discussions ingestion

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,24 @@
 Release Notes
 =============
 
+Version 0.22.1
+--------------
+
+- #1123 certificate validation link
+- - Add validation over name field
+- Fix migrations by renaming one conflicting migration to happen later
+- Change decimal places for amount from 2 to 5 and add validation (#1124)
+- - Import the signal in courses app
+- Add a "is_active" field to the product model
+- Open a fancybox upon clicking on Watch Now button..
+- Lowered max username length to 30 (in code, not in db)
+- #980 Coupons: product selection improvement
+- #1099 Program certificate links and view
+- Updated sync_grades_and_certificates params
+- Adding validation to proper Nginx config and full HTML response
+- Implement discount codes for B2B purchases (#1055)
+- Certificates: create program certificate
+
 Version 0.22.0 (Released September 18, 2019)
 --------------
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-Version 0.22.1
+Version 0.22.1 (Released September 23, 2019)
 --------------
 
 - #1123 certificate validation link

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -17,6 +17,7 @@ from ecommerce.api import make_checkout_url
 from ecommerce.factories import CouponVersionFactory
 from ecommerce.serializers import ProductVersionSerializer
 from mitxpro.utils import dict_without_keys
+from mitxpro.test_utils import assert_drf_json_equal
 
 
 CYBERSOURCE_SECURE_ACCEPTANCE_URL = "http://fake"
@@ -245,17 +246,20 @@ def test_order_status(client):
         reverse("b2b-order-status", kwargs={"hash": str(order.unique_id)})
     )
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json() == {
-        "email": order.email,
-        "num_seats": order.num_seats,
-        "product_version": ProductVersionSerializer(
-            order.product_version, context={"all_runs": True}
-        ).data,
-        "item_price": str(order.per_item_price),
-        "total_price": str(order.total_price),
-        "status": order.status,
-        "discount": None,
-    }
+    assert_drf_json_equal(
+        resp.json(),
+        {
+            "email": order.email,
+            "num_seats": order.num_seats,
+            "product_version": ProductVersionSerializer(
+                order.product_version, context={"all_runs": True}
+            ).data,
+            "item_price": str(order.per_item_price),
+            "total_price": str(order.total_price),
+            "status": order.status,
+            "discount": None,
+        },
+    )
 
 
 def test_order_status_missing(client):

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -81,7 +81,7 @@ class CourseRunFactory(DjangoModelFactory):
     expiration_date = factory.Faker(
         "date_time_between", start_date="+1y", end_date="+2y", tzinfo=pytz.utc
     )
-    live = factory.Faker("boolean")
+    live = True
 
     class Meta:
         model = CourseRun

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -82,6 +82,7 @@ class CourseRunSerializer(serializers.ModelSerializer):
             "expiration_date",
             "courseware_url",
             "courseware_id",
+            "current_price",
             "instructors",
             "id",
             "product_id",
@@ -115,11 +116,12 @@ class CourseSerializer(serializers.ModelSerializer):
         if all_runs:
             active_runs = instance.unexpired_runs
         else:
-            user = self.context["request"].user
-            if user.is_anonymous:
-                active_runs = []
-            else:
-                active_runs = instance.available_runs(user)
+            user = self.context["request"].user if "request" in self.context else None
+            active_runs = (
+                instance.available_runs(user)
+                if user and user.is_authenticated
+                else instance.unexpired_runs
+            )
         return [
             CourseRunSerializer(instance=run, context=self.context).data
             for run in active_runs
@@ -200,6 +202,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "description",
             "thumbnail_url",
             "readable_id",
+            "current_price",
             "id",
             "courses",
         ]

--- a/courses/views.py
+++ b/courses/views.py
@@ -23,6 +23,8 @@ from mitxpro.views import get_js_settings_context
 class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     """API view set for Programs"""
 
+    permission_classes = []
+
     serializer_class = ProgramSerializer
     queryset = Program.objects.all()
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -48,7 +48,7 @@ from ecommerce.serializers import (
     DataConsentUserSerializer,
 )
 from ecommerce.test_utils import unprotect_version_tables
-from mitxpro.test_utils import create_tempfile_csv
+from mitxpro.test_utils import create_tempfile_csv, assert_drf_json_equal
 from mitxpro.utils import dict_without_keys
 from users.factories import UserFactory
 
@@ -995,11 +995,9 @@ def test_products_viewset_list(user_drf_client, coupon_product_ids):
     products = response.json()
     assert {product.get("id") for product in products} == set(coupon_product_ids)
     for product in products:
-        assert (
-            product
-            == ProductSerializer(
-                instance=Product.objects.get(id=product.get("id"))
-            ).data
+        assert_drf_json_equal(
+            product,
+            ProductSerializer(instance=Product.objects.get(id=product.get("id"))).data,
         )
 
 
@@ -1018,11 +1016,9 @@ def test_products_viewset_detail(user_drf_client, coupon_product_ids):
         reverse("products_api-detail", kwargs={"pk": coupon_product_ids[0]})
     )
     assert response.status_code == status.HTTP_200_OK
-    assert (
-        response.json()
-        == ProductSerializer(
-            instance=Product.objects.get(id=coupon_product_ids[0])
-        ).data
+    assert_drf_json_equal(
+        response.json(),
+        ProductSerializer(instance=Product.objects.get(id=coupon_product_ids[0])).data,
     )
 
 

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -17,7 +17,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 from mitxpro.envs import get_any, get_bool, get_int, get_string, OffsettingSchedule
 
-VERSION = "0.22.0"
+VERSION = "0.22.1"
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/mitxpro/test_utils.py
+++ b/mitxpro/test_utils.py
@@ -10,6 +10,7 @@ import tempfile
 import pytest
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.renderers import JSONRenderer
 
 
 def any_instance_of(*cls):
@@ -43,6 +44,21 @@ def assert_not_raises():
         raise
     except Exception:  # pylint: disable=broad-except
         pytest.fail(f"An exception was not raised: {traceback.format_exc()}")
+
+
+def assert_drf_json_equal(obj1, obj2):
+    """
+    Asserts that two objects are equal after a round trip through JSON serialization/deserialization.
+    Particularly helpful when testing DRF serializers where you may get back OrderedDict and other such objects.
+
+    Args:
+        obj1 (object): the first object
+        obj2 (object): the second object
+    """
+    json_renderer = JSONRenderer()
+    converted1 = json.loads(json_renderer.render(obj1))
+    converted2 = json.loads(json_renderer.render(obj2))
+    assert converted1 == converted2
 
 
 class MockResponse:

--- a/mitxpro/test_utils_test.py
+++ b/mitxpro/test_utils_test.py
@@ -8,6 +8,7 @@ from mitxpro.test_utils import (
     assert_not_raises,
     MockResponse,
     PickleableMock,
+    assert_drf_json_equal,
 )
 
 
@@ -44,6 +45,13 @@ def test_assert_not_raises_failure():
     with pytest.raises(AssertionError):
         with assert_not_raises():
             assert 1 == 2
+
+
+def test_assert_drf_json_equall():
+    """Asserts that objects are equal in JSON"""
+    assert_drf_json_equal({"a": 1}, {"a": 1})
+    assert_drf_json_equal(2, 2)
+    assert_drf_json_equal([2], [2])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Prereq to https://github.com/mitodl/open-discussions/issues/2182

#### What's this PR do?
- Allows public access on the `/api/programs/` API so that discussions can access it
- Adds the `current_price` field to the program serializer

#### How should this be manually tested?
Go to `/api/programs` while logged out and verify it returns data and that the price is present on programs