### PR TITLE
Add instructors to programs API

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -304,6 +304,20 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             )
         )
 
+    @property
+    def instructors(self):
+        """Return a list of instructors from the related CMS page, or an empty list if there is no page"""
+        if self.page is not None:
+            faculty_page = self.page.faculty
+        else:
+            return []
+
+        return (
+            [{"name": member.value["name"]} for member in faculty_page.members]
+            if faculty_page is not None
+            else []
+        )
+
     def available_runs(self, user):
         """
         Get all enrollable runs for a Course that a user has not already enrolled in.
@@ -439,16 +453,7 @@ class CourseRun(TimestampedModel):
     @property
     def instructors(self):
         """List instructors for a course run if they are specified in a related CMS page"""
-        if self.course.page is not None:
-            faculty_page = self.course.page.faculty
-        else:
-            return []
-
-        return (
-            [{"name": member.value["name"]} for member in faculty_page.members]
-            if faculty_page is not None
-            else []
-        )
+        return self.course.instructors
 
     def __str__(self):
         return self.title

--- a/courses/models.py
+++ b/courses/models.py
@@ -203,6 +203,20 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         """ Gets the readable_id"""
         return self.readable_id
 
+    @property
+    def instructors(self):
+        """Gets a list of instructors from the related program page, or an empty list if none"""
+        if self.page is not None:
+            faculty_page = self.page.faculty
+        else:
+            return []
+
+        return (
+            [{"name": member.value["name"]} for member in faculty_page.members]
+            if faculty_page is not None
+            else []
+        )
+
     def __str__(self):
         return self.title
 
@@ -421,6 +435,20 @@ class CourseRun(TimestampedModel):
     def text_id(self):
         """ Gets the courseware_id"""
         return self.courseware_id
+
+    @property
+    def instructors(self):
+        """List instructors for a course run if they are specified in a related CMS page"""
+        if self.course.page is not None:
+            faculty_page = self.course.page.faculty
+        else:
+            return []
+
+        return (
+            [{"name": member.value["name"]} for member in faculty_page.members]
+            if faculty_page is not None
+            else []
+        )
 
     def __str__(self):
         return self.title

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -5,7 +5,11 @@ import factory
 import pytest
 from django.core.exceptions import ValidationError
 
-from cms.factories import CoursePageFactory, ProgramPageFactory
+from cms.factories import (
+    CoursePageFactory,
+    ProgramPageFactory,
+    FacultyMembersPageFactory,
+)
 from courses.factories import (
     CompanyFactory,
     CourseFactory,
@@ -605,3 +609,23 @@ def test_enrollment_is_ended():
 
     assert program_enrollment.is_ended
     assert course_enrollment.is_ended
+
+
+@pytest.mark.parametrize("has_page", [True, False])
+def test_instructors(has_page):
+    """CourseRun.instructors should list instructors from the related CMS page, or provide an empty list"""
+    faculty_names = ["Teacher One", "Teacher Two"]
+    course_run = CourseRunFactory.create()
+    if has_page:
+        course_page = CoursePageFactory.create(course=course_run.course)
+        FacultyMembersPageFactory.create(
+            parent=course_page,
+            **{
+                f"members__{idx}__member__name": name
+                for idx, name in enumerate(faculty_names)
+            },
+        )
+
+    assert course_run.instructors == (
+        [{"name": name} for name in faculty_names] if has_page else []
+    )

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -82,16 +82,7 @@ class CourseRunSerializer(BaseCourseRunSerializer):
 
     def get_instructors(self, instance):
         """Get the list of instructors"""
-        if getattr(instance.course, "coursepage", None) is not None:
-            faculty_page = instance.course.coursepage.faculty
-        else:
-            return []
-
-        return (
-            [{"name": member.value["name"]} for member in faculty_page.members]
-            if faculty_page is not None
-            else []
-        )
+        return instance.instructors
 
     class Meta:
         model = models.CourseRun
@@ -203,6 +194,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     end_date = serializers.SerializerMethodField()
     enrollment_start = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
+    instructors = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         """Serializer for courses"""
@@ -262,6 +254,10 @@ class ProgramSerializer(serializers.ModelSerializer):
         page = instance.page
         return page.get_full_url() if page else None
 
+    def get_instructors(self, instance):
+        """List all instructors who are a part of any course run within a program"""
+        return instance.instructors
+
     class Meta:
         model = models.Program
         fields = [
@@ -276,6 +272,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "end_date",
             "enrollment_start",
             "url",
+            "instructors",
         ]
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -66,8 +66,15 @@ def test_serialize_program(mock_context, has_product):
         + [CourseRunFactory.create(course=course1) for _ in range(2)]
         + [CourseRunFactory.create(course=course2) for _ in range(2)]
     )
-
+    faculty_names = ["Teacher 1", "Teacher 2"]
     page = ProgramPageFactory.create(program=program)
+    FacultyMembersPageFactory.create(
+        parent=page,
+        **{
+            f"members__{idx}__member__name": name
+            for idx, name in enumerate(faculty_names)
+        },
+    )
     if has_product:
         ProductVersionFactory.create(product__content_object=program)
     data = ProgramSerializer(instance=program, context=mock_context).data
@@ -95,6 +102,7 @@ def test_serialize_program(mock_context, has_product):
                 0
             ].enrollment_start.strftime(datetime_format),
             "url": f"http://localhost{page.get_url()}",
+            "instructors": [{"name": name} for name in faculty_names],
         },
     )
 
@@ -195,7 +203,7 @@ def test_serialize_course_run(has_product):
             "enrollment_end": drf_datetime(course_run.enrollment_end),
             "expiration_date": drf_datetime(course_run.expiration_date),
             "current_price": course_run.current_price,
-            "instructors": [{"name": name} for name in faculty_names],
+            "instructors": course_run.instructors,
             "id": course_run.id,
             "product_id": product_id,
         },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1165 

#### What's this PR do?
Moves the instructor logic to a property on the `CourseRun`, and adds additional logic to the programs API to return the instructors for the program page if there is one

#### How should this be manually tested?
Go to `/api/programs/` and check that the instructor list for the program contains all the instructors for each course run. There should not be any duplicates, each instructor should only appear once.
