### PR TITLE
Changed product coupon assignment match to be case-insensitive

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -475,7 +475,8 @@ def complete_order(order):
     )
     if order_coupon_ids:
         updated_count = ProductCouponAssignment.objects.filter(
-            email=order.purchaser.email, product_coupon__coupon__in=order_coupon_ids
+            email__iexact=order.purchaser.email,
+            product_coupon__coupon__in=order_coupon_ids,
         ).update(redeemed=True)
         if updated_count:
             log.info(
@@ -872,7 +873,7 @@ def fetch_and_serialize_unused_coupons(user):
             }
     """
     unused_product_coupon_ids = ProductCouponAssignment.objects.filter(
-        email=user.email, redeemed=False
+        email__iexact=user.email, redeemed=False
     ).values_list("product_coupon", flat=True)
     if not unused_product_coupon_ids:
         return []

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -896,7 +896,8 @@ def test_complete_order_coupon_assignments(mocker, user, basket_and_coupons):
     order = OrderFactory.create(purchaser=user, status=Order.CREATED)
     coupon_redemption = CouponRedemptionFactory.create(order=order)
     coupon_assignment = ProductCouponAssignmentFactory.create(
-        email=order.purchaser.email,
+        # Set assignment email as uppercase to test that the email match is case-insensitive
+        email=order.purchaser.email.upper(),
         product_coupon__coupon=coupon_redemption.coupon_version.coupon,
     )
 
@@ -1123,7 +1124,8 @@ def test_fetch_and_serialize_unused_coupons(user):
     # Create assignments for the user and set all to be unredeemed/unused
     ProductCouponAssignmentFactory.create_batch(
         len(product_coupons),
-        email=user.email,
+        # Set assignment email as uppercase to test that the email match is case-insensitive
+        email=user.email.upper(),
         redeemed=False,
         product_coupon=factory.Iterator(product_coupons),
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket – this bug was observed by @pdpinch

#### What's this PR do?
Changes the logic for fetching a user's unredeemed coupons so that the email matching is case-insensitive. If the user has a product coupon assignment with an email that was entered with differently-"cased" letters, they should still see a notification to redeem their coupon.

#### How should this be manually tested?
**Confirm that you can see the notification:**
- In Django admin, create a product coupon assignment for your user, enter the email with different combinations of uppercase and lowercase, and leave "redeemed" unchecked
- Log in as that user

You should see the unused coupon notification when you complete login. 

**Confirm that order completion sets the assignment to redeemed:**
- Complete an order using the coupon from the assignment you created above
- Check the product coupon assignment record in Django admin

The 'redeemed' box should be checked, and you should no longer see an unused coupon notification for that product coupon in the web app
