### PR TITLE
Allow anonymous access to course list and detail API

### DIFF
--- a/courses/views.py
+++ b/courses/views.py
@@ -32,6 +32,8 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
 class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     """API view set for Courses"""
 
+    permission_classes = []
+
     serializer_class = CourseSerializer
     queryset = Course.objects.all()
 

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -102,8 +102,11 @@ def test_delete_program(user_drf_client, programs):
     assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_get_courses(user_drf_client, courses, mock_context):
+@pytest.mark.parametrize("is_anonymous", [True, False])
+def test_get_courses(user_drf_client, courses, mock_context, is_anonymous):
     """Test the view that handles requests for all Courses"""
+    if is_anonymous:
+        user_drf_client.logout()
     resp = user_drf_client.get(reverse("courses_api-list"))
     courses_data = resp.json()
     assert len(courses_data) == len(courses)
@@ -113,8 +116,11 @@ def test_get_courses(user_drf_client, courses, mock_context):
         )
 
 
-def test_get_course(user_drf_client, courses, mock_context):
+@pytest.mark.parametrize("is_anonymous", [True, False])
+def test_get_course(user_drf_client, courses, mock_context, is_anonymous):
     """Test the view that handles a request for single Course"""
+    if is_anonymous:
+        user_drf_client.logout()
     course = courses[0]
     resp = user_drf_client.get(reverse("courses_api-detail", kwargs={"pk": course.id}))
     course_data = resp.json()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1151 

#### What's this PR do?
Allow anonymous access to the courses API so we can access this information from open discussions

Regarding the question about leaking data, this data is already exposed in `/api/programs/` if the course is part of a program. I don't think there is extra risk for courses which aren't part of programs.

#### How should this be manually tested?
Log out (or use incognito mode) and go to `/api/courses/`. Verify that the data exists and looks correct.
