### PR TITLE
add order optional parameter in refund_enrollment command

### DIFF
--- a/courses/management/commands/refund_enrollment.py
+++ b/courses/management/commands/refund_enrollment.py
@@ -32,6 +32,9 @@ class Command(EnrollmentChangeCommand):
             type=str,
             help="The 'courseware_id' value for an enrolled CourseRun",
         )
+        parser.add_argument(
+            "--order", type=str, help="The 'order_id' value for an user's order ID."
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):

--- a/courses/management/utils.py
+++ b/courses/management/utils.py
@@ -84,6 +84,7 @@ class EnrollmentChangeCommand(BaseCommand):
         """
         program_property = command_options["program"]
         run_property = command_options["run"]
+        order_property = command_options["order"]
         force = command_options["force"]
 
         if program_property and run_property:
@@ -93,16 +94,20 @@ class EnrollmentChangeCommand(BaseCommand):
         elif not program_property and not run_property:
             raise CommandError("Either 'program' or 'run' must be provided.")
 
+        query_params = {"user": user}
+        if order_property:
+            query_params["order"] = order_property
+
         if program_property:
-            enrolled_obj = Program.objects.get(readable_id=program_property)
-            enrollment = ProgramEnrollment.all_objects.filter(
-                user=user, program=enrolled_obj
-            ).first()
+            query_params["program"] = enrolled_obj = Program.objects.get(
+                readable_id=program_property
+            )
+            enrollment = ProgramEnrollment.all_objects.filter(**query_params).first()
         else:
-            enrolled_obj = CourseRun.objects.get(courseware_id=run_property)
-            enrollment = CourseRunEnrollment.all_objects.filter(
-                user=user, run=enrolled_obj
-            ).first()
+            query_params["run"] = enrolled_obj = CourseRun.objects.get(
+                courseware_id=run_property
+            )
+            enrollment = CourseRunEnrollment.all_objects.filter(**query_params).first()
 
         if not enrollment:
             raise CommandError("Enrollment not found for: {}".format(enrolled_obj))

--- a/courses/management/utils_tests.py
+++ b/courses/management/utils_tests.py
@@ -1,0 +1,39 @@
+"""Tests for command utils"""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from courses.factories import CourseRunEnrollmentFactory, ProgramEnrollmentFactory
+from courses.management.utils import EnrollmentChangeCommand
+from users.factories import UserFactory
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("order", [True, False])
+def test_fetch_enrollment(order):
+    """Test that method return enrollment and enrolled object, include order while querying if passed"""
+    user = UserFactory()
+    run_enrollment = CourseRunEnrollmentFactory(user=user)
+    program_enrollment = ProgramEnrollmentFactory(user=user)
+
+    run_command_options = {"run": run_enrollment.run}
+    program_command_options = {"program": program_enrollment.program}
+
+    if order:
+        run_command_options["order"] = run_enrollment.order
+        program_command_options["order"] = program_enrollment.order
+    enrollment_obj, enrolled_obj = EnrollmentChangeCommand.fetch_enrollment(
+        user=user, command_options=run_command_options
+    )
+
+    assert enrolled_obj == run_enrollment.run
+    assert enrollment_obj == run_enrollment
+
+    enrollment_obj, enrolled_obj = EnrollmentChangeCommand.fetch_enrollment(
+        user=user, command_options=program_command_options
+    )
+
+    assert enrolled_obj == program_enrollment.program
+    assert enrollment_obj == program_enrollment


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #1199  

#### What's this PR do?

- Add `order` an optional parameter in refund_enrollment command.
- Added tests for utils method.

#### How should this be manually tested?

- Purchase some programs/courses via full-price coupon
- Try refunded via the refund_enrollment management command and provide 'order' parameter
- It should set the associated order to refunded if `order` passed otherwise first enrollment would be refunded.