### PR TITLE
make Firefox Certificate print stylesheet makes page elements size identical to Chrome

### DIFF
--- a/static/scss/certificates/certificate.scss
+++ b/static/scss/certificates/certificate.scss
@@ -1,4 +1,5 @@
 // sass-lint:disable mixins-before-declarations
+// sass-lint:disable no-vendor-prefixes
 
 $gray-light: #d9e0e3;
 $text-gray-dark: #6b6969;
@@ -381,6 +382,14 @@ $text-gray-light: #d2d0d1;
           font-size: 11px;
         }
       }
+    }
+  }
+
+  @supports (-moz-appearance: meterbar) {
+    .certificate-page {
+      position: absolute !important;
+      left: 0px !important;
+      -moz-transform: scale(1.1);
     }
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What's this PR do?
fixes #1302 

#### How should this be manually tested?
(Required)

#### Screenshots 
**EARLIER**

![Screenshot from 2019-11-15 18-56-46](https://user-images.githubusercontent.com/4043989/68952084-10da4f00-07e1-11ea-9fc3-6dd3c85566b6.png)

**NOW**

![Screenshot from 2019-11-15 19-43-26](https://user-images.githubusercontent.com/4043989/68952120-23ed1f00-07e1-11ea-9782-6feb2410bee8.png)

**FIREFOX**

![Screenshot from 2019-11-15 19-54-10](https://user-images.githubusercontent.com/4043989/68952663-0bc9cf80-07e2-11ea-9d07-28c6e3b9db98.png)


**CHROME**

![Screenshot from 2019-11-15 19-54-23](https://user-images.githubusercontent.com/4043989/68952671-0f5d5680-07e2-11ea-9b76-410c0d3aef2d.png)
