### PR TITLE
asadiqbal08/mitxpro-1148 ProgramCertificate will not create for standalone course

### DIFF
--- a/courses/__init__.py
+++ b/courses/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-docstring,invalid-name
+default_app_config = "courses.apps.CoursesConfig"

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -23,4 +23,5 @@ def handle_create_course_run_certificate(
     if created:
         user = instance.user
         program = instance.course_run.course.program
-        transaction.on_commit(lambda: generate_program_certificate(user, program))
+        if program:
+            transaction.on_commit(lambda: generate_program_certificate(user, program))

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -3,7 +3,12 @@ Tests for signals
 """
 from unittest.mock import patch
 import pytest
-from courses.factories import CourseRunFactory, CourseRunCertificateFactory, UserFactory
+from courses.factories import (
+    CourseRunFactory,
+    CourseRunCertificateFactory,
+    UserFactory,
+    CourseFactory,
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -27,3 +32,21 @@ def test_create_course_certificate(generate_program_cert_mock, mock_on_commit):
     generate_program_cert_mock.assert_called_once_with(
         user, cert.course_run.course.program
     )
+
+
+# pylint: disable=unused-argument
+@patch("courses.signals.transaction.on_commit", side_effect=lambda callback: callback())
+@patch("courses.signals.generate_program_certificate", autospec=True)
+def test_generate_program_certificate_not_called(
+    generate_program_cert_mock, mock_on_commit
+):
+    """
+    Test that generate_program_certificate is not called when a course
+    is not associated with program.
+    """
+    user = UserFactory.create()
+    course = CourseFactory.create(program=None)
+    course_run = CourseRunFactory.create(course=course)
+    cert = CourseRunCertificateFactory.create(user=user, course_run=course_run)
+    cert.save()
+    generate_program_cert_mock.assert_not_called()

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -95,7 +95,6 @@ def generate_program_certificate(user, program):
         ProgramCertificate (or None if one was not found or created) paired
         with a boolean indicating whether the certificate was newly created.
     """
-
     existing_cert_queryset = ProgramCertificate.objects.filter(
         user=user, program=program
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1148 

#### What's this PR do?
- Referenced the `CoursesConfig` in courses app.
- Will not try to generate program certificate if the course is not associated with program.  

#### How should this be manually tested?
### Scenario-1
- After creating all the `CourseRunCertificate` for a program, 
- A signal should be fired and there should be corresponding `ProgramCertifiacate`. 

### Scenario-2
- Create a course that is not linked with any program. (standalone course).
- Enroll user for this course.
- CourseRunCertificate will create after passing the course and after saving an entry in `CourseRunCertificate`, a signal will be fired that try to generate program certificate. 
- As the course is not associated with any program. ProgramCertificate will not be created.
