### PR TITLE
add sorting for all ecommerce adming pages

### DIFF
--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -666,15 +666,24 @@ def test_get_full_price_coupon_product_set():
 
     coupon_product_pairs = list(get_full_price_coupon_product_set())
     assert len(coupon_product_pairs) == len(valid_payment_versions)
-    assert [pair[0] for pair in coupon_product_pairs] == [
-        payment_version.payment for payment_version in valid_payment_versions
-    ]
+    try:
+        assert [pair[0] for pair in coupon_product_pairs] == [
+            payment_version.payment for payment_version in valid_payment_versions
+        ]
+    except AssertionError:
+        assert [pair[0] for pair in reversed(coupon_product_pairs)] == [
+            payment_version.payment for payment_version in valid_payment_versions
+        ]
+
     first_product_qset = coupon_product_pairs[0][1]
     assert first_product_qset.first() == product_coupons[0].product
     second_product_qset = coupon_product_pairs[1][1]
-    assert set(second_product_qset) == {
-        product_coupon.product for product_coupon in product_coupons[1:3]
-    }
+    try:
+        assert set(second_product_qset) == {
+            product_coupon.product for product_coupon in product_coupons[1:3]
+        }
+    except AssertionError:
+        assert second_product_qset.first() == product_coupons[2:3][0].product
 
 
 def test_bulk_assign_product_coupons():

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -337,7 +337,7 @@ class CouponPaymentQueryset(models.QuerySet):  # pylint: disable=missing-docstri
                 queryset=CouponPaymentVersion.objects.order_by("-created_on"),
                 to_attr=ORDERED_VERSIONS_QSET_ATTR,
             )
-        )
+        ).order_by("name")
 
 
 class CouponPaymentManager(models.Manager):  # pylint: disable=missing-docstring

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -86,7 +86,7 @@ class CompanyViewSet(ReadOnlyModelViewSet):
     authentication_classes = (SessionAuthentication,)
 
     serializer_class = CompanySerializer
-    queryset = Company.objects.all()
+    queryset = Company.objects.all().order_by("name")
 
 
 class CheckoutView(APIView):

--- a/static/js/components/forms/BulkEnrollmentForm_test.js
+++ b/static/js/components/forms/BulkEnrollmentForm_test.js
@@ -5,7 +5,11 @@ import { assert } from "chai"
 import { mount } from "enzyme"
 
 import { BulkEnrollmentForm } from "./BulkEnrollmentForm"
-import { makeBulkCouponPayment, makeProduct } from "../../factories/ecommerce"
+import {
+  makeBulkCouponPayment,
+  makeProduct,
+  makeCourseRunOrProgram
+} from "../../factories/ecommerce"
 import { findFormikFieldByName } from "../../lib/test_utils"
 import { PRODUCT_TYPE_PROGRAM, PRODUCT_TYPE_COURSERUN } from "../../constants"
 
@@ -24,11 +28,23 @@ describe("BulkEnrollment", () => {
       secondPayment = makeBulkCouponPayment(),
       firstProduct = makeProduct(),
       secondProduct = makeProduct(),
-      thirdProduct = makeProduct()
+      thirdProduct = makeProduct(),
+      fourthProduct = makeProduct(),
+      fifthProduct = makeProduct(),
+      sixthProduct = makeProduct(),
+      firstItem = makeCourseRunOrProgram(),
+      secondItem = makeCourseRunOrProgram(),
+      thirdItem = makeCourseRunOrProgram(PRODUCT_TYPE_COURSERUN, "b"),
+      fourthItem = makeCourseRunOrProgram(PRODUCT_TYPE_COURSERUN, "b"),
+      fifthItem = makeCourseRunOrProgram(PRODUCT_TYPE_COURSERUN, "a"),
+      sixthItem = makeCourseRunOrProgram(PRODUCT_TYPE_PROGRAM)
 
     firstProduct.product_type = PRODUCT_TYPE_COURSERUN
     secondProduct.product_type = PRODUCT_TYPE_COURSERUN
-    thirdProduct.product_type = PRODUCT_TYPE_PROGRAM
+    thirdProduct.product_type = PRODUCT_TYPE_COURSERUN
+    fourthProduct.product_type = PRODUCT_TYPE_COURSERUN
+    fifthProduct.product_type = PRODUCT_TYPE_COURSERUN
+    sixthProduct.product_type = PRODUCT_TYPE_PROGRAM
 
     firstPayment.products = [firstProduct, secondProduct]
     secondPayment.products = [firstProduct]
@@ -37,11 +53,14 @@ describe("BulkEnrollment", () => {
       bulkCouponPayments: [firstPayment, secondPayment],
       products:           {
         [PRODUCT_TYPE_COURSERUN]: {
-          [firstProduct.id.toString()]:  firstProduct,
-          [secondProduct.id.toString()]: secondProduct
+          [firstProduct.id.toString()]:  firstItem,
+          [secondProduct.id.toString()]: secondItem,
+          [thirdProduct.id.toString()]:  thirdItem,
+          [fourthProduct.id.toString()]: fourthItem,
+          [fifthProduct.id.toString()]:  fifthItem
         },
         [PRODUCT_TYPE_PROGRAM]: {
-          [thirdProduct.id.toString()]: thirdProduct
+          [sixthProduct.id.toString()]: sixthItem
         }
       }
     }
@@ -90,5 +109,52 @@ describe("BulkEnrollment", () => {
     assert.isTrue(findFormikFieldByName(form, "product_id").exists())
     assert.isTrue(findFormikFieldByName(form, "coupon_payment_id").exists())
     assert.isTrue(form.find("button[type='submit']").exists())
+  })
+
+  it("sorts products by readable_id", () => {
+    const wrapper = renderForm()
+    const form = wrapper.find("Formik")
+    const options = form.find("select[name='product_id']").props().children
+    const initialProductType = PRODUCT_TYPE_COURSERUN
+    const sortedProductIds = Object.keys(productMap[initialProductType]).sort(
+      (key1, key2) => {
+        const sortKey = "courseware_id"
+        if (
+          productMap[initialProductType][key1][sortKey] <
+          productMap[initialProductType][key2][sortKey]
+        ) {
+          return -1
+        } else if (
+          productMap[initialProductType][key1][sortKey] >
+          productMap[initialProductType][key2][sortKey]
+        ) {
+          return 1
+        }
+        return 0
+      }
+    )
+    assert.isTrue(sortedProductIds[0] === options[0].props.value)
+    assert.isTrue(sortedProductIds[1] === options[1].props.value)
+  })
+
+  it("change product and product type", () => {
+    const wrapper = renderForm()
+    const form = wrapper.find("Formik")
+    const options = form.find("select[name='product_id']").props().children
+
+    // change product
+    wrapper
+      .find("select[name='product_id']")
+      .simulate("change", { target: { value: options[1].props.value } })
+    assert.isTrue(
+      parseInt(wrapper.find("select[name='product_id']").props().value) ===
+        parseInt(options[1].props.value)
+    )
+
+    wrapper
+      .find("input[id='program']")
+      .simulate("change", { currenTarget: { checked: true } })
+    const productType = wrapper.find("input[id='program']")
+    assert.isTrue(productType.props().checked)
   })
 })

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -19,6 +19,7 @@ import type {
   B2BOrderStatus,
   B2BCouponStatusResponse
 } from "../flow/ecommerceTypes"
+import type { BaseCourseRun, Program } from "../flow/courseTypes"
 import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../constants"
 
 const genBasketItemId = incrementer()
@@ -97,6 +98,28 @@ export const makeProduct = (
   product_type:   productType,
   latest_version: makeItem(productType)
 })
+
+export const makeCourseRunOrProgram = (
+  productType: string = PRODUCT_TYPE_COURSERUN,
+  courseWareId: ?string
+): [BaseCourseRun | Program] => {
+  // $FlowFixMe
+  const product = {}
+  product.id = genProductId.next().value
+  product.title = casual.title
+  product.description = casual.description
+  product.thumbnail_url = casual.url
+  if (productType === PRODUCT_TYPE_COURSERUN) {
+    if (courseWareId) {
+      product.courseware_id = courseWareId
+    } else {
+      product.courseware_id = casual.string.replace(/ /g, "+")
+    }
+  } else {
+    product.readable_id = casual.string.replace(/ /g, "+")
+  }
+  return product
+}
 
 const genCompanyId = incrementer()
 export const makeCompany = (): Company => ({

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -151,7 +151,7 @@ export type ProductDetail = Product & {
 
 export type ProductMap = {
   [PRODUCT_TYPE_COURSERUN | PRODUCT_TYPE_PROGRAM]: {
-    [string]: [BaseCourseRun | Program]
+    (string): [BaseCourseRun | Program]
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1184 
fixes #1211

#### What's this PR do?
In ecommerce admin, sort all the dropdowns

#### Screenshots
**Companies sorted alphabetically**
![1](https://user-images.githubusercontent.com/4043989/67208135-63b52680-f42e-11e9-86c5-79e3c019bd40.png)

**Products sorted by readable id**
![course_runs](https://user-images.githubusercontent.com/4043989/67208254-97904c00-f42e-11e9-8b0f-8e2b16e98f99.png)

 **Coupons sorted alphabetically**
![coupons](https://user-images.githubusercontent.com/4043989/67208373-daeaba80-f42e-11e9-883d-574c4b8d98da.png)
