### PR TITLE
asadiqbal08/mitxpro-1162 Display account created date and last login date on user admin page

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -49,7 +49,7 @@ class UserAdmin(ContribUserAdmin, HijackUserAdminMixin):
     """Admin views for user"""
 
     fieldsets = (
-        (None, {"fields": ("username", "password")}),
+        (None, {"fields": ("username", "password", "last_login", "created_on")}),
         (_("Personal Info"), {"fields": ("name", "email")}),
         (
             _("Permissions"),
@@ -65,11 +65,19 @@ class UserAdmin(ContribUserAdmin, HijackUserAdminMixin):
             },
         ),
     )
-    list_display = ("username", "email", "name", "is_staff", "hijack_field")
+    list_display = (
+        "username",
+        "email",
+        "name",
+        "is_staff",
+        "hijack_field",
+        "last_login",
+        "created_on",
+    )
     list_filter = ("is_staff", "is_superuser", "is_active", "groups")
     search_fields = ("username", "name", "email")
     ordering = ("email",)
-    readonly_fields = ("username",)
+    readonly_fields = ("username", "last_login", "created_on")
     inlines = [UserLegalAddressInline, UserProfileInline]
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#1162 

#### What's this PR do?
Display account created date and last login date on user admin page

#### How should this be manually tested?
- Visit `/admin/users/user/`
- `Last Login` and `Created On` date should be there in both detail & user edit mode.