### PR TITLE
#1203 Exports inquiry admin action fix

### DIFF
--- a/compliance/admin.py
+++ b/compliance/admin.py
@@ -27,9 +27,9 @@ class ExportsInquiryLogAdmin(admin.ModelAdmin):
         eligible_objects = queryset.exclude(
             computed_result__in=[RESULT_MANUALLY_APPROVED, RESULT_SUCCESS]
         )
-        eligible_objects.update(computed_result=RESULT_MANUALLY_APPROVED)
         for obj in eligible_objects:
             ensure_active_user(obj.user)
+        eligible_objects.update(computed_result=RESULT_MANUALLY_APPROVED)
 
     manually_approve_inquiry.short_description = "Manually approve selected records"
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1203 

#### What's this PR do?
Fixes #1203 

#### How should this be manually tested?
Use the admin action as designed to manually update exports inquiry log and verify that the respective user has been activated and Open edX credentials have been created.