### PR TITLE
#1245 Add search to product and version admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -283,6 +283,14 @@ class ProductVersionAdmin(admin.ModelAdmin):
     save_on_top = True
     readonly_fields = ("text_id",)
     raw_id_fields = ("product",)
+    search_fields = (
+        "text_id",
+        "description",
+        "product__courseruns__title",
+        "product__programs__title",
+        "product__courseruns__courseware_id",
+        "product__programs__readable_id",
+    )
 
     def get_queryset(self, request):
         """Return all active and in_active products"""
@@ -314,6 +322,12 @@ class ProductAdmin(admin.ModelAdmin):
     inlines = [ProductVersionInline]
     list_display = ("id", "content_object")
     list_filter = ("is_active", ProductContentTypeListFilter)
+    search_fields = (
+        "courseruns__title",
+        "programs__title",
+        "courseruns__courseware_id",
+        "programs__readable_id",
+    )
 
     def get_queryset(self, request):
         """Return all active and in_active products"""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1245 

#### What's this PR do?
Adds search on product and product version admin. For product admin:
- `title`
- `readable_id`

are searchable. For product version:
- `title`
- `readable_id`
- `text_id`
- `description`

are searchable.

#### How should this be manually tested?
Go to the Django admin for Product and ProductVersion. You should be able to search through the objects using any of the attributes defined above.
