### PR TITLE
Added custom metadata options in mail API, added metadata to bulk enrollment emails

### DIFF
--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -18,7 +18,7 @@ from b2b_ecommerce.api import (
     generate_b2b_cybersource_sa_payload,
 )
 from b2b_ecommerce.models import B2BCoupon, B2BCouponRedemption, B2BOrder
-from ecommerce.api import make_checkout_url
+from ecommerce.utils import make_checkout_url
 from ecommerce.models import ProductVersion, Coupon
 from ecommerce.serializers import ProductVersionSerializer
 from mitxpro.utils import make_csv_http_response

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -13,7 +13,7 @@ from b2b_ecommerce.factories import (
     ProductVersionFactory,
 )
 from b2b_ecommerce.models import B2BCoupon, B2BOrder, B2BCouponRedemption
-from ecommerce.api import make_checkout_url
+from ecommerce.utils import make_checkout_url
 from ecommerce.factories import CouponVersionFactory
 from ecommerce.serializers import ProductVersionSerializer
 from mitxpro.utils import dict_without_keys

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -7,7 +7,7 @@ import hashlib
 import hmac
 import logging
 from traceback import format_exc
-from urllib.parse import quote_plus, urljoin, urlencode
+from urllib.parse import quote_plus, urljoin
 import uuid
 import itertools
 
@@ -1057,29 +1057,6 @@ def determine_order_status_change(order, decision):
         return Order.FAILED
 
     return Order.FULFILLED
-
-
-def make_checkout_url(*, product_id=None, code=None):
-    """
-    Helper function to create a checkout URL with appropriate query parameters.
-
-    Args:
-        product_id (int): A Product ID
-        code (str): The coupon code
-
-    Returns:
-        str: The URL for the checkout page, including product and coupon code if available
-    """
-    base_checkout_url = urljoin(settings.SITE_BASE_URL, reverse("checkout-page"))
-    if product_id is None and code is None:
-        return base_checkout_url
-
-    query_params = {}
-    if product_id is not None:
-        query_params["product"] = product_id
-    if code is not None:
-        query_params["code"] = code
-    return f"{base_checkout_url}?{urlencode(query_params)}"
 
 
 def fulfill_order(request_data):

--- a/ecommerce/constants.py
+++ b/ecommerce/constants.py
@@ -14,3 +14,5 @@ REFERENCE_NUMBER_PREFIX = "xpro-b2c-"
 # related ProductVersions in reverse creation order) can use `to_attr` and this attribute name
 # for the prefetched results.
 ORDERED_VERSIONS_QSET_ATTR = "ordered_versions"
+
+BULK_ENROLLMENT_EMAIL_TAG = "bulk_enrollment"

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -99,6 +99,17 @@ class Product(TimestampedModel):
         else:
             raise ValueError(f"Unexpected content type for {self.content_type.model}")
 
+    @property
+    def type_string(self):
+        """
+        Helper property to return a string representation of the product type,
+        e.g.: "courserun", "program"
+
+        Returns:
+            str: String representing the product type
+        """
+        return self.content_type.model
+
     def __str__(self):
         """Description of a product"""
         return f"Product for {self.content_object}"

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -130,6 +130,18 @@ def test_run_queryset(is_program):
     )
 
 
+def test_type_string():
+    """
+    type_string should return a string representation of the Product type
+    """
+    program = ProgramFactory.create()
+    run = CourseRunFactory.create()
+    program_product = ProductFactory.create(content_object=program)
+    assert program_product.type_string == "program"
+    run_product = ProductFactory.create(content_object=run)
+    assert run_product.type_string == "courserun"
+
+
 @pytest.mark.parametrize("hubspot_api_key", [None, "fake-key"])
 def test_hubspot_syncs(mock_hubspot_syncs, settings, hubspot_api_key):
     """ Test that hubspot sync tasks are called only if API key is set"""

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -1,8 +1,10 @@
 """Utility functions for ecommerce"""
 import logging
+from urllib.parse import urljoin, urlencode
 
 from django.conf import settings
 from django.core import mail
+from django.urls import reverse
 
 from ecommerce.exceptions import ParseException
 
@@ -78,3 +80,26 @@ def send_support_email(subject, message):
             )
     except:  # pylint: disable=bare-except
         log.exception("Exception sending email to admins")
+
+
+def make_checkout_url(*, product_id=None, code=None):
+    """
+    Helper function to create a checkout URL with appropriate query parameters.
+
+    Args:
+        product_id (int): A Product ID
+        code (str): The coupon code
+
+    Returns:
+        str: The URL for the checkout page, including product and coupon code if available
+    """
+    base_checkout_url = urljoin(settings.SITE_BASE_URL, reverse("checkout-page"))
+    if product_id is None and code is None:
+        return base_checkout_url
+
+    query_params = {}
+    if product_id is not None:
+        query_params["product"] = product_id
+    if code is not None:
+        query_params["code"] = code
+    return f"{base_checkout_url}?{urlencode(query_params)}"

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -31,8 +31,8 @@ from ecommerce.api import (
     validate_basket_for_checkout,
     complete_order,
     bulk_assign_product_coupons,
-    make_checkout_url,
 )
+from ecommerce.utils import make_checkout_url
 from ecommerce.exceptions import ParseException
 from ecommerce.mail_api import send_bulk_enroll_emails
 from ecommerce.models import (

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -13,7 +13,7 @@ from django.urls import reverse
 from django.views.generic import FormView
 from django.views.generic.base import View
 
-from ecommerce.api import make_checkout_url
+from ecommerce.utils import make_checkout_url
 from ecommerce.models import Coupon, Product
 from mitxpro.views import get_js_settings_context
 from voucher.forms import UploadVoucherForm, VOUCHER_PARSE_ERROR


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1213 

#### What's this PR do?
(Required)

#### How should this be manually tested?
- Make sure you have access to Mailgun logs (you should be able to log in at mailgun.com and use your MIT email)
- (Optional) Set your `MAILGUN_SENDER_DOMAIN` to the xpro-ci setting. It will be easier to find your logged messages and it will create less noise for otherwise-important domains
- Create a bulk coupon for some run/program (if you don't already have one), and use the Bulk Enrollments form to assign some of those coupons to two or more users
    - Both of those pages can be found under `/ecommerce/admin/`
    - Feel free to use 2 different emails that will go to the same address (`me@mit.edu`, `me+1@mit.edu`)
- If the bulk enrollment submission was successful, you should see the messages in the Mailgun logs
- Click on each message in the Mailgun logs to see the JSON metadata attached to the message. Each one should have `tags: ["bulk_enrollment"]`, and `user-variables: {"enrollment_code": <assigned coupon code>, "(courserun or program)": <text id of the course run or program>}`

#### Any background context you want to provide?
- Mailgun allows for [tags](https://documentation.mailgun.com/en/latest/user_manual.html#tagging) and "[user variables](https://documentation.mailgun.com/en/latest/user_manual.html#attaching-data-to-messages)" to be attached to messages. Both are types of metadata that we can eventually use to track what's happening with messages. To me it made sense to use tags to categorize the messages as bulk enrollment emails, and user variables to indicate the enrollment code and product type that was sent out. I can go into more detail if needed

#### Screenshots (if appropriate)
![ss 2019-10-21 at 13 52 20 ](https://user-images.githubusercontent.com/14932219/67229823-1626c280-f40a-11e9-864a-de49bcb9af49.png)
