### PR TITLE
Changed coupon assignment sheet handling to fetch one at a time

### DIFF
--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -28,8 +28,10 @@ def handle_incomplete_coupon_assignments():
     Processes all as-yet-incomplete coupon assignment spreadsheets
     """
     coupon_assignment_handler = CouponAssignmentHandler()
-    spreadsheets = coupon_assignment_handler.process_assignment_spreadsheets()
-    return [(spreadsheet.id, spreadsheet.title) for spreadsheet in spreadsheets]
+    processed_spreadsheet_metadata = (
+        coupon_assignment_handler.process_assignment_spreadsheets()
+    )
+    return processed_spreadsheet_metadata
 
 
 @app.task


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket – this was noticed while testing on RC

#### What's this PR do?
When coupon assignment spreadsheets are fetched and processed to create new coupon assignments, those spreadsheets are now fetched and loaded into memory one at a time.

#### How should this be manually tested?
I tested this using ngrok locally. Further functional testing can be done on RC

#### Any background context you want to provide?
This is the library method that was being used to fetch spreadsheet data before this PR: https://github.com/nithinmurali/pygsheets/blob/staging/pygsheets/client.py#L160-L170. It fetches all of the spreadsheets that match a query and immediately creates object representations of all of them in memory. This was causing issues with worker memory in RC. Loading/serializing these objects one-by-one should help with that memory issue
