### PR TITLE
Update program serializer

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -45,7 +45,7 @@ class CourseFactory(DjangoModelFactory):
     """Factory for Courses"""
 
     program = factory.SubFactory(ProgramFactory)
-    position_in_program = factory.Sequence(lambda n: n)
+    position_in_program = None  # will get populated in save()
     title = fuzzy.FuzzyText(prefix="Course ")
     readable_id = factory.Sequence("course-{0}".format)
     live = factory.Faker("boolean")

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -210,7 +210,12 @@ class ProgramSerializer(serializers.ModelSerializer):
         return instance.page.description if instance.page else None
 
     def get_start_date(self, instance):
-        """Start date"""
+        """
+        start_date is the starting date for the earliest live course run for all courses in a program
+
+        Returns:
+            datetime: The starting date
+        """
         return (
             models.CourseRun.objects.filter(course__program=instance, live=True)
             .order_by("start_date")
@@ -219,7 +224,12 @@ class ProgramSerializer(serializers.ModelSerializer):
         )
 
     def get_end_date(self, instance):
-        """End date"""
+        """
+        end_date is the end date for the latest live course run for all courses in a program.
+
+        Returns:
+            datetime: The ending date
+        """
         return (
             models.CourseRun.objects.filter(course__program=instance, live=True)
             .order_by("end_date")
@@ -228,7 +238,9 @@ class ProgramSerializer(serializers.ModelSerializer):
         )
 
     def get_enrollment_start(self, instance):
-        """Enrollment start"""
+        """
+        enrollment_start is first date where enrollment starts for any live course run
+        """
         return (
             models.CourseRun.objects.filter(course__program=instance, live=True)
             .order_by("enrollment_start")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1129 

#### What's this PR do?
Adds `start_date`, `end_date`, `enrollment_start`, `url`, and updates `thumbnail_url` to use absolute urls.

#### How should this be manually tested?
Go to `/api/programs/` and verify that the data looks accurate

