### PR TITLE
Optimized bulk enrollment form queries

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -48,7 +48,25 @@ class BaseCourseSerializer(serializers.ModelSerializer):
         fields = ["id", "title", "description", "thumbnail_url", "readable_id"]
 
 
-class CourseRunSerializer(serializers.ModelSerializer):
+class BaseCourseRunSerializer(serializers.ModelSerializer):
+    """Minimal CourseRun model serializer"""
+
+    class Meta:
+        model = models.CourseRun
+        fields = [
+            "title",
+            "start_date",
+            "end_date",
+            "enrollment_start",
+            "enrollment_end",
+            "expiration_date",
+            "courseware_url",
+            "courseware_id",
+            "id",
+        ]
+
+
+class CourseRunSerializer(BaseCourseSerializer):
     """CourseRun model serializer"""
 
     product_id = serializers.SerializerMethodField()
@@ -73,20 +91,7 @@ class CourseRunSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.CourseRun
-        fields = [
-            "title",
-            "start_date",
-            "end_date",
-            "enrollment_start",
-            "enrollment_end",
-            "expiration_date",
-            "courseware_url",
-            "courseware_id",
-            "current_price",
-            "instructors",
-            "id",
-            "product_id",
-        ]
+        fields = BaseCourseRunSerializer.Meta.fields + ["product_id", "instructors"]
 
 
 class CourseSerializer(serializers.ModelSerializer):

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -66,7 +66,7 @@ class BaseCourseRunSerializer(serializers.ModelSerializer):
         ]
 
 
-class CourseRunSerializer(BaseCourseSerializer):
+class CourseRunSerializer(BaseCourseRunSerializer):
     """CourseRun model serializer"""
 
     product_id = serializers.SerializerMethodField()
@@ -91,7 +91,11 @@ class CourseRunSerializer(BaseCourseSerializer):
 
     class Meta:
         model = models.CourseRun
-        fields = BaseCourseRunSerializer.Meta.fields + ["product_id", "instructors"]
+        fields = BaseCourseRunSerializer.Meta.fields + [
+            "product_id",
+            "instructors",
+            "current_price",
+        ]
 
 
 class CourseSerializer(serializers.ModelSerializer):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -11,7 +11,7 @@ from urllib.parse import quote_plus, urljoin, urlencode
 import uuid
 
 from django.conf import settings
-from django.db.models import Q, Max, F, Count, Subquery, Prefetch
+from django.db.models import Q, Max, F, Count, Subquery
 from django.db import transaction
 from django.urls import reverse
 from rest_framework.exceptions import ValidationError
@@ -34,11 +34,7 @@ from courseware.exceptions import (
     UnknownEdxApiEnrollException,
 )
 from ecommerce import mail_api
-from ecommerce.constants import (
-    CYBERSOURCE_DECISION_ACCEPT,
-    CYBERSOURCE_DECISION_CANCEL,
-    ORDERED_VERSIONS_QSET_ATTR,
-)
+from ecommerce.constants import CYBERSOURCE_DECISION_ACCEPT, CYBERSOURCE_DECISION_CANCEL
 from ecommerce.exceptions import EcommerceException
 from ecommerce.models import (
     Basket,
@@ -55,7 +51,6 @@ from ecommerce.models import (
     DataConsentAgreement,
     DataConsentUser,
     Product,
-    ProductVersion,
     ProductCouponAssignment,
     Line,
     Order,

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -42,6 +42,7 @@ from ecommerce.api import (
     make_receipt_url,
     get_product_courses,
     get_available_bulk_product_coupons,
+    get_full_price_coupon_product_set,
     validate_basket_for_checkout,
     complete_order,
     enroll_user_in_order_items,
@@ -621,6 +622,57 @@ def test_get_available_bulk_product_coupons():
     )
     assert available_qset.count() == 2
     assert list(available_qset) == [first_product_coupon, additional_product_coupons[0]]
+
+
+def test_get_full_price_coupon_product_set():
+    """get_full_price_coupon_product_set should yield 100%-off coupons paired with the products they apply to"""
+    coupons = CouponFactory.create_batch(
+        4, enabled=factory.Iterator([True, True, True, False])
+    )
+    # Create two 100% coupons
+    valid_payment_versions = CouponPaymentVersionFactory.create_batch(
+        2,
+        amount=1,
+        payment=factory.Iterator([coupon.payment for coupon in coupons[0:2]]),
+        coupon_type=CouponPaymentVersion.SINGLE_USE,
+    )
+    # Create another 100% coupon, then deprecate it with a newer 50% version
+    CouponPaymentVersionFactory.create_batch(
+        2,
+        amount=factory.Iterator([1, 0.5]),
+        payment=coupons[2].payment,
+        coupon_type=CouponPaymentVersion.SINGLE_USE,
+    )
+    # Create another 100% coupon with a disabled Coupon
+    CouponPaymentVersionFactory.create(
+        amount=1,
+        payment=coupons[3].payment,
+        coupon_type=CouponPaymentVersion.SINGLE_USE,
+    )
+    product_coupons = CouponEligibilityFactory.create_batch(
+        len(coupons), coupon=factory.Iterator(coupons)
+    )
+    # Also apply the second full price coupon payment to the same product as that the first applies to. This will test
+    # to make sure that the "products" map doesn't have repeat entries for the same product.
+    first_coupon_product = product_coupons[0].product
+    product_coupons.insert(
+        2,
+        CouponEligibilityFactory.create(
+            product=first_coupon_product, coupon=product_coupons[1].coupon
+        ),
+    )
+
+    coupon_product_pairs = list(get_full_price_coupon_product_set())
+    assert len(coupon_product_pairs) == len(valid_payment_versions)
+    assert [pair[0] for pair in coupon_product_pairs] == [
+        payment_version.payment for payment_version in valid_payment_versions
+    ]
+    first_product_qset = coupon_product_pairs[0][1]
+    assert first_product_qset.first() == product_coupons[0].product
+    second_product_qset = coupon_product_pairs[1][1]
+    assert set(second_product_qset) == set(
+        [product_coupon.product for product_coupon in product_coupons[1:3]]
+    )
 
 
 @pytest.mark.parametrize("has_coupon", [True, False])

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -670,9 +670,9 @@ def test_get_full_price_coupon_product_set():
     first_product_qset = coupon_product_pairs[0][1]
     assert first_product_qset.first() == product_coupons[0].product
     second_product_qset = coupon_product_pairs[1][1]
-    assert set(second_product_qset) == set(
-        [product_coupon.product for product_coupon in product_coupons[1:3]]
-    )
+    assert set(second_product_qset) == {
+        product_coupon.product for product_coupon in product_coupons[1:3]
+    }
 
 
 @pytest.mark.parametrize("has_coupon", [True, False])

--- a/ecommerce/constants.py
+++ b/ecommerce/constants.py
@@ -9,3 +9,8 @@ CYBERSOURCE_DECISION_ERROR = "ERROR"
 CYBERSOURCE_DECISION_CANCEL = "CANCEL"
 
 REFERENCE_NUMBER_PREFIX = "xpro-b2c-"
+
+# Any query that is prefetching an ordered set of related versions (ex: Product qset fetching
+# related ProductVersions in reverse creation order) can use `to_attr` and this attribute name
+# for the prefetched results.
+ORDERED_VERSIONS_QSET_ATTR = "ordered_versions"

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -126,11 +126,10 @@ class BaseProductSerializer(serializers.ModelSerializer):
         model = models.Product
 
 
-class ProductSerializer(serializers.ModelSerializer):
+class ProductSerializer(BaseProductSerializer):
     """ Product Serializer """
 
     title = serializers.SerializerMethodField()
-    product_type = serializers.SerializerMethodField()
     latest_version = serializers.SerializerMethodField()
 
     def get_title(self, instance):
@@ -138,10 +137,6 @@ class ProductSerializer(serializers.ModelSerializer):
         return instance.content_type.get_object_for_this_type(
             pk=instance.object_id
         ).title
-
-    def get_product_type(self, instance):
-        """ Return the product type """
-        return instance.content_type.model
 
     def get_latest_version(self, instance):
         """Serialize and return the latest ProductVersion for the Product"""
@@ -157,7 +152,7 @@ class ProductSerializer(serializers.ModelSerializer):
         ).data
 
     class Meta:
-        fields = ["id", "title", "product_type", "latest_version"]
+        fields = BaseProductSerializer.Meta.fields + ["title", "latest_version"]
         model = models.Product
 
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -115,6 +115,8 @@ class ProductVersionSerializer(serializers.ModelSerializer):
 
 
 class BaseProductSerializer(serializers.ModelSerializer):
+    """ Basic Product Serializer """
+
     product_type = serializers.SerializerMethodField()
 
     def get_product_type(self, instance):

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -378,7 +378,10 @@ def test_current_coupon_payment_version_serializer():
 
 
 def test_current_coupon_payment_version_serializer_latest(mocker):
-
+    """
+    Test that CurrentCouponPaymentSerializer does not try to get the latest CouponPaymentVersion
+    from the model object if it is passed in via context
+    """
     # Since we're testing the preference of the 'latest_version' context var
     # over CouponPayment.latest_version, we patch CouponPayment.latest_version to return None.
     # If that property is used instead of the context var, the results will be invalid.

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -5,6 +5,8 @@ Tests for ecommerce serializers
 from decimal import Decimal
 
 import pytest
+import factory
+from django.db.models import Prefetch
 from rest_framework.exceptions import ValidationError
 
 from mitxpro.test_utils import any_instance_of
@@ -13,6 +15,7 @@ from courses.factories import CourseFactory, ProgramFactory, CourseRunFactory
 from courses.serializers import CourseSerializer
 from courses.constants import CATALOG_COURSE_IMG_WAGTAIL_FILL
 from ecommerce.api import get_readable_id, round_half_up
+from ecommerce.constants import ORDERED_VERSIONS_QSET_ATTR
 from ecommerce.factories import (
     ProductVersionFactory,
     ProductFactory,
@@ -24,7 +27,10 @@ from ecommerce.factories import (
 )
 from ecommerce.models import (
     CouponSelection,
+    CouponPayment,
+    CouponPaymentVersion,
     Product,
+    ProductVersion,
     CourseRunSelection,
     DataConsentUser,
 )
@@ -371,6 +377,32 @@ def test_current_coupon_payment_version_serializer():
     }
 
 
+def test_current_coupon_payment_version_serializer_latest(mocker):
+
+    # Since we're testing the preference of the 'latest_version' context var
+    # over CouponPayment.latest_version, we patch CouponPayment.latest_version to return None.
+    # If that property is used instead of the context var, the results will be invalid.
+    mocker.patch(
+        "ecommerce.models.CouponPayment.latest_version",
+        new_callable=mocker.PropertyMock,
+        return_value=None,
+    )
+    payment = CouponPaymentFactory.create()
+    versions = CouponPaymentVersionFactory.create_batch(3, payment=payment)
+    payment_qset = CouponPayment.objects.prefetch_related(
+        Prefetch(
+            "versions",
+            queryset=CouponPaymentVersion.objects.order_by("-created_on"),
+            to_attr=ORDERED_VERSIONS_QSET_ATTR,
+        )
+    )
+    expected_version = versions[2]
+    serialized = CurrentCouponPaymentSerializer(
+        instance=payment_qset.first(), context={"latest_version": expected_version}
+    ).data
+    assert serialized["version"]["id"] == expected_version.id
+
+
 def test_serialize_product(coupon_product_ids):
     """ Test that ProductSerializer has correct data """
     product = Product.objects.get(id=coupon_product_ids[0])
@@ -379,6 +411,39 @@ def test_serialize_product(coupon_product_ids):
     assert serialized_data.get("title") == run.title
     assert serialized_data.get("product_type") == "courserun"
     assert serialized_data.get("id") == product.id
+
+
+def test_serialize_product_with_ordered(mocker):
+    """
+    Test that ProductSerializer takes a context variable that says the ProductVersions are
+    already ordered, so it can use that ordered list of versions instead of calling
+    Product.latest_version and running another query.
+    """
+    # Since we're testing the preference of the 'ordered_versions' queryset property
+    # over Product.latest_version, we patch 'latest_version' to return None. If 'latest_version'
+    # is used by the serializer, the results will be invalid.
+    mocker.patch(
+        "ecommerce.models.Product.latest_version",
+        new_callable=mocker.PropertyMock,
+        return_value=None,
+    )
+    products = ProductFactory.create_batch(2)
+    versions = ProductVersionFactory.create_batch(4, product=factory.Iterator(products))
+    product_qset = Product.objects.prefetch_related(
+        Prefetch(
+            "productversions",
+            queryset=ProductVersion.objects.order_by("-created_on"),
+            to_attr=ORDERED_VERSIONS_QSET_ATTR,
+        )
+    )
+    serialized_data = ProductSerializer(
+        product_qset, context={"has_ordered_versions": True}, many=True
+    ).data
+    expected_versions = [versions[2], versions[3]]
+    assert len(serialized_data) == len(products)
+    assert [version.id for version in expected_versions] == [
+        product_data["latest_version"]["id"] for product_data in serialized_data
+    ]
 
 
 def test_serialize_company():

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -191,6 +191,31 @@ class BulkEnrollCouponListView(APIView):
     authentication_classes = (SessionAuthentication,)
 
     def get(self, request, *args, **kwargs):  # pylint: disable=missing-docstring
+        """
+        Handles GET requests. Response data is of this form:
+
+        {
+            "coupon_payments": [
+                {
+                    <serialized CouponPayment>,
+                    "products": [
+                        <basic serialized data for a Product that the CouponPayment applies to>,
+                        ...
+                    ]
+                },
+                ...
+            ],
+            "product_map": {
+                "courserun": {
+                    "<Product.id>": {<serialized CourseRun>},
+                    ...
+                },
+                "program": {
+                    "<Product.id>": {<serialized Program>},
+                    ...
+                }
+            }
+        """
         product_set = set()
         serialized = {"coupon_payments": []}
         for coupon_payment, products in get_full_price_coupon_product_set():

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -212,10 +212,10 @@ class BulkEnrollCouponListView(APIView):
                     ).data,
                 }
             )
-        serialized["products"] = defaultdict(dict)
+        serialized["product_map"] = defaultdict(dict)
         for product in product_set:
             product_object = product.content_object
-            serialized["products"][product.content_type.model][str(product.id)] = (
+            serialized["product_map"][product.content_type.model][str(product.id)] = (
                 BaseCourseRunSerializer(product_object).data
                 if isinstance(product_object, CourseRun)
                 else BaseProgramSerializer(product_object).data

--- a/mitxpro/test_utils.py
+++ b/mitxpro/test_utils.py
@@ -134,3 +134,17 @@ def format_as_iso8601(time):
         miniseconds_format = ".%f"
         formatted_time += time.strftime(miniseconds_format)[:4]
     return formatted_time + "Z"
+
+
+def list_of_dicts(specialty_dict_iter):
+    """
+    Some library methods yield an OrderedDict or defaultdict, and it's easier to confirm their contents using a
+    regular dict. This function turns an iterable of specialty dicts into a list of normal dicts.
+
+    Args:
+        specialty_dict_iter:
+
+    Returns:
+        list of dict: A list of dicts
+    """
+    return list(map(dict, specialty_dict_iter))

--- a/static/js/components/forms/BulkEnrollmentForm.js
+++ b/static/js/components/forms/BulkEnrollmentForm.js
@@ -173,11 +173,13 @@ export class BulkEnrollmentForm extends React.Component<
                 name="product_id"
                 onChange={this.onChangeProductId(setFieldValue)}
               >
-                {R.toPairs(productMap[values.product_type]).map(([productId, productObject]) => (
-                  <option key={productId} value={productId}>
-                    {productObject.title}
-                  </option>
-                ))}
+                {R.toPairs(productMap[values.product_type]).map(
+                  ([productId, productObject]) => (
+                    <option key={productId} value={productId}>
+                      {productObject.title}
+                    </option>
+                  )
+                )}
               </Field>
             </section>
 

--- a/static/js/components/forms/BulkEnrollmentForm.js
+++ b/static/js/components/forms/BulkEnrollmentForm.js
@@ -6,6 +6,7 @@ import * as yup from "yup"
 
 import { RadioButtonGroup, RadioButton } from "../input/radio"
 import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_LABELS } from "../../constants"
+import { parseIntOrUndefined } from "../../lib/util"
 
 import type {
   BulkCouponPayment,
@@ -16,6 +17,12 @@ import type {
 const getFirstId = R.compose(
   R.prop("id"),
   R.head
+)
+
+const getFirstKeyAsInt = R.compose(
+  parseIntOrUndefined,
+  R.head,
+  R.keys
 )
 
 const bulkEnrollmentValidations = yup.object().shape({
@@ -61,7 +68,7 @@ export class BulkEnrollmentForm extends React.Component<
     const { productMap } = this.props
 
     const selectedProductType = e.target.value
-    const selectedProductId = getFirstId(productMap[selectedProductType])
+    const selectedProductId = getFirstKeyAsInt(productMap[selectedProductType])
     setFieldValue("product_type", selectedProductType)
     setFieldValue("product_id", selectedProductId)
     setFieldValue(
@@ -107,7 +114,7 @@ export class BulkEnrollmentForm extends React.Component<
     const { productMap } = this.props
 
     const initialProductType = PRODUCT_TYPE_COURSERUN
-    const initialProductId = getFirstId(productMap[PRODUCT_TYPE_COURSERUN])
+    const initialProductId = getFirstKeyAsInt(productMap[initialProductType])
     const initialCouponPaymentId = getFirstId(
       this.getBulkCouponsForProduct(initialProductId)
     )
@@ -166,9 +173,9 @@ export class BulkEnrollmentForm extends React.Component<
                 name="product_id"
                 onChange={this.onChangeProductId(setFieldValue)}
               >
-                {productMap[values.product_type].map((product, i) => (
-                  <option key={i} value={product.id}>
-                    {product.title}
+                {R.toPairs(productMap[values.product_type]).map(([productId, productObject]) => (
+                  <option key={productId} value={productId}>
+                    {productObject.title}
                   </option>
                 ))}
               </Field>

--- a/static/js/components/forms/BulkEnrollmentForm_test.js
+++ b/static/js/components/forms/BulkEnrollmentForm_test.js
@@ -38,10 +38,10 @@ describe("BulkEnrollment", () => {
       products:           {
         [PRODUCT_TYPE_COURSERUN]: {
           [firstProduct.id.toString()]:  firstProduct,
-          [secondProduct.id.toString()]: secondProduct,
+          [secondProduct.id.toString()]: secondProduct
         },
         [PRODUCT_TYPE_PROGRAM]: {
-          [thirdProduct.id.toString()]: thirdProduct,
+          [thirdProduct.id.toString()]: thirdProduct
         }
       }
     }

--- a/static/js/components/forms/BulkEnrollmentForm_test.js
+++ b/static/js/components/forms/BulkEnrollmentForm_test.js
@@ -7,7 +7,6 @@ import { mount } from "enzyme"
 import { BulkEnrollmentForm } from "./BulkEnrollmentForm"
 import { makeBulkCouponPayment, makeProduct } from "../../factories/ecommerce"
 import { findFormikFieldByName } from "../../lib/test_utils"
-import { createProductMap } from "../../lib/ecommerce"
 import { PRODUCT_TYPE_PROGRAM, PRODUCT_TYPE_COURSERUN } from "../../constants"
 
 describe("BulkEnrollment", () => {
@@ -33,7 +32,19 @@ describe("BulkEnrollment", () => {
 
     firstPayment.products = [firstProduct, secondProduct]
     secondPayment.products = [firstProduct]
-    return [firstPayment, secondPayment]
+
+    return {
+      bulkCouponPayments: [firstPayment, secondPayment],
+      products:           {
+        [PRODUCT_TYPE_COURSERUN]: {
+          [firstProduct.id.toString()]:  firstProduct,
+          [secondProduct.id.toString()]: secondProduct,
+        },
+        [PRODUCT_TYPE_PROGRAM]: {
+          [thirdProduct.id.toString()]: thirdProduct,
+        }
+      }
+    }
   }
 
   const renderForm = (props = {}) =>
@@ -49,8 +60,9 @@ describe("BulkEnrollment", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     submitRequestStub = sandbox.stub().returns(defaultSubmitResponse)
-    bulkCouponPayments = createTestData()
-    productMap = createProductMap(bulkCouponPayments)
+    const testData = createTestData()
+    bulkCouponPayments = testData.bulkCouponPayments
+    productMap = testData.products
   })
 
   it("submits a request to send bulk enrollment emails", async () => {

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -1,5 +1,5 @@
 // @flow
-export type CourseRun = {
+export type BaseCourseRun = {
   title: string,
   start_date: ?string,
   end_date: ?string,
@@ -7,7 +7,10 @@ export type CourseRun = {
   enrollment_end: ?string,
   courseware_url: ?string,
   courseware_id: string,
-  id: number,
+  id: number
+}
+
+export type CourseRun = BaseCourseRun & {
   product_id: ?number
 }
 

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -166,7 +166,7 @@ export type BulkCouponPayment = {
 
 export type BulkCouponPaymentsResponse = {
   coupon_payments: Array<BulkCouponPayment>,
-  products: ProductMap
+  product_map: ProductMap
 }
 
 export type BulkCouponSendResponse = {

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Course } from "./courseTypes"
+import type { Course, BaseCourseRun, Program } from "./courseTypes"
 import {PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM} from "../constants"
 
 export type CheckoutResponse = {
@@ -136,10 +136,13 @@ export type Coupon = {
   updated_on: Date
 }
 
-export type Product = {
+export type SimpleProduct = {
   id: number,
-  title: string,
   product_type: string,
+}
+
+export type Product = SimpleProduct & {
+  title: string,
 }
 
 export type ProductDetail = Product & {
@@ -147,19 +150,24 @@ export type ProductDetail = Product & {
 }
 
 export type ProductMap = {
-  [PRODUCT_TYPE_COURSERUN | PRODUCT_TYPE_PROGRAM]: Array<Product>,
+  [PRODUCT_TYPE_COURSERUN | PRODUCT_TYPE_PROGRAM]: {
+    [string]: [BaseCourseRun | Program]
+  }
 }
 
 export type BulkCouponPayment = {
   id: number,
   name: string,
   version: CouponPaymentVersion,
-  products: Array<Product>,
+  products: Array<SimpleProduct>,
   created_on: Date,
   updated_on: Date
 }
 
-export type BulkCouponPaymentsResponse = Array<BulkCouponPayment>
+export type BulkCouponPaymentsResponse = {
+  coupon_payments: Array<BulkCouponPayment>,
+  products: ProductMap
+}
 
 export type BulkCouponSendResponse = {
   emails: Array<string>

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -61,20 +61,6 @@ export const formatRunTitle = (run: ?CourseRun) =>
 
 export const isPromo = equals(COUPON_TYPE_PROMO)
 
-export const createProductMap = (
-  bulkCouponPayments: Array<BulkCouponPayment>
-): ProductMap =>
-  R.compose(
-    R.mergeRight({
-      [PRODUCT_TYPE_PROGRAM]:   [],
-      [PRODUCT_TYPE_COURSERUN]: []
-    }),
-    R.groupBy(R.prop("product_type")),
-    R.uniqBy(R.prop("id")),
-    R.flatten,
-    R.pluck("products")
-  )(bulkCouponPayments)
-
 export const findRunInProduct = (
   product: ProductDetail
 ): [?CourseRun, ?Course] => {

--- a/static/js/lib/ecommerce_test.js
+++ b/static/js/lib/ecommerce_test.js
@@ -3,15 +3,8 @@ import { assert } from "chai"
 import Decimal from "decimal.js-light"
 import moment from "moment"
 
-import {
-  makeItem,
-  makeCouponSelection,
-} from "../factories/ecommerce"
-import {
-  calculatePrice,
-  formatPrice,
-  formatRunTitle,
-} from "./ecommerce"
+import { makeItem, makeCouponSelection } from "../factories/ecommerce"
+import { calculatePrice, formatPrice, formatRunTitle } from "./ecommerce"
 import { makeCourseRun } from "../factories/course"
 
 describe("ecommerce", () => {

--- a/static/js/lib/ecommerce_test.js
+++ b/static/js/lib/ecommerce_test.js
@@ -6,16 +6,12 @@ import moment from "moment"
 import {
   makeItem,
   makeCouponSelection,
-  makeBulkCouponPayment,
-  makeProduct
 } from "../factories/ecommerce"
 import {
   calculatePrice,
   formatPrice,
   formatRunTitle,
-  createProductMap
 } from "./ecommerce"
-import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../constants"
 import { makeCourseRun } from "../factories/course"
 
 describe("ecommerce", () => {
@@ -57,33 +53,6 @@ describe("ecommerce", () => {
     it("returns an empty string if null or undefined", () => {
       assert.equal(formatPrice(null), "")
       assert.equal(formatPrice(undefined), "")
-    })
-  })
-
-  describe("createProductMap", () => {
-    it("creates a map of product type to a list of matching products", () => {
-      const firstPayment = makeBulkCouponPayment(),
-        secondPayment = makeBulkCouponPayment(),
-        firstProduct = makeProduct(),
-        secondProduct = makeProduct(),
-        thirdProduct = makeProduct()
-
-      firstProduct.product_type = PRODUCT_TYPE_COURSERUN
-      secondProduct.product_type = PRODUCT_TYPE_COURSERUN
-      thirdProduct.product_type = PRODUCT_TYPE_PROGRAM
-
-      firstPayment.products = [firstProduct, secondProduct]
-      secondPayment.products = [firstProduct, thirdProduct]
-      const bulkCouponPayments = [firstPayment, secondPayment]
-
-      assert.deepEqual(createProductMap(bulkCouponPayments), {
-        [PRODUCT_TYPE_COURSERUN]: [firstProduct, secondProduct],
-        [PRODUCT_TYPE_PROGRAM]:   [thirdProduct]
-      })
-      assert.deepEqual(createProductMap([firstPayment]), {
-        [PRODUCT_TYPE_COURSERUN]: [firstProduct, secondProduct],
-        [PRODUCT_TYPE_PROGRAM]:   []
-      })
     })
   })
 

--- a/static/js/lib/queries/ecommerceAdmin.js
+++ b/static/js/lib/queries/ecommerceAdmin.js
@@ -13,7 +13,7 @@ export default {
   bulkCouponPaymentsQuery:    () => ({
     url:       "/api/bulk_coupons/",
     transform: (json: BulkCouponPaymentsResponse) => ({
-      bulkCouponProducts: json.products,
+      bulkCouponProducts: json.product_map,
       bulkCouponPayments: json.coupon_payments
     }),
     update: {

--- a/static/js/lib/queries/ecommerceAdmin.js
+++ b/static/js/lib/queries/ecommerceAdmin.js
@@ -4,7 +4,6 @@ import { pathOr } from "ramda"
 import { nextState } from "./util"
 import { getCookie } from "../api"
 import { objectToFormData } from "../util"
-import { createProductMap } from "../ecommerce"
 
 import type { BulkCouponPaymentsResponse } from "../../flow/ecommerceTypes"
 
@@ -14,8 +13,8 @@ export default {
   bulkCouponPaymentsQuery:    () => ({
     url:       "/api/bulk_coupons/",
     transform: (json: BulkCouponPaymentsResponse) => ({
-      bulkCouponProducts: createProductMap(json),
-      bulkCouponPayments: json
+      bulkCouponProducts: json.products,
+      bulkCouponPayments: json.coupon_payments
     }),
     update: {
       bulkCouponProducts: nextState,

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -180,6 +180,11 @@ export const newSetWithout = (set: Set<*>, valueToDelete: any): Set<*> => {
   return newSet
 }
 
+export const parseIntOrUndefined = (value: any): ?number => {
+  const parsed = parseInt(value)
+  return isNaN(parsed) ? undefined : parsed
+}
+
 /**
  * Returns a Promise that executes a function after a given number of milliseconds then resolves
  */


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1071 

#### What's this PR do?
Fixes performance issues with the bulk coupon assignment page. There were deeply-nested queries N+1 in the serializers being used to return 100%-off coupons and the products they apply to. This PR "flattens" those queries

#### How should this be manually tested?
Make sure the bulk enrollment form still works. The real test for performance can happen when this makes it to RC
