### PR TITLE
#1250 Add SignatoryIndexPage from CMS

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -345,6 +345,7 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, Page):
         "ResourcePage",
         "ImageCarouselPage",
         "CertificateIndexPage",
+        "SignatoryIndexPage",
     ]
 
     def _get_child_page_of_type(self, cls):


### PR DESCRIPTION
#### What are the relevant tickets?
#1250 

#### What's this PR do?
Fixes #1250, adds the ability to create a `SignatoryIndexPage` from the CMS rather than solely relying on `setup_index_pages` management command to set up the index page.

#### How should this be manually tested?
Make sure you do not have an existing signatory index page under the home page. Click `Add child page` under the home page, you should be able to see `SignatoryIndexPage` as an eligible candidate type for child page.
