### PR TITLE
#1205 certificate button 404 fix

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -30,6 +30,7 @@ def get_user_enrollments(user):
     program_enrollments = (
         ProgramEnrollment.objects.select_related("program__programpage")
         .prefetch_related("program__courses")
+        .select_related("user", "company")
         .filter(user=user)
         .all()
     )
@@ -41,7 +42,7 @@ def get_user_enrollments(user):
     )
     program_course_ids = set(course.id for course in program_courses)
     course_run_enrollments = (
-        CourseRunEnrollment.objects.select_related("run__course__coursepage")
+        CourseRunEnrollment.objects.select_related("run__course__coursepage", "company")
         .filter(user=user)
         .order_by("run__start_date")
         .all()

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -303,6 +303,14 @@ class CourseRunEnrollmentSerializer(serializers.ModelSerializer):
         """
         Resolve a certificate for this enrollment if it exists
         """
+        # No need to include a certificate if there is no corresponding wagtail page
+        # to support the render
+        if (
+            not enrollment.run.course.page
+            or not enrollment.run.course.page.certificate_page
+        ):
+            return None
+
         # Using IDs because we don't need the actual record and this avoids redundant queries
         user_id = enrollment.user_id
         course_run_id = enrollment.run_id
@@ -332,6 +340,11 @@ class ProgramEnrollmentSerializer(serializers.ModelSerializer):
         """
         Resolve a certificate for this enrollment if it exists
         """
+        # No need to include a certificate if there is no corresponding wagtail page
+        # to support the render
+        if not enrollment.program.page or not enrollment.program.page.certificate_page:
+            return None
+
         # Using IDs because we don't need the actual record and this avoids redundant queries
         user_id = enrollment.user_id
         program_id = enrollment.program_id


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1205 

#### What's this PR do?
Modifies the `CourseRunEnrollmentSerializer` and `ProgramEnrollmentSerializer` to not include any certificate related information in output if the corresponding wagtail page does not exist for the courseware object or if the courseware object page does not have a valid `CertificatePage` child page.

N.B.: This PR also fixes a couple of small n+1 query issues in the dashboard view.

#### How should this be manually tested?
Make sure your testing user has multiple enrollments and certificate. Go to the dashboard page and verify that "view certificate" button is visible against those courses/programs for which:
- the certificate exists
- the courseware page exists in wagtail
- the courseware page has a valid and live `CertificatePage` child page

any other enrollments should not show a "view certificate" button.