### PR TITLE
#1243 Set user context for Sentry

### DIFF
--- a/static/js/components/Header.js
+++ b/static/js/components/Header.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react"
+import * as Sentry from "@sentry/browser"
 
 import TopAppBar from "./TopAppBar"
 import NotificationContainer from "./NotificationContainer"
@@ -10,11 +11,27 @@ type Props = {
   currentUser: CurrentUser
 }
 
-const Header = ({ currentUser }: Props) => (
-  <React.Fragment>
-    <TopAppBar currentUser={currentUser} />
-    <NotificationContainer />
-  </React.Fragment>
-)
+const Header = ({ currentUser }: Props) => {
+  if (currentUser && currentUser.is_authenticated) {
+    Sentry.configureScope(scope => {
+      scope.setUser({
+        id:       currentUser.id,
+        email:    currentUser.email,
+        username: currentUser.username,
+        name:     currentUser.name
+      })
+    })
+  } else {
+    Sentry.configureScope(scope => {
+      scope.setUser(null)
+    })
+  }
+  return (
+    <React.Fragment>
+      <TopAppBar currentUser={currentUser} />
+      <NotificationContainer />
+    </React.Fragment>
+  )
+}
 
 export default Header


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1243 

#### What's this PR do?
Adds user context to Sentry so error reports provide more insight into the user that is having the issue.

#### How should this be manually tested?
Set up a Sentry instance and try to reproduce a bug (raising an `Http404` from the `ecommerce.views.BasketView` is a quick way to do that) and verify that the errors logged in Sentry include the user context as shown in the screenshot below.

#### Screenshots (if appropriate)
![screencapture-localhost-9000-sentry-internal-issues-20-2019-11-05-17_39_28](https://user-images.githubusercontent.com/45350418/68208569-4027d980-fff3-11e9-8524-a4b5e009dab8.png)
