### PR TITLE
#978 Admin interface for export compliance result

### DIFF
--- a/compliance/admin.py
+++ b/compliance/admin.py
@@ -1,0 +1,45 @@
+"""
+Admin site bindings for compliance
+"""
+
+from django.conf import settings
+from django.contrib import admin
+
+from mitxpro.utils import get_field_names
+from users.utils import ensure_active_user
+
+from .constants import RESULT_MANUALLY_APPROVED, RESULT_SUCCESS
+from .models import ExportsInquiryLog
+
+
+class ExportsInquiryLogAdmin(admin.ModelAdmin):
+    """Admin for ExportsInquiryLog"""
+
+    model = ExportsInquiryLog
+    search_fields = ["user__email", "computed_result", "info_code", "reason_code"]
+    list_filter = ["computed_result", "info_code", "reason_code"]
+    list_display = ["user", "computed_result", "info_code", "reason_code"]
+    readonly_fields = [] if settings.DEBUG else get_field_names(ExportsInquiryLog)
+    actions = ["manually_approve_inquiry"]
+
+    def manually_approve_inquiry(self, request, queryset):
+        """Admin action to manually approve export compliance inquiry records"""
+        eligible_objects = queryset.exclude(
+            computed_result__in=[RESULT_MANUALLY_APPROVED, RESULT_SUCCESS]
+        )
+        eligible_objects.update(computed_result=RESULT_MANUALLY_APPROVED)
+        for obj in eligible_objects:
+            ensure_active_user(obj.user)
+
+    manually_approve_inquiry.short_description = "Manually approve selected records"
+
+    def has_add_permission(self, request):
+        # We want to allow this while debugging
+        return settings.DEBUG
+
+    def has_delete_permission(self, request, obj=None):
+        # We want to allow this while debugging
+        return settings.DEBUG
+
+
+admin.site.register(ExportsInquiryLog, ExportsInquiryLogAdmin)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#978 

#### What's this PR do?
Adds a Django admin section for export compliance results. ~~If the status is changed to `RESULT_MANUALLY_APPROVED` the user is activated if not already, and the edx account/record is repaired if necessary.~~ The section is read-only however provides an admin action to manually approve selected inquiry records. Upon manual approval the user is activated (if not already) and edx auth credentials are repaired (if required).

#### How should this be manually tested?
Create an export compliance result object with `computed_result` not equal to `MANUALLY_APPROVED` or `SUCCESS`. From the change list, select the record and apply the manual approval action. The log from the `web` service should display the process being carried out, and errors if any.

#### Screenshots (if appropriate)
![Screenshot from 2019-10-02 13-53-32](https://user-images.githubusercontent.com/45350418/66031142-3c98c280-e51c-11e9-87aa-7481a3d56a8d.png)
![Screenshot from 2019-10-02 13-59-47](https://user-images.githubusercontent.com/45350418/66031485-f2fca780-e51c-11e9-8391-8b712cab1191.png)
