### PR TITLE
#1246 sync course runs from edx

### DIFF
--- a/app.json
+++ b/app.json
@@ -59,6 +59,14 @@
       "description": "ID of the Google Sheet that contains requests for coupons",
       "required": false
     },
+    "CRON_COURSERUN_SYNC_DAYS": {
+      "description": "'day_of_week' value for 'sync-courseruns-data' scheduled task (default will run once a day).",
+      "required": false
+    },
+    "CRON_COURSERUN_SYNC_HOURS": {
+      "description": "'hours' value for the 'sync-courseruns-data' scheduled task (defaults to midnight)",
+      "required": false
+    },
     "CRON_COURSE_CERTIFICATES_DAYS": {
       "description": "'day_of_week' value for 'generate-course-certificate' scheduled task (default will run once a day).",
       "required": false
@@ -347,13 +355,13 @@
       "description": "The base redirect URL for an OAuth Application for the Open edX API",
       "required": false
     },
-    "OPENEDX_GRADES_API_TOKEN": {
-      "description": "Access token to use with OpenEdX API client for syncing grades",
-      "required": false
-    },
     "OPENEDX_OAUTH_APP_NAME": {
       "description": "The 'name' value for the Open edX OAuth Application",
       "required": true
+    },
+    "OPENEDX_SERVICE_WORKER_API_TOKEN": {
+      "description": "Active access token with staff level permissions to use with OpenEdX API client for service tasks",
+      "required": false
     },
     "OPENEDX_TOKEN_EXPIRES_HOURS": {
       "description": "The number of hours until an access token for the Open edX API expires",

--- a/courses/management/commands/sync_courseruns.py
+++ b/courses/management/commands/sync_courseruns.py
@@ -1,0 +1,53 @@
+"""
+Management command to sync dates and title for all or a specific course run from edX
+"""
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from courses.models import CourseRun
+from courses.utils import sync_course_runs
+from mitxpro.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """
+    Command to sync course run dates and title from edX.
+    """
+
+    help = "Sync dates and title for all or a specific course run from edX."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--run",
+            type=str,
+            help="The 'courseware_id' value for a CourseRun",
+            required=False,
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # pylint: disable=too-many-locals
+        """Handle command execution"""
+        runs = []
+        if options["run"]:
+            try:
+                runs = [CourseRun.objects.get(courseware_id=options["run"])]
+            except CourseRun.DoesNotExist:
+                raise CommandError(
+                    "Could not find run with courseware_id={}".format(options["run"])
+                )
+        else:
+            # We pick up all the course runs that do not have an expiration date (implies not having
+            # an end_date) or those that are not expired yet, in case the user has not specified any
+            # course run id.
+            now = now_in_utc()
+            runs = CourseRun.objects.live().filter(
+                Q(expiration_date__isnull=True) | Q(expiration_date__gt=now)
+            )
+
+        success_count, error_count = sync_course_runs(runs)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Sync complete: {success_count} updated, {error_count} failures"
+            )
+        )

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -375,6 +375,39 @@ def get_edx_api_client(user, ttl_in_seconds=OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS)
     )
 
 
+def get_edx_api_service_client():
+    """
+    Gets an edx api client instance for the service worker user
+
+    Returns:
+         EdxApi: edx api service worker client instance
+    """
+    if settings.OPENEDX_SERVICE_WORKER_API_TOKEN is None:
+        raise ImproperlyConfigured("OPENEDX_SERVICE_WORKER_API_TOKEN is not set")
+
+    edx_client = EdxApi(
+        {
+            "access_token": settings.OPENEDX_SERVICE_WORKER_API_TOKEN,
+            "api_key": settings.OPENEDX_API_KEY,
+        },
+        settings.OPENEDX_API_BASE_URL,
+        timeout=settings.EDX_API_CLIENT_TIMEOUT,
+    )
+
+    return edx_client
+
+
+def get_edx_api_course_detail_client():
+    """
+    Gets an edx api client instance for use with the grades api
+
+    Returns:
+        CourseDetails: edx api course client instance
+    """
+    edx_client = get_edx_api_service_client()
+    return edx_client.course_detail
+
+
 def get_edx_api_grades_client():
     """
     Gets an edx api client instance for use with the grades api
@@ -382,18 +415,7 @@ def get_edx_api_grades_client():
     Returns:
         UserCurrentGrades: edx api grades client instance
     """
-    if settings.OPENEDX_GRADES_API_TOKEN is None:
-        raise ImproperlyConfigured("OPENEDX_GRADES_API_TOKEN is not set")
-
-    edx_client = EdxApi(
-        {
-            "access_token": settings.OPENEDX_GRADES_API_TOKEN,
-            "api_key": settings.OPENEDX_API_KEY,
-        },
-        settings.OPENEDX_API_BASE_URL,
-        timeout=settings.EDX_API_CLIENT_TIMEOUT,
-    )
-
+    edx_client = get_edx_api_service_client()
     return edx_client.current_grades
 
 

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -664,6 +664,17 @@ CRON_COURSE_CERTIFICATES_DAYS = get_string(
     None,
     description="'day_of_week' value for 'generate-course-certificate' scheduled task (default will run once a day).",
 )
+CRON_COURSERUN_SYNC_HOURS = get_string(
+    "CRON_COURSERUN_SYNC_HOURS",
+    0,
+    description="'hours' value for the 'sync-courseruns-data' scheduled task (defaults to midnight)",
+)
+CRON_COURSERUN_SYNC_DAYS = get_string(
+    "CRON_COURSERUN_SYNC_DAYS",
+    None,
+    description="'day_of_week' value for 'sync-courseruns-data' scheduled task (default will run once a day).",
+)
+
 
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
@@ -735,6 +746,16 @@ CELERY_BEAT_SCHEDULE = {
             minute=0,
             hour=CRON_COURSE_CERTIFICATES_HOURS,
             day_of_week=CRON_COURSE_CERTIFICATES_DAYS or "*",
+            day_of_month="*",
+            month_of_year="*",
+        ),
+    },
+    "sync-courseruns-data": {
+        "task": "courses.tasks.sync_courseruns_data",
+        "schedule": crontab(
+            minute=0,
+            hour=CRON_COURSERUN_SYNC_HOURS,
+            day_of_week=CRON_COURSERUN_SYNC_DAYS or "*",
             day_of_month="*",
             month_of_year="*",
         ),
@@ -891,10 +912,10 @@ MITXPRO_REGISTRATION_ACCESS_TOKEN = get_string(
     description="Access token to secure Open edX registration API with",
 )
 
-OPENEDX_GRADES_API_TOKEN = get_string(
-    "OPENEDX_GRADES_API_TOKEN",
+OPENEDX_SERVICE_WORKER_API_TOKEN = get_string(
+    "OPENEDX_SERVICE_WORKER_API_TOKEN",
     None,
-    "Access token to use with OpenEdX API client for syncing grades",
+    "Active access token with staff level permissions to use with OpenEdX API client for service tasks",
 )
 EDX_API_CLIENT_TIMEOUT = get_int(
     "EDX_API_CLIENT_TIMEOUT",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#1246 

#### What's this PR do?
Adds a management command (scheduled task to be included as well) that allows syncing course run information from Open edX instance for any course runs that exist on the xPRO side. Information that is fetched and updated is:
- title
- start date
- end date
- enrollment start date
- enrollment end date


#### How should this be manually tested?
Run the management command:
`docker-compose exec web python manage.py sync_courseruns`