### PR TITLE
Fixed Product admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -49,7 +49,8 @@ class ProductContentTypeListFilter(admin.SimpleListFilter):
         Returns the filtered queryset based on the value provided in the query string and retrievable via
         `self.value()`.
         """
-        return queryset.filter(content_type__model=self.value())
+        qset_filter = {} if not self.value() else {"content_type__model": self.value()}
+        return queryset.filter(**qset_filter)
 
 
 class LineAdmin(admin.ModelAdmin):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket - fixes minor django admin bug introduced in #1166

#### What's this PR do?
Fixes `Product` admin to show all Products when there is no content type filter. There was a bug that showed nothing in this admin unless a content type filter was selected

#### How should this be manually tested?
Go to Product admin page (/admin/ecommerce/product/), confirm that you see all products
