### PR TITLE
MIT xPRO - 1119 Watch Now button should come only in the presence of video

### DIFF
--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -38,7 +38,7 @@
           <h2>{{ page.subhead }}</h2>
         </div>
         <div class="mt-5 mb-5">
-          {% if action_title and action_url %}
+          {% if page.about_mit_xpro.video_url and action_title and action_url %}
             <a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="{{ action_url }}">{{ action_title }}</a>
           {% else %}
             {% if not user.is_anonymous %}

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -14,13 +14,14 @@ from cms.factories import (
     CertificatePageFactory,
     HomePageFactory,
 )
-from cms.models import CourseIndexPage, HomePage, ProgramIndexPage
+from cms.models import CourseIndexPage, HomePage, ProgramIndexPage, TextVideoSection
 from courses.factories import (
     CourseFactory,
     CourseRunFactory,
     CourseRunCertificateFactory,
     ProgramCertificateFactory,
 )
+
 from mitxpro.utils import now_in_utc
 
 pytestmark = pytest.mark.django_db
@@ -36,13 +37,30 @@ def test_home_page_view(client):
     resp = client.get(page.get_url())
     content = resp.content.decode("utf-8")
 
+    # without watch now button
+    assert (
+        f'<a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="#">Watch Now</a>'
+        not in content
+    )
+    assert "dropdown-menu" in content
+
+    # add video section
+    about_page = TextVideoSection(
+        content="<p>content</p>", video_url="http://test.com/abcd"
+    )
+    page.add_child(instance=about_page)
+    resp = client.get(page.get_url())
+    content = resp.content.decode("utf-8")
+
+    # with watch now button
     assert (
         f'<a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="#">Watch Now</a>'
         in content
     )
+    assert "dropdown-menu" not in content
+
     assert reverse("user-dashboard") not in content
     assert reverse("checkout-page") not in content
-    assert "dropdown-menu" not in content
 
 
 def test_courses_index_view(client):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1119 

#### What's this PR do?
Hide **Watch Now** button if there is no video to play

#### How should this be manually tested?
Remove Video Section from Home page or remove Video URL from video section and check whether **Watch Now** button is available or not.
