### PR TITLE
#1301 Fix certificate view (4 signatures inline)

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -87,7 +87,7 @@
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
 
-                            <div class="col-sm-4 signature-{{ page.signatory_pages | length }} certify-by">
+                            <div class="col-sm-4 col-md-3 certify-by">
                                 <div class="signature-area">
                                     {% image signatory.signature_image max-150x50 %}
                                 </div>

--- a/static/scss/certificates/certificate.scss
+++ b/static/scss/certificates/certificate.scss
@@ -294,39 +294,7 @@ $text-gray-light: #d2d0d1;
   }
 
   .certify-by-row {
-    display: block;
-
-    &:after {
-      content: "";
-      display: block;
-      clear: both;
-    }
-
-    .certify-by {
-      float: left;
-      width: 33.3333%;
-
-      &.signature-1 {
-        float: none;
-        margin: 0 auto;
-      }
-
-      &.signature-2 {
-        width: 30%;
-
-        &:first-child {
-          margin-left: 20%;
-        }
-      }
-
-      &.signature-4 {
-        width: 25%;
-      }
-
-      &.signature-5 {
-        width: 20%;
-      }
-    }
+    flex-wrap: nowrap;
   }
 
   @page {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1301 

#### What's this PR do?
Modifies the certificate template to show up to 4 signatures per row for desktop- and table-width screens, 3 signatures per row for intermediate width and 1 signature per row for small width screens.

#### How should this be manually tested?
Visit any certificate view, the UI should behave as described above.

#### Screenshots (if appropriate)
![screencapture-xpro-odl-local-8053-certificate-46ac074b-cbb8-4b76-8562-7bf4331f5501-2019-11-07-16_39_55](https://user-images.githubusercontent.com/45350418/68386592-3088cc00-017e-11ea-88b8-bc2cb38e5bec.png)
![screencapture-xpro-odl-local-8053-certificate-46ac074b-cbb8-4b76-8562-7bf4331f5501-2019-11-07-16_42_14](https://user-images.githubusercontent.com/45350418/68386595-32528f80-017e-11ea-8bfa-c7f08b88d25c.png)
![screencapture-xpro-odl-local-8053-certificate-46ac074b-cbb8-4b76-8562-7bf4331f5501-2019-11-07-16_43_00](https://user-images.githubusercontent.com/45350418/68386597-34b4e980-017e-11ea-96e9-7bff6811cc7e.png)
