### PR TITLE
Filter courses, runs, and programs based on product and live status

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -35,7 +35,7 @@ class ProgramFactory(DjangoModelFactory):
 
     title = fuzzy.FuzzyText(prefix="Program ")
     readable_id = factory.Sequence("program-{0}".format)
-    live = factory.Faker("boolean")
+    live = True
 
     class Meta:
         model = Program
@@ -48,7 +48,7 @@ class CourseFactory(DjangoModelFactory):
     position_in_program = None  # will get populated in save()
     title = fuzzy.FuzzyText(prefix="Course ")
     readable_id = factory.Sequence("course-{0}".format)
-    live = factory.Faker("boolean")
+    live = True
 
     class Meta:
         model = Course

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -31,7 +31,7 @@ from courses.serializers import (
     CourseRunEnrollmentSerializer,
     ProgramEnrollmentSerializer,
 )
-from ecommerce.factories import ProductVersionFactory, ProductFactory
+from ecommerce.factories import ProductVersionFactory
 from ecommerce.serializers import CompanySerializer
 from ecommerce.serializers_test import datetime_format
 from mitxpro.test_utils import drf_datetime, assert_drf_json_equal
@@ -92,7 +92,9 @@ def test_serialize_program(mock_context, has_product):
             "id": program.id,
             "description": page.description,
             "courses": [
-                CourseSerializer(instance=course, context=mock_context).data
+                CourseSerializer(
+                    instance=course, context={**mock_context, "filter_products": False}
+                ).data
                 for course in [course1, course2]
             ],
             "thumbnail_url": f"http://localhost:8053{page.thumbnail_image.file.url}",
@@ -159,7 +161,7 @@ def test_serialize_course(mock_context, is_anonymous, all_runs):
 
     # create products for all courses so the serializer shows them
     for run in CourseRun.objects.all():
-        ProductVersionFactory.create(product=ProductFactory(content_object=run))
+        ProductVersionFactory.create(product__content_object=run)
 
     data = CourseSerializer(instance=course, context=mock_context).data
 

--- a/courses/views.py
+++ b/courses/views.py
@@ -26,7 +26,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = []
 
     serializer_class = ProgramSerializer
-    queryset = Program.objects.all()
+    queryset = Program.objects.filter(live=True).exclude(products=None)
 
 
 class CourseViewSet(viewsets.ReadOnlyModelViewSet):
@@ -35,7 +35,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = []
 
     serializer_class = CourseSerializer
-    queryset = Course.objects.all()
+    queryset = Course.objects.filter(live=True)
 
 
 class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #1224 

#### What's this PR do?
Filters out programs and course runs which don't have products, and filters out non-live programs, courses, and course runs

#### How should this be manually tested?
Set `live=False` on a program and view `/api/programs/`. It should not show up.