### PR TITLE
Changed catalog logic to show courses with past start dates but future enrollment end dates

### DIFF
--- a/cms/utils.py
+++ b/cms/utils.py
@@ -1,21 +1,45 @@
 """utils for cms"""
+import itertools
+import datetime
+import pytz
 from wagtail.core.models import Site, Page
 
 
-def get_sort_keys(page):
-    """Key function for returning keys for sorting."""
-
-    return page.product.next_run_date, page.is_course_page, page.title
-
-
-def sort_and_filter_pages(pages):
+def filter_and_sort_catalog_pages(program_pages, course_pages):
     """
-    Get list of pages and return sorted and filtered list. It will sort page
-    based on start_date, type and title.
-    """
+    Filters program and course pages to only include those that should be visible in the catalog, then returns a tuple
+    of sorted lists of pages
 
-    return sorted(
-        [page for page in pages if page.product.next_run_date], key=get_sort_keys
+    Args:
+        program_pages (iterable of ProgramPage): ProgramPages to filter and sort
+        course_pages (iterable of CoursePage): CoursePages to filter and sort
+
+    Returns:
+        tuple of (list of Pages): A tuple containing a list of combined ProgramPages and CoursePages, a list of
+            ProgramPages, and a list of CoursePages, all sorted by the next course run date and title
+    """
+    valid_program_pages = [
+        page for page in program_pages if page.product.is_catalog_visible
+    ]
+    valid_course_pages = [
+        page for page in course_pages if page.product.is_catalog_visible
+    ]
+
+    page_run_dates = {
+        page: page.product.next_run_date
+        or datetime.datetime(year=datetime.MINYEAR, month=1, day=1, tzinfo=pytz.UTC)
+        for page in itertools.chain(valid_program_pages, valid_course_pages)
+    }
+    return (
+        sorted(
+            valid_program_pages + valid_course_pages,
+            # ProgramPages with the same next run date as a CoursePage should be sorted first
+            key=lambda page: (page_run_dates[page], page.is_course_page, page.title),
+        ),
+        sorted(
+            valid_program_pages, key=lambda page: (page_run_dates[page], page.title)
+        ),
+        sorted(valid_course_pages, key=lambda page: (page_run_dates[page], page.title)),
     )
 
 

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -90,6 +90,9 @@ class CourseRunFactory(DjangoModelFactory):
         past_start = factory.Trait(
             start_date=factory.Faker("past_datetime", tzinfo=pytz.utc)
         )
+        past_enrollment_end = factory.Trait(
+            enrollment_end=factory.Faker("past_datetime", tzinfo=pytz.utc)
+        )
 
 
 class CourseRunCertificateFactory(DjangoModelFactory):

--- a/courses/models.py
+++ b/courses/models.py
@@ -166,6 +166,12 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         )
 
     @property
+    def is_catalog_visible(self):
+        """Returns True if this program should be shown on in the catalog"""
+        # NOTE: This is implemented with courses.all() to allow for prefetch_related optimization.
+        return any(course.is_catalog_visible for course in self.courses.all())
+
+    @property
     def current_price(self):
         """Gets the price if it exists"""
         product = self.products.first()
@@ -236,6 +242,21 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
                 and course_run.start_date > now
             ),
             default=None,
+        )
+
+    @property
+    def is_catalog_visible(self):
+        """Returns True if this course should be shown on in the catalog"""
+        now = now_in_utc()
+        # NOTE: This is implemented with courseruns.all() to allow for prefetch_related optimization.
+        return any(
+            course_run
+            for course_run in self.courseruns.all()
+            if course_run.live
+            and (
+                (course_run.start_date and course_run.start_date > now)
+                or (course_run.enrollment_end and course_run.enrollment_end > now)
+            )
         )
 
     @property

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -68,6 +68,29 @@ def test_program_next_run_date():
     assert program.next_run_date == future_dates[0]
 
 
+def test_program_is_catalog_visible():
+    """
+    is_catalog_visible should return True if a program has any course run that has a start date or enrollment end
+    date in the future
+    """
+    program = ProgramFactory.create()
+    runs = CourseRunFactory.create_batch(
+        2, course__program=program, past_start=True, past_enrollment_end=True
+    )
+    assert program.is_catalog_visible is False
+
+    now = now_in_utc()
+    run = runs[0]
+    run.start_date = now + timedelta(hours=1)
+    run.save()
+    assert program.is_catalog_visible is True
+
+    run.start_date = now - timedelta(hours=1)
+    run.enrollment_end = now + timedelta(hours=1)
+    run.save()
+    assert program.is_catalog_visible is True
+
+
 def test_program_first_course_unexpired_runs():
     """
     first_course_unexpired_runs should return the unexpired course runs of the earliest course
@@ -361,6 +384,29 @@ def test_course_next_run_date():
         2, course=course, start_date=factory.Iterator(future_dates), live=True
     )
     assert course.next_run_date == future_dates[0]
+
+
+def test_course_is_catalog_visible():
+    """
+    is_catalog_visible should return True if a course has any course run that has a start date or enrollment end
+    date in the future
+    """
+    course = CourseFactory.create()
+    runs = CourseRunFactory.create_batch(
+        2, course=course, past_start=True, past_enrollment_end=True
+    )
+    assert course.is_catalog_visible is False
+
+    now = now_in_utc()
+    run = runs[0]
+    run.start_date = now + timedelta(hours=1)
+    run.save()
+    assert course.is_catalog_visible is True
+
+    run.start_date = now - timedelta(hours=1)
+    run.enrollment_end = now + timedelta(hours=1)
+    run.save()
+    assert course.is_catalog_visible is True
 
 
 def test_course_page():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1168 

#### What's this PR do?
Changes catalog logic so that if a course/program only has runs with a past start date, but has at least one run with a future enrollment end date, it still shows up in the program

#### How should this be manually tested?
For some program/course:
1. Set all associated course runs to have a past `start_date` and `enrollment_end`
1. Confirm that the program/course does not show up in the catalog
1. Choose one of those course runs, and set the `enrollment_end` to a future date
1. Confirm that the program/course now shows up in the catalog

#### Any background context you want to provide?
There are some inefficiencies going on with the way we query for program/course pages, filter them, and sort them. Issue: https://github.com/mitodl/mitxpro/issues/1170
