### PR TITLE
MIT xPRO - 1233 When user has multiple unredeemed coupons, only one message displays

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -898,6 +898,9 @@ def fetch_and_serialize_unused_coupons(user):
         {
             "coupon_code": coupon_data["coupon__coupon_code"],
             "product_id": coupon_data["product__id"],
+            "product_name": Product.objects.get(id=coupon_data["product__id"])
+            .run_queryset[0]
+            .title,
             "expiration_date": coupon_data[
                 "coupon__payment__versions__expiration_date"
             ],

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1134,6 +1134,7 @@ def test_fetch_and_serialize_unused_coupons(user):
         {
             "coupon_code": expected_product_coupon.coupon.coupon_code,
             "product_id": expected_product_coupon.product.id,
+            "product_name": expected_product_coupon.product.content_object.title,
             "expiration_date": expected_payment_version.expiration_date,
         }
     ]

--- a/static/js/components/NotificationContainer.js
+++ b/static/js/components/NotificationContainer.js
@@ -62,7 +62,7 @@ export class NotificationContainer extends React.Component<Props, State> {
             <Alert
               key={i}
               color={notification.color || "info"}
-              className="rounded-0 border-0"
+              className="rounded-0 border-0 m-1"
               isOpen={!hiddenNotifications.has(notificationKey)}
               toggle={dismiss}
               fade={true}

--- a/static/js/components/notifications/index.js
+++ b/static/js/components/notifications/index.js
@@ -21,11 +21,11 @@ export const TextNotification = (
 export const UnusedCouponNotification = (
   props: UnusedCouponNotificationProps & ComponentProps
 ) => {
-  const { productId, couponCode, dismiss } = props
+  const { productId, productName, couponCode, dismiss } = props
 
   return (
     <span>
-      You have an unused coupon.{" "}
+      You have an unused enrollment code.{" "}
       <MixedLink
         dest={`${routes.checkout}?product=${productId}&code=${couponCode}`}
         onClick={dismiss}
@@ -33,7 +33,7 @@ export const UnusedCouponNotification = (
       >
         Checkout now
       </MixedLink>{" "}
-      to redeem it.
+      to enroll in {productName}.
     </span>
   )
 }

--- a/static/js/components/notifications/index_test.js
+++ b/static/js/components/notifications/index_test.js
@@ -29,11 +29,13 @@ describe("Notification component", () => {
 
   it("UnusedCouponNotification", () => {
     const productId = 1,
-      couponCode = "code"
+      couponCode = "code",
+      productName = "name"
     const wrapper = shallow(
       <UnusedCouponNotification
         productId={productId}
         couponCode={couponCode}
+        productName={productName}
         dismiss={dismissStub}
       />
     )

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -41,9 +41,9 @@ export class App extends React.Component<Props, void> {
       // $FlowFixMe: currentUser cannot be undefined or is_anonymous=true
       const unusedCoupons = currentUser.unused_coupons
       unusedCoupons.map((unusedCoupon, index) => {
-        const key1 = `unused-coupon-${index}`
+        const key = `unused-coupon-${index}`
         addUserNotification({
-          [key1]: {
+          [key]: {
             type:  ALERT_TYPE_UNUSED_COUPON,
             props: {
               productId:   unusedCoupon.product_id,

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -39,15 +39,19 @@ export class App extends React.Component<Props, void> {
     if (this.shouldShowUnusedCouponAlert(prevProps, this.props)) {
       const { currentUser, addUserNotification } = this.props
       // $FlowFixMe: currentUser cannot be undefined or is_anonymous=true
-      const unusedCoupon = currentUser.unused_coupons[0]
-      addUserNotification({
-        "unused-coupon": {
-          type:  ALERT_TYPE_UNUSED_COUPON,
-          props: {
-            productId:  unusedCoupon.product_id,
-            couponCode: unusedCoupon.coupon_code
+      const unusedCoupons = currentUser.unused_coupons
+      unusedCoupons.map((unusedCoupon, index) => {
+        const key1 = `unused-coupon-${index}`
+        addUserNotification({
+          [key1]: {
+            type:  ALERT_TYPE_UNUSED_COUPON,
+            props: {
+              productId:   unusedCoupon.product_id,
+              productName: unusedCoupon.product_name,
+              couponCode:  unusedCoupon.coupon_code
+            }
           }
-        }
+        })
       })
     }
   }

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -85,4 +85,74 @@ describe("Top-level App", () => {
       assert.deepEqual(state.ui.userNotifications, expectedNotificationState)
     })
   })
+
+  describe("unused coupons alert", () => {
+    let userWithUnusedCoupons,
+      unusedCoupon,
+      unusedCoupon1,
+      unusedCoupon2,
+      expectedNotificationState
+
+    beforeEach(() => {
+      unusedCoupon = makeUnusedCoupon()
+      unusedCoupon1 = makeUnusedCoupon()
+      unusedCoupon2 = makeUnusedCoupon()
+      userWithUnusedCoupons = mergeRight(makeUser(), {
+        unused_coupons: [unusedCoupon, unusedCoupon1, unusedCoupon2]
+      })
+      expectedNotificationState = {
+        "unused-coupon-0": {
+          type:  ALERT_TYPE_UNUSED_COUPON,
+          props: {
+            productId:   unusedCoupon.product_id,
+            productName: unusedCoupon.product_name,
+            couponCode:  unusedCoupon.coupon_code
+          }
+        },
+        "unused-coupon-1": {
+          type:  ALERT_TYPE_UNUSED_COUPON,
+          props: {
+            productId:   unusedCoupon1.product_id,
+            productName: unusedCoupon1.product_name,
+            couponCode:  unusedCoupon1.coupon_code
+          }
+        },
+        "unused-coupon-2": {
+          type:  ALERT_TYPE_UNUSED_COUPON,
+          props: {
+            productId:   unusedCoupon2.product_id,
+            productName: unusedCoupon2.product_name,
+            couponCode:  unusedCoupon2.coupon_code
+          }
+        }
+      }
+    })
+
+    it("is triggered if the user is loaded and has unused coupons", async () => {
+      const { inner, store } = await renderPage()
+
+      inner.setProps({ currentUser: userWithUnusedCoupons })
+
+      const { ui } = store.getState()
+      assert.deepEqual(ui.userNotifications, expectedNotificationState)
+    })
+
+    it("is triggered if the user changes from the checkout page to another page", async () => {
+      let state
+      const { inner, store } = await renderPage(
+        {},
+        {
+          location: { pathname: routes.checkout }
+        }
+      )
+
+      inner.setProps({ currentUser: userWithUnusedCoupons })
+      state = store.getState()
+      assert.deepEqual(state.ui.userNotifications, {})
+
+      inner.setProps({ location: { pathname: routes.dashboard } })
+      state = store.getState()
+      assert.deepEqual(state.ui.userNotifications, expectedNotificationState)
+    })
+  })
 })

--- a/static/js/containers/App_test.js
+++ b/static/js/containers/App_test.js
@@ -47,11 +47,12 @@ describe("Top-level App", () => {
         unused_coupons: [unusedCoupon]
       })
       expectedNotificationState = {
-        "unused-coupon": {
+        "unused-coupon-0": {
           type:  ALERT_TYPE_UNUSED_COUPON,
           props: {
-            productId:  unusedCoupon.product_id,
-            couponCode: unusedCoupon.coupon_code
+            productId:   unusedCoupon.product_id,
+            productName: unusedCoupon.product_name,
+            couponCode:  unusedCoupon.coupon_code
           }
         }
       }

--- a/static/js/containers/HeaderApp.js
+++ b/static/js/containers/HeaderApp.js
@@ -25,15 +25,19 @@ export class HeaderApp extends React.Component<Props, void> {
     if (this.shouldShowUnusedCouponAlert(prevProps, this.props)) {
       const { currentUser, addUserNotification } = this.props
       // $FlowFixMe: currentUser cannot be undefined or is_anonymous=true
-      const unusedCoupon = currentUser.unused_coupons[0]
-      addUserNotification({
-        "unused-coupon": {
-          type:  ALERT_TYPE_UNUSED_COUPON,
-          props: {
-            productId:  unusedCoupon.product_id,
-            couponCode: unusedCoupon.coupon_code
+      const unusedCoupons = currentUser.unused_coupons
+      unusedCoupons.map((unusedCoupon, index) => {
+        const key1 = `unused-coupon-${index}`
+        addUserNotification({
+          [key1]: {
+            type:  ALERT_TYPE_UNUSED_COUPON,
+            props: {
+              productId:   unusedCoupon.product_id,
+              productName: unusedCoupon.product_name,
+              couponCode:  unusedCoupon.coupon_code
+            }
           }
-        }
+        })
       })
     }
   }

--- a/static/js/containers/HeaderApp.js
+++ b/static/js/containers/HeaderApp.js
@@ -27,9 +27,9 @@ export class HeaderApp extends React.Component<Props, void> {
       // $FlowFixMe: currentUser cannot be undefined or is_anonymous=true
       const unusedCoupons = currentUser.unused_coupons
       unusedCoupons.map((unusedCoupon, index) => {
-        const key1 = `unused-coupon-${index}`
+        const key = `unused-coupon-${index}`
         addUserNotification({
-          [key1]: {
+          [key]: {
             type:  ALERT_TYPE_UNUSED_COUPON,
             props: {
               productId:   unusedCoupon.product_id,

--- a/static/js/containers/HeaderApp_test.js
+++ b/static/js/containers/HeaderApp_test.js
@@ -36,11 +36,12 @@ describe("Top-level HeaderApp", () => {
         unused_coupons: [unusedCoupon]
       })
       expectedNotificationState = {
-        "unused-coupon": {
+        "unused-coupon-0": {
           type:  ALERT_TYPE_UNUSED_COUPON,
           props: {
-            productId:  unusedCoupon.product_id,
-            couponCode: unusedCoupon.coupon_code
+            productId:   unusedCoupon.product_id,
+            productName: unusedCoupon.product_name,
+            couponCode:  unusedCoupon.coupon_code
           }
         }
       }

--- a/static/js/factories/user.js
+++ b/static/js/factories/user.js
@@ -19,6 +19,7 @@ export const makeAnonymousUser = (): AnonymousUser => ({
 export const makeUnusedCoupon = (): UnusedCoupon => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
   product_id:      incr.next().value,
+  product_name:    casual.word,
   coupon_code:     casual.word,
   expiration_date: casual.moment.format()
 })

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -52,6 +52,7 @@ export type LegalAddress = {
 export type UnusedCoupon = {
   coupon_code: string,
   product_id: number,
+  product_name: string,
   expiration_date: string
 }
 

--- a/static/js/reducers/notifications.js
+++ b/static/js/reducers/notifications.js
@@ -9,6 +9,7 @@ import type { Action } from "../flow/reduxTypes"
 export type TextNotificationProps = { text: string }
 export type UnusedCouponNotificationProps = {
   productId: number,
+  productName: string,
   couponCode: string
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What's this PR do?
fixes #1233 

#### How should this be manually tested?
In order to test it, you need to perform the following steps
1. Create Coupons 
2. Do bulk enrollment and upload users' CSV file.
3. Login to any of the CSV users account.

#### Screenshots
**Desktop**

![image](https://user-images.githubusercontent.com/4043989/67935062-f1d99b80-fbea-11e9-96d0-f764baf04c41.png)

**Mobile**

![image](https://user-images.githubusercontent.com/4043989/67935526-d3c06b00-fbeb-11e9-9fc7-ec9401ecf63a.png)
