### PR TITLE
Added setting for controlling edx API client request timeout

### DIFF
--- a/app.json
+++ b/app.json
@@ -115,6 +115,10 @@
       "description": "The log level for django",
       "required": false
     },
+    "EDX_API_CLIENT_TIMEOUT": {
+      "description": "Timeout (in seconds) for requests made via the edX API client",
+      "required": false
+    },
     "GA_TRACKING_ID": {
       "description": "Google analytics tracking ID",
       "required": false

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -371,6 +371,7 @@ def get_edx_api_client(user, ttl_in_seconds=OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS)
     return EdxApi(
         {"access_token": auth.access_token, "api_key": settings.OPENEDX_API_KEY},
         settings.OPENEDX_API_BASE_URL,
+        timeout=settings.EDX_API_CLIENT_TIMEOUT,
     )
 
 
@@ -390,6 +391,7 @@ def get_edx_api_grades_client():
             "api_key": settings.OPENEDX_API_KEY,
         },
         settings.OPENEDX_API_BASE_URL,
+        timeout=settings.EDX_API_CLIENT_TIMEOUT,
     )
 
     return edx_client.current_grades

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -787,6 +787,11 @@ OPENEDX_GRADES_API_TOKEN = get_string(
     None,
     "Access token to use with OpenEdX API client for syncing grades",
 )
+EDX_API_CLIENT_TIMEOUT = get_int(
+    "EDX_API_CLIENT_TIMEOUT",
+    60,
+    "Timeout (in seconds) for requests made via the edX API client",
+)
 
 
 # features flags


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
No ticket – [relevant sentry issue](https://sentry.io/organizations/mit-office-of-digital-learning/issues/1234039550/) 

#### What's this PR do?
Makes the edX API client timeout configurable via settings, and sets the default timeout to 60s (rather than the library default of 25s)

#### How should this be manually tested?
Run some of our management commands that use the API client (e.g.: `sync_grades_and_certificates`) and make sure it isn't broken. You can also use `courseware.api.get_edx_api_client` or `courseware.api.get_edx_api_grades_client` in a Django shell and make sure requests are successful. 

#### Any background context you want to provide?
See sentry issue

