### PR TITLE
#1276 Configurable CSRF_TRUSTED_ORIGINS env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -63,6 +63,10 @@
       "description": "'hours' value for the 'generate-course-certificate' scheduled task (defaults to midnight)",
       "required": false
     },
+    "CSRF_TRUSTED_ORIGINS": {
+      "description": "Comma separated string of trusted domains that should be CSRF exempt",
+      "required": false
+    },
     "CYBERSOURCE_ACCESS_KEY": {
       "description": "CyberSource Access Key",
       "required": false

--- a/mitxpro/envs.py
+++ b/mitxpro/envs.py
@@ -168,6 +168,25 @@ def parse_str(name, value, default):  # pylint: disable=unused-argument
     return value
 
 
+def parse_list(name, value, default):  # pylint: disable=unused-argument
+    """
+    Parses a comma separated string into a list
+
+    Argumments:
+        value (str or list[str]):
+            the value as a string or list of strings
+
+    Returns:
+        list[str]:
+            the parsed value
+    """
+    parsed_value = value
+    if isinstance(value, str):
+        parsed_value = value.split(",")
+
+    return [item.strip(" ") for item in parsed_value]
+
+
 def parse_any(name, value, default):
     """
     Attempts to parse an environment variable as a bool, int, or a string
@@ -185,7 +204,7 @@ def parse_any(name, value, default):
             the environment variable value parsed as a bool, int, or a string
     """
     # attempt to parse the var in this order of parsers
-    for parser in [parse_bool, parse_int, parse_str]:
+    for parser in [parse_bool, parse_int, parse_str, parse_list]:
         try:
             return parser(name, value, default)
         except EnvironmentVariableParseException:
@@ -237,6 +256,7 @@ class EnvParser:
     get_string = var_parser(parse_str)
     get_bool = var_parser(parse_bool)
     get_int = var_parser(parse_int)
+    get_list = var_parser(parse_list)
     get_any = var_parser(parse_any)
 
 
@@ -246,6 +266,7 @@ env = EnvParser()
 get_string = env.get_string
 get_int = env.get_int
 get_bool = env.get_bool
+get_list = env.get_list
 get_any = env.get_any
 validate = env.validate
 list_environment_vars = env.list_environment_vars

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -15,7 +15,14 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-from mitxpro.envs import get_any, get_bool, get_int, get_string, OffsettingSchedule
+from mitxpro.envs import (
+    get_any,
+    get_bool,
+    get_int,
+    get_string,
+    get_list,
+    OffsettingSchedule,
+)
 
 VERSION = "0.29.2"
 
@@ -50,6 +57,12 @@ HEROKU_APP_NAME = get_string(
 )
 
 ALLOWED_HOSTS = ["*"]
+
+CSRF_TRUSTED_ORIGINS = get_list(
+    "CSRF_TRUSTED_ORIGINS",
+    [],
+    description="Comma separated string of trusted domains that should be CSRF exempt",
+)
 
 SECURE_SSL_REDIRECT = get_bool(
     "MITXPRO_SECURE_SSL_REDIRECT",

--- a/mitxpro/settings_test.py
+++ b/mitxpro/settings_test.py
@@ -98,6 +98,24 @@ class TestSettings(TestCase):
         mail.mail_admins("Test", "message")
         self.assertIn(test_admin_email, mail.outbox[0].to)
 
+    def test_csrf_trusted_origins(self):
+        """Verify that we can configure CSRF_TRUSTED_ORIGINS with a var"""
+        # Test the default
+        settings_vars = self.patch_settings(REQUIRED_SETTINGS)
+        self.assertEqual(settings_vars.get("CSRF_TRUSTED_ORIGINS"), [])
+
+        # Verify the env var works
+        settings_vars = self.patch_settings(
+            {
+                **REQUIRED_SETTINGS,
+                "CSRF_TRUSTED_ORIGINS": "some.domain.com, some.other.domain.org",
+            }
+        )
+        self.assertEqual(
+            settings_vars.get("CSRF_TRUSTED_ORIGINS"),
+            ["some.domain.com", "some.other.domain.org"],
+        )
+
     def test_db_ssl_enable(self):
         """Verify that we can enable/disable database SSL with a var"""
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#1276 

#### What's this PR do?
Adds a configurable `CSRF_TRUSTED_ORIGINS` environment variable and comma separated list parser method.

#### How should this be manually tested?
Set `CSRF_TRUSTED_ORIGINS` environment variable to a comma separated string for domains and verify that `django.conf.settings.CSRF_TRUSTED_ORIGINS` value is a list of all the domains listed in the env var.