### PR TITLE
#1259 Usernamify fix for Turkish characters

### DIFF
--- a/users/utils.py
+++ b/users/utils.py
@@ -17,6 +17,10 @@ USERNAME_SEPARATOR_REPLACE_CHARS = "\\s_"
 USERNAME_INVALID_CHAR_PATTERN = r"[^\w{}{}]|[\d]".format(
     USERNAME_SEPARATOR_REPLACE_CHARS, USERNAME_SEPARATOR
 )
+
+USERNAME_TURKISH_I_CHARS = r"[ıİ]"
+USERNAME_TURKISH_I_CHARS_REPLACEMENT = "i"
+
 # Pattern for chars to replace with a single separator. The separator character itself
 # is also included in this pattern so repeated separators are squashed down.
 USERNAME_SEPARATOR_REPLACE_PATTERN = r"[{}{}]+".format(
@@ -33,9 +37,12 @@ def _reformat_for_username(string):
     Returns:
         str: A version of the string with username-appropriate characters
     """
-    cleaned = re.sub(USERNAME_INVALID_CHAR_PATTERN, "", string)
+    cleaned_string = re.sub(USERNAME_INVALID_CHAR_PATTERN, "", string)
+    cleaned_string = re.sub(
+        USERNAME_TURKISH_I_CHARS, USERNAME_TURKISH_I_CHARS_REPLACEMENT, cleaned_string
+    )
     return (
-        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR, cleaned)
+        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR, cleaned_string)
         .lower()
         .strip(USERNAME_SEPARATOR)
     )
@@ -56,6 +63,7 @@ def usernameify(full_name, email=""):
             full name and email
     """
     username = _reformat_for_username(full_name)
+
     if not username and email:
         log.error(
             "User's full name could not be used to generate a username (full name: '%s'). "

--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -17,6 +17,7 @@ from users.utils import ensure_active_user, is_duplicate_username_error, usernam
         ["Кирил Френков", None, "кирил-френков"],
         ["年號", None, "年號"],
         ["abcdefghijklmnopqrstuvwxyz", None, "abcdefghijklmnopqrst"],
+        ["ai bi cı dI eİ fI", None, "ai-bi-ci-di-ei-fi"],
         ["", "some.email@example.co.uk", "someemail"],
     ],
 )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1259 

#### What's this PR do?
Fixes the `users.utils._reformat_for_username` method to replace invalid Turkish characters with a suitable substitute so that user onboarding does not fail on Open edX.

#### How should this be manually tested?
Try to sign up with a user with any of the following characters in the "Full Name" attribute, as many times as required:
`iiıIİI`

The user signup should be successful and user should also be created on the Open edX instance. In both xPRO and Open edX the username should have all of these characters replaced with a lowercase `i`.
