### PR TITLE
#1280 External course page apply now button fix

### DIFF
--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -40,13 +40,13 @@
         <div class="mt-5 mb-5">
           {% if page.about_mit_xpro.video_url and action_title and action_url %}
             <a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="{{ action_url }}">{{ action_title }}</a>
+          {% elif page.is_external_course_page %}
+            <a class="enroll-button enroll-now" href="{{ page.external_url }}">
+              Apply Now
+            </a>
           {% elif page.product %}
             {% if not user.is_anonymous %}
-              {% if page.is_external_course_page %}
-                <a class="enroll-button enroll-now" href="{{ page.external_url }}">
-                  Apply Now
-                </a>
-              {% elif not enrolled and product_id and page.product.first_unexpired_run %}
+              {% if not enrolled and product_id and page.product.first_unexpired_run %}
                 <a class="enroll-button enroll-now" href="{{ checkout_url }}">
                   Enroll Now
                 </a>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1280 

#### What's this PR do?
Fixes the regression bug that caused "Apply Now" button to disappear on external course pages.

#### How should this be manually tested?
Go to any external course page, the "Apply Now" button should appear. Go to any other product page with a product setup properly and the "Enroll Now" or "Enrolled" button should appear as expected.
