### PR TITLE
#1200 Course certificate generation task fix

### DIFF
--- a/courses/utils.py
+++ b/courses/utils.py
@@ -39,7 +39,7 @@ def ensure_course_run_grade(user, course_run, edx_grade, should_update=False):
             if (
                 not created
                 and not run_grade.set_by_admin
-                and not has_equal_properties(run_grade, edx_grade)
+                and not has_equal_properties(run_grade, grade_properties)
             ):
                 # Perform actual update now.
                 run_grade.grade = edx_grade.percent


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1200 

#### What's this PR do?
Fixes a bug in the `ensure_course_run_grade` method that caused automatic course certificate generation task to fail.

#### How should this be manually tested?
Set up the environment appropriately (a finished course run, course run grades in xpro, task timing set up as required) and verify that at the configured time the certificates are generated as per the grades in your xpro database. There should be no error logs generated.