### PR TITLE
Add product_id to hubspot line item

### DIFF
--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -180,7 +180,15 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                         "hidden": False,
                     },
                 ],
-            }
+            },
+            {
+                "name": "product_id",
+                "label": "Product Id",
+                "description": "The product id of the latest product version",
+                "groupName": "lineiteminformation",
+                "type": "string",
+                "fieldType": "text",
+            },
         ],
     },
 }
@@ -394,6 +402,11 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
             {
                 "propertyName": "status",
                 "targetHubspotProperty": "status",
+                "dataType": "STRING",
+            },
+            {
+                "propertyName": "product_id",
+                "targetHubspotProperty": "product_id",
                 "dataType": "STRING",
             },
         ]

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -25,6 +25,7 @@ class LineSerializer(serializers.ModelSerializer):
     product = serializers.SerializerMethodField()
     order = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
+    product_id = serializers.SerializerMethodField()
 
     def get_order(self, instance):
         """ Get the order id and return the hubspot deal integratorObject id"""
@@ -38,8 +39,14 @@ class LineSerializer(serializers.ModelSerializer):
         """ Get status of the associated Order """
         return instance.order.status
 
+    def get_product_id(self, instance):
+        """Return the product version text_id"""
+        if instance.product_version:
+            return instance.product_version.text_id
+        return ""
+
     class Meta:
-        fields = ("id", "product", "order", "quantity", "status")
+        fields = ("id", "product", "order", "quantity", "status", "product_id")
         model = models.Line
 
 

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -63,6 +63,7 @@ def test_serialize_line():
         "order": format_hubspot_id(line.order_id),
         "quantity": line.quantity,
         "status": line.order.status,
+        "product_id": line.product_version.text_id,
     }
 
 


### PR DESCRIPTION
You will need to run the management command `configure_hubspot_bridge` on production before these changes take effect.
To backfill data, run the management command `sync_hubspot`.

#### What are the relevant tickets?
closes #1352 

#### What's this PR do?
This PR adds product_id to the hubspot line item

#### How should this be manually tested?
1. Create an ecommerce Line (easiest way is with a factory).
2. Sync the Line, Order, Purchaser, Product with hubspot (run the sync_hubspot management command)
3. Find the Order associated with the line in the hubspot deal interface and note down the Deal Id (its in the URL)
4. Send a get request to `https://api.hubapi.com/crm-associations/v1/associations/{deal_id}/HUBSPOT_DEFINED/19?hapikey={settings.HUBSPOT_API_KEY}`. This will return the ids of the line items associated with the deal.
5. Then send a get request to 
`https://api.hubapi.com/crm-objects/v1/objects/line_items/{line_item_id}?hapikey={settings.HUBSPOT_API_KEY}&properties=product_id`. This will return data associated with the line item you created.
6. Check that the product_id field is properly filled in the response.