### PR TITLE
Not check for expired run if there is --force flag

### DIFF
--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -61,7 +61,7 @@ class Command(EnrollmentChangeCommand):
                     from_run.course.title, to_run.course.title
                 )
             )
-        elif not to_run.is_unexpired:
+        elif not to_run.is_unexpired and not options["force"]:
             raise CommandError("'to' run is expired")
 
         from_enrollment = CourseRunEnrollment.all_objects.get(user=user, run=from_run)

--- a/courses/management/commands/transfer_enrollment.py
+++ b/courses/management/commands/transfer_enrollment.py
@@ -28,6 +28,9 @@ class Command(EnrollmentChangeCommand):
             help="The id, email, or username of the User to whom the enrollment will be transferred",
             required=True,
         )
+        parser.add_argument(
+            "--order", type=str, help="The 'order_id' value for an user's order ID."
+        )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
             "--program",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes #1234 
fixes #1256

#### What's this PR do?
Allow learners to be tranfered or enrolled into expired course runs 

#### How should this be manually tested?
Try to run defer an user to an expired course run. Should not check for expired run if `--f` flag is there.

`./manage.py defer_enrollment`
