### PR TITLE
Filter invalid runs from selected runs list

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -56,6 +56,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
 
         model_class = instance.product.content_type.model_class()
         if model_class is CourseRun:
+            # filter_products=True because the course run must have an associated product.
             return [
                 CourseSerializer(
                     instance.product.content_object.course,
@@ -67,6 +68,8 @@ class ProductVersionSerializer(serializers.ModelSerializer):
                 program=instance.product.content_object
             ).order_by("position_in_program")
 
+            # filter_products=False because we want to show course runs even if they don't have
+            # products, since the product is for the program.
             return CourseSerializer(
                 courses, many=True, context={**self.context, "filter_products": False}
             ).data

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -56,17 +56,22 @@ class ProductVersionSerializer(serializers.ModelSerializer):
 
         model_class = instance.product.content_type.model_class()
         if model_class is CourseRun:
-            courses = [instance.product.content_object.course]
+            return [
+                CourseSerializer(
+                    instance.product.content_object.course,
+                    context={**self.context, "filter_products": True},
+                ).data
+            ]
         elif model_class is Program:
             courses = Course.objects.filter(
                 program=instance.product.content_object
             ).order_by("position_in_program")
+
+            return CourseSerializer(
+                courses, many=True, context={**self.context, "filter_products": False}
+            ).data
         else:
             raise ValueError(f"Unexpected product for {model_class}")
-
-        return [
-            CourseSerializer(course, context=self.context).data for course in courses
-        ]
 
     def get_thumbnail_url(self, instance):
         """Return the thumbnail for the courserun or program"""
@@ -227,6 +232,36 @@ class CouponSerializer(serializers.ModelSerializer):
         model = models.Coupon
 
 
+def _serialize_item(*, item, basket, context):
+    """
+    Serialize a BasketItem
+
+    Args:
+        item (BasketItem): A basket item
+        basket (Basket): A basket
+        context (dict): Context from the BasketSerializer
+
+    Returns:
+        dict:
+            A serialized representation
+    """
+    serialized_product_version = ProductVersionSerializer(
+        instance=latest_product_version(item.product), context=context
+    ).data
+    valid_run_ids = set()
+    for course in serialized_product_version["courses"]:
+        for run in course["courseruns"]:
+            valid_run_ids.add(run["id"])
+    run_ids = [
+        run_id
+        for run_id in models.CourseRunSelection.objects.filter(
+            basket=basket
+        ).values_list("run", flat=True)
+        if run_id in valid_run_ids
+    ]
+    return {**serialized_product_version, "run_ids": run_ids}
+
+
 class BasketSerializer(serializers.ModelSerializer):
     """Basket model serializer"""
 
@@ -237,16 +272,7 @@ class BasketSerializer(serializers.ModelSerializer):
     def get_items(self, instance):
         """ Get the basket items """
         return [
-            {
-                **ProductVersionSerializer(
-                    instance=latest_product_version(item.product), context=self.context
-                ).data,
-                "run_ids": list(
-                    models.CourseRunSelection.objects.filter(
-                        basket=instance
-                    ).values_list("run", flat=True)
-                ),
-            }
+            _serialize_item(item=item, basket=instance, context=self.context)
             for item in instance.basketitems.all()
         ]
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -261,8 +261,9 @@ class BasketSerializer(serializers.ModelSerializer):
         ).data
         valid_run_ids = set()
         for course in serialized_product_version["courses"]:
-            for run in course["courseruns"]:
-                valid_run_ids.add(run["id"])
+            valid_run_ids = valid_run_ids.union(
+                {run["id"] for run in course["courseruns"]}
+            )
         run_ids = list(
             models.CourseRunSelection.objects.filter(
                 basket=basket, run_id__in=valid_run_ids

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -260,13 +260,11 @@ class BasketSerializer(serializers.ModelSerializer):
         for course in serialized_product_version["courses"]:
             for run in course["courseruns"]:
                 valid_run_ids.add(run["id"])
-        run_ids = [
-            run_id
-            for run_id in models.CourseRunSelection.objects.filter(
-                basket=basket
+        run_ids = list(
+            models.CourseRunSelection.objects.filter(
+                basket=basket, run_id__in=valid_run_ids
             ).values_list("run", flat=True)
-            if run_id in valid_run_ids
-        ]
+        )
         return {**serialized_product_version, "run_ids": run_ids}
 
     def get_items(self, instance):

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -179,12 +179,16 @@ def test_serialize_basket_data_consents(basket_and_agreement, mock_context):
     }
 
 
-def test_serialize_basket(basket_and_agreement, mock_context):
+@pytest.mark.parametrize("is_live", [True, False])
+def test_serialize_basket(basket_and_agreement, mock_context, is_live):
     """Test Basket serialization"""
     basket = basket_and_agreement.basket
     selection = CouponSelection.objects.get(basket=basket)
     run = CourseRunSelection.objects.get(basket=basket).run
     data_consent = DataConsentUser.objects.get(user=basket.user)
+    run.live = is_live
+    run.save()
+
     data = BasketSerializer(instance=basket, context=mock_context).data
     assert data == {
         "items": [
@@ -193,7 +197,7 @@ def test_serialize_basket(basket_and_agreement, mock_context):
                     instance=basket_and_agreement.product.latest_version,
                     context=mock_context,
                 ).data,
-                "run_ids": [run.id],
+                "run_ids": [run.id] if is_live else [],
             }
         ],
         "coupons": [CouponSelectionSerializer(selection).data],


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1307 

#### What's this PR do?
Adds logic to filter out invalid selected runs from the basket API. This fixes the issue because when checkout happens, the basket is first patched with the new list of run ids, which now excludes the invalid one.

#### How should this be manually tested?
To reproduce on master:
 - Go to the checkout page for a program product
 - Select course runs in a program and attempt to checkout. You should see the Cybersource form. Don't fill it out, we don't need to fulfill the order.
 - Make a course run invalid in some way. Setting `live=False` is probably easiest, or change the dates so it is invalid.
 - Go to /checkout, select some runs, and click "Place your order". You should see a validation error "Only one run per course can be selected"

Check out this branch and repeat the above steps. You should not see the validation error anymore.
