### PR TITLE
Add topics to programs API

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -204,6 +204,7 @@ class ProgramSerializer(serializers.ModelSerializer):
     enrollment_start = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     instructors = serializers.SerializerMethodField()
+    topics = serializers.SerializerMethodField()
 
     def get_courses(self, instance):
         """Serializer for courses"""
@@ -267,6 +268,15 @@ class ProgramSerializer(serializers.ModelSerializer):
         """List all instructors who are a part of any course run within a program"""
         return instance.instructors
 
+    def get_topics(self, instance):
+        """List all topics in all courses in the program"""
+        topics = (
+            models.CourseTopic.objects.filter(course__program=instance)
+            .values("name")
+            .distinct("name")
+        )
+        return list(topics)
+
     class Meta:
         model = models.Program
         fields = [
@@ -282,6 +292,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "enrollment_start",
             "url",
             "instructors",
+            "topics",
         ]
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -78,6 +78,10 @@ def test_serialize_program(mock_context, has_product):
     )
     if has_product:
         ProductVersionFactory.create(product__content_object=program)
+    topics = [CourseTopic.objects.create(name=f"topic{num}") for num in range(3)]
+    course1.topics.set([topics[0], topics[1]])
+    course2.topics.set([topics[1], topics[2]])
+
     data = ProgramSerializer(instance=program, context=mock_context).data
 
     assert_drf_json_equal(
@@ -104,6 +108,7 @@ def test_serialize_program(mock_context, has_product):
             ].enrollment_start.strftime(datetime_format),
             "url": f"http://localhost{page.get_url()}",
             "instructors": [{"name": name} for name in faculty_names],
+            "topics": [{"name": topic.name} for topic in topics],
         },
     )
 


### PR DESCRIPTION
Blocked by #1196 
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1172 

#### What's this PR do?
Adds a union of course topics to the program API.

#### How should this be manually tested?
Go to `/api/programs/` and verify that the topics for each program match all topics in each course. 
