### PR TITLE
#1173 Purchase event tracking through GTM

### DIFF
--- a/app.json
+++ b/app.json
@@ -127,6 +127,10 @@
       "description": "Google analytics tracking ID",
       "required": false
     },
+    "GTM_TRACKING_ID": {
+      "description": "Google Tag Manager container ID",
+      "required": false
+    },
     "HEROKU_APP_NAME": {
       "description": "The name of the review app",
       "required": false

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -130,8 +130,20 @@ class CheckoutView(APIView):
             complete_order(order)
             order.save_and_log(request.user)
 
+            product = line.product_version.product
+
+            # $0 orders do not go to CyberSource so we need to build a payload
+            # for GTM in order to track these purchases as well. Actual tracking
+            # call is sent from the frontend.
+            payload = {
+                "transaction_id": "T-{}".format(order.id),
+                "transaction_total": 0.00,
+                "product_type": product.type_string,
+                "courseware_id": readable_id,
+                "reference_number": "REF-{}".format(order.id),
+            }
+
             # This redirects the user to our order success page
-            payload = {}
             url = make_receipt_url(base_url=base_url, readable_id=readable_id)
             method = "GET"
         else:

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -191,7 +191,13 @@ def test_zero_price_checkout(
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {
-        "payload": {},
+        "payload": {
+            "transaction_id": "T-{}".format(order.id),
+            "transaction_total": 0.0,
+            "product_type": line.product_version.product.type_string,
+            "courseware_id": readable_id,
+            "reference_number": "REF-{}".format(order.id),
+        },
         "url": f"http://testserver/dashboard/?status=purchased&purchased={quote_plus(readable_id)}",
         "method": "GET",
     }

--- a/mitxpro/context_processors.py
+++ b/mitxpro/context_processors.py
@@ -11,7 +11,12 @@ def api_keys(request):
     Pass a `APIKEYS` dictionary into the template context, which holds
     IDs and secret keys for the various APIs used in this project.
     """
-    return {"APIKEYS": {"GA_TRACKING_ID": settings.GA_TRACKING_ID}}
+    return {
+        "APIKEYS": {
+            "GA_TRACKING_ID": settings.GA_TRACKING_ID,
+            "GTM_TRACKING_ID": settings.GTM_TRACKING_ID,
+        }
+    }
 
 
 def configuration_context(request):

--- a/mitxpro/serializers.py
+++ b/mitxpro/serializers.py
@@ -9,6 +9,7 @@ class AppContextSerializer(serializers.Serializer):
     """Serializer for the application context"""
 
     public_path = serializers.SerializerMethodField()
+    gtm_tracking_id = serializers.SerializerMethodField()
     ga_tracking_id = serializers.SerializerMethodField()
     environment = serializers.SerializerMethodField()
     release_version = serializers.SerializerMethodField()
@@ -21,6 +22,10 @@ class AppContextSerializer(serializers.Serializer):
     def get_release_version(self, request):
         """Returns a dictionary of features"""
         return settings.VERSION
+
+    def get_gtm_tracking_id(self, request):
+        """Returns the GTM container ID"""
+        return settings.GTM_TRACKING_ID
 
     def get_ga_tracking_id(self, request):
         """Returns a dictionary of features"""

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -562,6 +562,9 @@ STATUS_TOKEN = get_string(
 )
 HEALTH_CHECK = ["CELERY", "REDIS", "POSTGRES"]
 
+GTM_TRACKING_ID = get_string(
+    "GTM_TRACKING_ID", "", description="Google Tag Manager container ID"
+)
 GA_TRACKING_ID = get_string(
     "GA_TRACKING_ID", "", description="Google analytics tracking ID"
 )

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -18,6 +18,11 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css" rel="stylesheet"/>
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
+    {% if CSOURCE_PAYLOAD %}
+    var CSOURCE_PAYLOAD = {{ CSOURCE_PAYLOAD|safe }};
+    {% else %}
+    var CSOURCE_PAYLOAD = null;
+    {% endif %}
     </script>
     {% render_bundle 'style' %}
     <title>{% block title %}{% endblock %}</title>

--- a/mitxpro/templates/partials/gtm_body.html
+++ b/mitxpro/templates/partials/gtm_body.html
@@ -1,6 +1,6 @@
-{% if APIKEYS.GA_TRACKING_ID %}
+{% if APIKEYS.GTM_TRACKING_ID %}
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ APIKEYS.GA_TRACKING_ID }}"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ APIKEYS.GTM_TRACKING_ID }}"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 {% endif %}

--- a/mitxpro/templates/partials/gtm_head.html
+++ b/mitxpro/templates/partials/gtm_head.html
@@ -1,7 +1,7 @@
-{% if APIKEYS.GA_TRACKING_ID %}
+{% if APIKEYS.GTM_TRACKING_ID %}
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{ APIKEYS.GA_TRACKING_ID }}');</script>
+  })(window,document,'script','dataLayer','{{ APIKEYS.GTM_TRACKING_ID }}');</script>
 {% endif %}

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -1,5 +1,7 @@
 // @flow
 /* global SETTINGS: false */
+declare var dataLayer: Object[]
+
 import React from "react"
 import DocumentTitle from "react-document-title"
 import { CHECKOUT_PAGE_TITLE } from "../../constants"
@@ -200,7 +202,24 @@ export class CheckoutPage extends React.Component<Props, State> {
 
       const { method, url, payload } = checkoutResponse.body
       if (method === "GET") {
-        window.location = url
+        if (SETTINGS.gtmTrackingID) {
+          dataLayer.push({
+            event:            "purchase",
+            transactionId:    payload.transaction_id,
+            transactionTotal: payload.transaction_total,
+            productType:      payload.product_type,
+            coursewareId:     payload.courseware_id,
+            referenceNumber:  payload.reference_number,
+            eventTimeout:     2000,
+            eventCallback:    () => {
+              setTimeout(() => {
+                window.location = url
+              }, 1500)
+            }
+          })
+        } else {
+          window.location = url
+        }
       } else {
         const form = createCyberSourceForm(url, payload)
         const body: HTMLElement = (document.querySelector("body"): any)

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -1,5 +1,8 @@
 // @flow
 /* global SETTINGS: false */
+declare var dataLayer: Object[]
+declare var CSOURCE_PAYLOAD: ?Object
+
 import React from "react"
 import DocumentTitle from "react-document-title"
 import { DASHBOARD_PAGE_TITLE } from "../../constants"
@@ -54,6 +57,17 @@ export class DashboardPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    if (CSOURCE_PAYLOAD && SETTINGS.gtmTrackingID) {
+      dataLayer.push({
+        event:            "purchase",
+        transactionId:    CSOURCE_PAYLOAD.transaction_id,
+        transactionTotal: CSOURCE_PAYLOAD.transaction_total,
+        productType:      CSOURCE_PAYLOAD.product_type,
+        coursewareId:     CSOURCE_PAYLOAD.courseware_id,
+        referenceNumber:  CSOURCE_PAYLOAD.reference_number
+      })
+      CSOURCE_PAYLOAD = null
+    }
     this.handleOrderStatus()
   }
 

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -7,6 +7,7 @@ declare type Settings = {
   sentry_dsn: string,
   release_version: string,
   environment: string,
+  gtmTrackingID: ?string,
   gaTrackingID: ?string,
   recaptchaKey: ?string,
   support_email: string,

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -9,6 +9,7 @@ const _createSettings = () => ({})
 
 global.SETTINGS = _createSettings()
 global.TESTING = true
+global.CSOURCE_PAYLOAD = null
 
 // polyfill for Object.entries
 import entries from "object.entries"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1173 

#### What's this PR do?
Adds a GTM container trigger/tag for tracking purchases. This PR includes carrying UTM variables through the session for proper source/medium attribution for the marketing platforms. The tag registers the purchase event with UA ecommerce.

#### How should this be manually tested?
Setup the GTM CI container in your settings and complete a purchase with Cybersource. You should be able to see the events/purchases in GA and GTM debugger (if enabled).

#### Screenshots (if appropriate)
![Screenshot from 2019-10-17 17-43-38](https://user-images.githubusercontent.com/45350418/67010229-b2994e00-f106-11e9-949a-5add7db1f67a.png)
![Screenshot from 2019-10-17 17-43-09](https://user-images.githubusercontent.com/45350418/67010232-b2994e00-f106-11e9-837a-6f8b26f4526a.png)
![Screenshot from 2019-10-17 17-42-32](https://user-images.githubusercontent.com/45350418/67010233-b331e480-f106-11e9-92b6-128cf7095707.png)
![Screenshot from 2019-10-17 17-42-13](https://user-images.githubusercontent.com/45350418/67010235-b331e480-f106-11e9-87b5-0ceba542634e.png)
![Screenshot from 2019-10-17 17-41-56](https://user-images.githubusercontent.com/45350418/67010237-b331e480-f106-11e9-9c2b-2903d211599b.png)
![Screenshot from 2019-10-17 17-41-42](https://user-images.githubusercontent.com/45350418/67010238-b3ca7b00-f106-11e9-8690-1c32476083e7.png)
![Screenshot from 2019-10-17 17-40-59](https://user-images.githubusercontent.com/45350418/67010239-b3ca7b00-f106-11e9-9870-c89205bb671c.png)
