### PR TITLE
#1265 Certificate generation only on passed status

### DIFF
--- a/courses/factories.py
+++ b/courses/factories.py
@@ -16,6 +16,7 @@ from .models import (
     CourseRunEnrollment,
     CourseRunCertificate,
     ProgramCertificate,
+    CourseRunGrade,
 )
 
 FAKE = faker.Factory.create()
@@ -103,6 +104,20 @@ class CourseRunCertificateFactory(DjangoModelFactory):
 
     class Meta:
         model = CourseRunCertificate
+
+
+class CourseRunGradeFactory(DjangoModelFactory):
+    """Factory for CourseRunGrade"""
+
+    course_run = factory.SubFactory(CourseRunFactory)
+    user = factory.SubFactory(UserFactory)
+    grade = factory.fuzzy.FuzzyDecimal(low=0.0, high=1.0)
+    letter_grade = factory.fuzzy.FuzzyText(length=1)
+    passed = factory.fuzzy.FuzzyChoice([True, False])
+    set_by_admin = factory.fuzzy.FuzzyChoice([True, False])
+
+    class Meta:
+        model = CourseRunGrade
 
 
 class ProgramCertificateFactory(DjangoModelFactory):

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -67,18 +67,22 @@ def process_course_run_grade_certificate(course_run_grade):
     """
     user = course_run_grade.user
     course_run = course_run_grade.course_run
+
+    # A grade of 0.0 indicates that the certificate should be deleted
     should_delete = not bool(course_run_grade.grade)
+    should_create = course_run_grade.passed
 
     if should_delete:
         delete_count, _ = CourseRunCertificate.objects.filter(
             user=user, course_run=course_run
         ).delete()
         return None, False, (delete_count > 0)
-    else:
+    elif should_create:
         certificate, created = CourseRunCertificate.objects.get_or_create(
             user=user, course_run=course_run
         )
         return certificate, created, False
+    return None, False, False
 
 
 def generate_program_certificate(user, program):

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -10,8 +10,12 @@ from courses.factories import (
     CourseRunFactory,
     CourseRunCertificateFactory,
     ProgramCertificateFactory,
+    CourseRunGradeFactory,
 )
-from courses.utils import generate_program_certificate
+from courses.utils import (
+    generate_program_certificate,
+    process_course_run_grade_certificate,
+)
 from courses.models import ProgramCertificate
 
 pytestmark = pytest.mark.django_db
@@ -27,6 +31,80 @@ def user():
 def program():
     """User object fixture"""
     return ProgramFactory.create()
+
+
+@pytest.fixture()
+def course():
+    """Course object fixture"""
+    return CourseFactory.create()
+
+
+# pylint: disable=too-many-arguments
+@pytest.mark.parametrize(
+    "grade, passed, exp_certificate, exp_created, exp_deleted",
+    [
+        [0.25, True, True, True, False],
+        [0.0, True, False, False, False],
+        [1.0, False, False, False, False],
+    ],
+)
+def test_course_run_certificate(
+    user, course, grade, passed, exp_certificate, exp_created, exp_deleted
+):
+    """
+    Test that the certificate is generated correctly
+    """
+    certificate, created, deleted = process_course_run_grade_certificate(
+        CourseRunGradeFactory.create(
+            course_run__course=course, user=user, grade=grade, passed=passed
+        )
+    )
+    assert bool(certificate) is exp_certificate
+    assert created is exp_created
+    assert deleted is exp_deleted
+
+
+def test_course_run_certificate_idempotent(user, course):
+    """
+    Test that the certificate generation is idempotent
+    """
+    grade = CourseRunGradeFactory.create(
+        course_run__course=course, user=user, grade=0.25, passed=True
+    )
+
+    # Certificate is created the first time
+    certificate, created, deleted = process_course_run_grade_certificate(grade)
+    assert certificate
+    assert created
+    assert not deleted
+
+    # Existing certificate is simply returned without any create/delete
+    certificate, created, deleted = process_course_run_grade_certificate(grade)
+    assert certificate
+    assert not created
+    assert not deleted
+
+
+def test_course_run_certificate_blacklist(user, course):
+    """
+    Test that the certificate is not generated if grade isn't passing
+    """
+    grade = CourseRunGradeFactory.create(
+        course_run__course=course, user=user, grade=1.0, passed=True
+    )
+
+    # Initially the certificate is created
+    certificate, created, deleted = process_course_run_grade_certificate(grade)
+    assert certificate
+    assert created
+    assert not deleted
+
+    # Now that the grade indicates score 0.0, certificate should be deleted
+    grade.grade = 0.0
+    certificate, created, deleted = process_course_run_grade_certificate(grade)
+    assert not certificate
+    assert not created
+    assert deleted
 
 
 def test_generate_program_certificate_already_exist(user, program):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1265 

#### What's this PR do?
Modifies the certificate generation method to consider the `grade.passed` and `grade.percentage` (`grade.grade` in xPRO) while creating/updating/deleting certificates for course run grades. 

#### How should this be manually tested?
Run any sync commands or use the `courses.utils.process_course_run_grade_certificate` method (used in the scheduled app tasks) to sync/generate grades and certificates. No certificates should be generated for any grades that have either:
- `passed=False`
- `percentage=0.0` (for Open edX grade object) or `grade=0.0` (for xPRO `CourseRunGrade` object)
