### PR TITLE
#1222 Program next run date comes from first course

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -628,6 +628,11 @@ class ProductPage(MetadataPageMixin, Page):
         """Checks whether the page in question is for an external course or not."""
         return isinstance(self, ExternalCoursePage)
 
+    @property
+    def is_program_page(self):
+        """Gets the product page type, this is used for sorting product pages."""
+        return isinstance(self, ProgramPage)
+
 
 class ProgramPage(ProductPage):
     """

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -40,13 +40,13 @@
         <div class="mt-5 mb-5">
           {% if page.about_mit_xpro.video_url and action_title and action_url %}
             <a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="{{ action_url }}">{{ action_title }}</a>
-          {% else %}
+          {% elif page.product %}
             {% if not user.is_anonymous %}
               {% if page.is_external_course_page %}
                 <a class="enroll-button enroll-now" href="{{ page.external_url }}">
                   Apply Now
                 </a>
-              {% elif not enrolled and product_id %}
+              {% elif not enrolled and product_id and page.product.first_unexpired_run %}
                 <a class="enroll-button enroll-now" href="{{ checkout_url }}">
                   Enroll Now
                 </a>
@@ -55,7 +55,7 @@
                   Enrolled <i class="material-icons">check</i>
                 </a>
               {% endif %}
-            {% else %}
+            {% elif product_id and page.product.first_unexpired_run %}
               <div class="enroll-dropdown">
                 <a class="enroll-button dropdown-toggle" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="true">
                   Enroll Now

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -42,7 +42,6 @@ def test_home_page_view(client):
         f'<a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="#">Watch Now</a>'
         not in content
     )
-    assert "dropdown-menu" in content
 
     # add video section
     about_page = TextVideoSection(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1222 

#### What's this PR do?
Modifies `start_date` and `next_run_date` calculations in programs to use the first course in the program (`position_in_program=1`).

#### How should this be manually tested?
Create different courses and course runs for a program. Verify that the start date and next run dates are those set for the first course only. This includes hiding the "enroll now" button if the first course in the program does not have an upcoming course run to enroll into.