### PR TITLE
asadiqbal08/mitxpro-1192 Show time along with date for upcoming courses.

### DIFF
--- a/static/js/lib/courses.js
+++ b/static/js/lib/courses.js
@@ -3,6 +3,7 @@ import moment from "moment"
 
 import {
   formatPrettyDate,
+  formatPrettyDateTimeAmPm,
   firstItem,
   secondItem,
   parseDateString,
@@ -28,7 +29,7 @@ export const getDateSummary = (
   const startDate = parseDateString(courseRunEnrollment.run.start_date)
   if (startDate && startDate.isAfter(now)) {
     return {
-      text:       `Starts: ${formatPrettyDate(startDate)}`,
+      text:       `Starts: ${formatPrettyDateTimeAmPm(startDate)}`,
       inProgress: false
     }
   }
@@ -45,7 +46,7 @@ export const getDateSummary = (
   if (endDate) {
     if (endDate.isAfter(now)) {
       return {
-        text:       `Ends: ${formatPrettyDate(endDate)}`,
+        text:       `Ends: ${formatPrettyDateTimeAmPm(endDate)}`,
         inProgress: true
       }
     } else {

--- a/static/js/lib/courses_test.js
+++ b/static/js/lib/courses_test.js
@@ -8,7 +8,7 @@ import {
   makeCourseRunEnrollment,
   makeProgramEnrollment
 } from "../factories/course"
-import { formatPrettyDate } from "./util"
+import { formatPrettyDate, formatPrettyDateTimeAmPm } from "./util"
 
 describe("courses API function", () => {
   describe("programDateRange", () => {
@@ -51,7 +51,7 @@ describe("courses API function", () => {
     it("returns a summary if the start date is in the future", () => {
       courseRunEnrollment.run.start_date = future.toISOString()
       assert.deepEqual(coursesApi.getDateSummary(courseRunEnrollment), {
-        text:       `Starts: ${formatPrettyDate(future)}`,
+        text:       `Starts: ${formatPrettyDateTimeAmPm(future)}`,
         inProgress: false
       })
     })
@@ -60,7 +60,7 @@ describe("courses API function", () => {
       courseRunEnrollment.run.start_date = past.toISOString()
       courseRunEnrollment.run.end_date = future.toISOString()
       assert.deepEqual(coursesApi.getDateSummary(courseRunEnrollment), {
-        text:       `Ends: ${formatPrettyDate(future)}`,
+        text:       `Ends: ${formatPrettyDateTimeAmPm(future)}`,
         inProgress: true
       })
     })

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -145,6 +145,9 @@ export const assertRaises = async (
 export const formatPrettyDate = (momentDate: Moment) =>
   momentDate.format("MMMM D, YYYY")
 
+export const formatPrettyDateTimeAmPm = (momentDate: Moment) =>
+  momentDate.format("LLL")
+
 export const firstItem = R.view(R.lensIndex(0))
 
 export const secondItem = R.view(R.lensIndex(1))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1192 

#### What's this PR do?
As a user, I'd like to know the exact time that the course starts, so I'm not checking and re-checking the dashboard over a 24 hour period. So displaying the start time along with date for upcoming courses. 

#### How should this be manually tested?
- Enroll in a course or a program. 
- Start date of product would be in future. 
- After landing to dashboard, time in `AM/PM` format should be displayed.

##### Updated Later as per suggestion:
- Verify the time along with End Date too

#### Screen Shots (Time with Start and End Date):

<img width="1060" alt="Screen Shot 2019-10-15 at 4 18 34 PM" src="https://user-images.githubusercontent.com/7334669/66827159-9b702a00-ef67-11e9-9346-b62521b94701.png">
