### PR TITLE
asadiqbal08/mitxpro-1104 - Update Forgot Password message

### DIFF
--- a/static/js/containers/pages/login/LoginForgotPasswordPage.js
+++ b/static/js/containers/pages/login/LoginForgotPasswordPage.js
@@ -6,6 +6,7 @@ import { FORGOT_PASSWORD_PAGE_TITLE } from "../../../constants"
 import { compose } from "redux"
 import { connect } from "react-redux"
 import { mutateAsync } from "redux-query"
+import { Link } from "react-router-dom"
 
 import { addUserNotification } from "../../../actions"
 import auth from "../../../lib/queries/auth"
@@ -19,32 +20,49 @@ import type { EmailFormValues } from "../../../components/forms/EmailForm"
 
 type Props = {
   history: RouterHistory,
-  forgotPassword: (email: string) => Promise<any>,
-  addUserNotification: Function
+  forgotPassword: (email: string) => Promise<any>
 }
 
-const passwordResetText = (email: string) =>
-  `If an account with the email "${email}" exists, an email has been sent with a password reset link.`
+type State = {
+  forgotEmailSent: boolean,
+  text: Object | null
+}
 
-export class LoginForgotPasswordPage extends React.Component<Props> {
+const passwordResetText = (email: string) => (
+  <p>
+    If an account with the email <span className="email">{email}</span> <br />{" "}
+    exists, an email has been sent with a password reset link.
+  </p>
+)
+
+export class LoginForgotPasswordPage extends React.Component<Props, State> {
+  constructor(props: Props, state: State) {
+    super(props, state)
+    this.state = { forgotEmailSent: false, text: null }
+  }
   async onSubmit({ email }: EmailFormValues, { setSubmitting }: any) {
-    const { addUserNotification, forgotPassword, history } = this.props
+    const { forgotPassword, history } = this.props
 
     try {
       await forgotPassword(email)
-
-      addUserNotification({
-        "forgot-password-sent": {
-          type:  ALERT_TYPE_TEXT,
-          props: {
-            text: passwordResetText(email)
-          }
+      this.setState((state, props) => {
+        return {
+          forgotEmailSent: true,
+          text:            passwordResetText(email)
         }
       })
-      history.push(routes.login.begin)
+
+      history.push(routes.login.forgot)
     } finally {
       setSubmitting(false)
     }
+  }
+
+  resetEmailLinkSent() {
+    this.setState({
+      forgotEmailSent: false,
+      text:            null
+    })
   }
 
   render() {
@@ -53,17 +71,53 @@ export class LoginForgotPasswordPage extends React.Component<Props> {
         title={`${SETTINGS.site_name} | ${FORGOT_PASSWORD_PAGE_TITLE}`}
       >
         <div className="container auth-page">
-          <div className="row auth-header">
-            <h1 className="col-12">Forgot Password</h1>
+          <div className="auth-header">
+            <h1>Forgot Password</h1>
           </div>
-          <div className="row auth-card card-shadow auth-form">
-            <div className="col-12">
-              <p>Enter your email to receive a password reset link.</p>
+          {this.state.forgotEmailSent ? (
+            <div className="card-shadow confirm-sent-page">
+              <h3 className="text-center">Thank You!</h3>
+              {this.state.text}
+              <p>
+                <b>
+                  If you do NOT receive your password reset email, here's what
+                  to do:
+                </b>
+              </p>
+              <ol>
+                <li>
+                  <b>Wait a few moments.</b> It might take several minutes to
+                  receive your password reset email.
+                </li>
+                <li>
+                  <b>Check your spam folder.</b> It might be there.
+                </li>
+                <li>
+                  <b>Is your email correct?</b> If you made a typo, no problem,
+                  just try to
+                  <Link
+                    to={routes.login.forgot.begin}
+                    onClick={this.resetEmailLinkSent.bind(this)}
+                  >
+                    {` reset your password `}
+                  </Link>
+                  again.
+                </li>
+              </ol>
+              <div className="contact-support">
+                <b>Still no password reset email? </b>
+                Please contact our {` ${SETTINGS.site_name} `}
+                <a href={`mailto:${SETTINGS.support_email}`}>
+                  Customer Support Center.
+                </a>
+              </div>
             </div>
-            <div className="col-12">
+          ) : (
+            <div className="auth-card card-shadow auth-form">
+              <p>Enter your email to receive a password reset link.</p>
               <EmailForm onSubmit={this.onSubmit.bind(this)} />
             </div>
-          </div>
+          )}
         </div>
       </DocumentTitle>
     )

--- a/static/js/containers/pages/register/RegisterConfirmSentPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmSentPage.js
@@ -28,11 +28,16 @@ export class RegisterConfirmSentPage extends React.Component<Props> {
 
           <div className="confirm-sent-page">
             <h2 className="text-center font-weight-600">Thank You!</h2>
-            We sent an email to <span className="email">{email}</span>
-            ,<br /> please verify your address to continue.
-            <div>
-              If you do NOT receive your verification email, here’s what to do:
-            </div>
+            <p>
+              We sent an email to <span className="email">{email}</span>
+              ,<br /> please verify your address to continue.
+            </p>
+            <p>
+              <b>
+                If you do NOT receive your verification email, here’s what to
+                do:
+              </b>
+            </p>
             <ol>
               <li>
                 <span className="font-weight-600">Wait a few moments.</span> It

--- a/static/js/containers/pages/register/RegisterConfirmSentPage_test.js
+++ b/static/js/containers/pages/register/RegisterConfirmSentPage_test.js
@@ -53,7 +53,7 @@ describe("RegisterConfirmSentPage", () => {
   it("displays user's email on the page", async () => {
     const { inner } = await renderPage()
     assert.equal(
-      inner.find(".confirm-sent-page > span").text("href"),
+      inner.find(".confirm-sent-page > p > span").text("href"),
       userEmail
     )
   })

--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -15,6 +15,10 @@
     letter-spacing: 0.06em;
   }
 
+  b {
+    font-weight: 600;
+  }
+
   h4 {
     @include media-breakpoint-down(xs) {
       font-size: 16px;
@@ -25,7 +29,7 @@
     font-size: 16px;
     letter-spacing: 1.05px;
     line-height: 20px;
-    padding: 49px 100px 8px;
+    padding: 49px 95px 40px;
     position: relative;
     box-shadow: inset 0 1px 3px 0 rgba(0,0,0,0.5), -4px 3px 17px -4px rgba(0,0,0,0.25);
     background-color: $very-light-gray;
@@ -50,7 +54,6 @@
     }
 
     div:first-of-type {
-      padding-top: 20px;
       font-weight: 600;
     }
 
@@ -59,6 +62,7 @@
     }
 
     .contact-support {
+      padding-top: 20px;
       line-height: 21px;
     }
 
@@ -67,6 +71,7 @@
       padding-left: 18px;
       letter-spacing: 0.55px;
       line-height: 21px;
+      margin-bottom: 0;
 
       li {
         margin-bottom: 4px;


### PR DESCRIPTION
#### ScreenShot:

<img width="717" alt="Screen Shot 2019-09-25 at 2 26 47 PM" src="https://user-images.githubusercontent.com/7334669/65588248-9e977c00-dfa0-11e9-8621-f101c2de091d.png">


#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#1104 

#### What's this PR do?
Updated the message over the Forget-Password Screen.

#### How should this be manually tested?
- Click on the Sign In button.
- Input your email ID.
- Click on the Forget Password link.
- Enter the email which will receive the email. 
- A text message should be appeared a shown above and in the ticket design . 


