### PR TITLE
#843 Checkout: non-200 responses

### DIFF
--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -53,6 +53,7 @@
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="{% static 'js/notifications.js' %}"></script>
     {% endblock %}
+    {% if zendesk_config.help_widget_enabled %}
     <script type="text/javascript">
         zE('webWidget', 'prefill', {
             name: {
@@ -62,6 +63,7 @@
                 value: '{{user.email}}',
             }
         });
+    {% endif %}
     </script>
   </body>
 </html>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#843 

#### What's this PR do?
Logs error to Sentry for basket update response as well as checkout response if the status was non 200 and there was no body.

#### How should this be manually tested?
Configure sentry and make sure you return a non-200 response from the API for the basket and checkout operations.

#### Screenshots (if appropriate)
Checkout page
![Screenshot from 2019-09-25 18-30-25](https://user-images.githubusercontent.com/45350418/65608015-f47f1a80-dfc6-11e9-8606-2849deadaa18.png)

Sentry issue
![Screenshot from 2019-09-19 19-13-38](https://user-images.githubusercontent.com/45350418/65251998-a921c380-db11-11e9-9bd4-09482800fa6e.png)

Sentry error (response not in format so the whole response object is dumped)
![Screenshot from 2019-10-03 18-16-55](https://user-images.githubusercontent.com/45350418/66129860-25d09980-e60a-11e9-933a-1cf96a7b19cc.png)

Sentry exception (response is in format so only the API error object is dumped)
![Screenshot from 2019-10-03 18-17-07](https://user-images.githubusercontent.com/45350418/66129882-31bc5b80-e60a-11e9-9fdd-88e3680d4c54.png)
