### PR TITLE
Fixed file watch bug and added management command options

### DIFF
--- a/sheets/management/commands/setup_request_sheet_file_watch.py
+++ b/sheets/management/commands/setup_request_sheet_file_watch.py
@@ -2,9 +2,11 @@
 Makes a request to receive push notifications when the coupon request Sheet is updated.
 """
 from django.core.management import BaseCommand
+from django.conf import settings
+
 from googleapiclient.errors import HttpError
 
-from sheets.api import renew_coupon_request_file_watch
+from sheets.api import renew_coupon_request_file_watch, request_file_watch
 
 
 class Command(BaseCommand):
@@ -14,9 +16,30 @@ class Command(BaseCommand):
 
     help = __doc__
 
+    def add_arguments(self, parser):  # pylint:disable=missing-docstring
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--confirm",
+            action="store_true",
+            help=(
+                "Make the request to create the file watch via API even if our local file watch "
+                "record is unexpired. Uses the same dates and channel ID as the existing record."
+            ),
+        )
+        group.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Make the request to create a new file watch via API and overwrite any existing "
+                "file watch record."
+            ),
+        )
+
     def handle(self, *args, **options):  # pylint:disable=missing-docstring
         try:
-            file_watch, created, updated = renew_coupon_request_file_watch()
+            file_watch, created, updated = renew_coupon_request_file_watch(
+                force=options["force"]
+            )
         except HttpError as exc:
             self.stdout.write(
                 self.style.ERROR(
@@ -25,6 +48,7 @@ class Command(BaseCommand):
                     )
                 )
             )
+            exit(1)
         else:
             if created:
                 desc = "created"
@@ -34,6 +58,45 @@ class Command(BaseCommand):
                 desc = "found (unexpired)"
             self.stdout.write(
                 self.style.SUCCESS(
-                    "Coupon request sheet file watch {}:\n{}".format(desc, file_watch)
+                    "Coupon request sheet file watch {}.\n{}".format(desc, file_watch)
                 )
             )
+
+            if not created and not updated and options["confirm"]:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "\n--confirm flag provided, so an API request will now be made to create a file watch "
+                        "that matches the file watch record in the database..."
+                    )
+                )
+                try:
+                    resp_dict = request_file_watch(
+                        settings.COUPON_REQUEST_SHEET_ID,
+                        file_watch.channel_id,
+                        expiration=file_watch.expiration_date,
+                    )
+                except HttpError as exc:
+                    existing_channel_id_message = "Channel id {} not unique".format(
+                        file_watch.channel_id
+                    )
+                    if existing_channel_id_message in str(exc):
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                "The file watch with channel id {} already exists.".format(
+                                    file_watch.channel_id
+                                )
+                            )
+                        )
+                    else:
+                        self.stdout.write(
+                            self.style.ERROR("Request failed: {}".format(exc))
+                        )
+                        exit(1)
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "New file watch successfully created via API.\n Response: {}".format(
+                                resp_dict
+                            )
+                        )
+                    )

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -50,5 +50,5 @@ def renew_file_watches():
     """
     Renews push notifications for changes to certain files via the Google API.
     """
-    file_watch, created = api.renew_coupon_request_file_watch()
+    file_watch, created, _ = api.renew_coupon_request_file_watch()
     return file_watch.id, file_watch.channel_id, created


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. This fixes a bug found on RC

#### What's this PR do?
- Fixes a bug where the channel ID of a file watch record in the database was not being updated when a new file watch was created via API. This resulted in file watch requests from Google being incorrectly rejected for having the wrong channel ID.
- Fixes a bug in the the task to renew the file watch (forgot to change the number of values to unpack from an API method)
- Adds a couple options to the file watch management command to help us address situations where the file watch isn't working as expected.

#### How should this be manually tested?
Code review only. I tested this locally with ngrok, and this will be tested further in RC
