### PR TITLE
Lowered max username length to 30 (in code, not in db)

### DIFF
--- a/users/constants.py
+++ b/users/constants.py
@@ -1,2 +1,2 @@
 """User constants"""
-USERNAME_MAX_LEN = 50
+USERNAME_MAX_LEN = 30

--- a/users/models.py
+++ b/users/models.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext_lazy as _
 import pycountry
 
 from mitxpro.models import TimestampedModel
-from users.constants import USERNAME_MAX_LEN
 
 # Defined in edX Profile model
 MALE = "m"
@@ -137,7 +136,9 @@ class User(AbstractBaseUser, TimestampedModel, PermissionsMixin):
     USERNAME_FIELD = "username"
     REQUIRED_FIELDS = ["email", "name"]
 
-    username = models.CharField(unique=True, max_length=USERNAME_MAX_LEN)
+    # NOTE: Username max length was set to 50 before we lowered it. We're hardcoding this
+    # value here now until we are ready to migrate the max length at the database level.
+    username = models.CharField(unique=True, max_length=50)
     email = models.EmailField(blank=False, unique=True)
     name = models.TextField(blank=True, default="")
     is_staff = models.BooleanField(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. Addresses this sentry issue: https://sentry.io/organizations/mit-office-of-digital-learning/issues/1229561383/events/8f8e5c2ee91b41798d21f5a3ead8e06a/?environment=production&project=1413655

#### What's this PR do?
Lowers username max length in code (not yet in database field)

#### How should this be manually tested?
Create a user with a very long name (i.e.: a name that would create a username with more than 30 chars). The generated username should be 30 chars long
