### PR TITLE
Disable server-side cursors by default to avoid invalid cursor errors

### DIFF
--- a/app.json
+++ b/app.json
@@ -267,6 +267,10 @@
       "description": "Disables SSL to postgres if set to True",
       "required": false
     },
+    "MITXPRO_DB_DISABLE_SS_CURSORS": {
+      "description": "Disable server-side cursors",
+      "required": false
+    },
     "MITXPRO_EMAIL_BACKEND": {
       "description": null,
       "required": false

--- a/app.json
+++ b/app.json
@@ -268,7 +268,7 @@
       "required": false
     },
     "MITXPRO_DB_DISABLE_SS_CURSORS": {
-      "description": "Disable server-side cursors",
+      "description": null,
       "required": false
     },
     "MITXPRO_EMAIL_BACKEND": {

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -260,6 +260,7 @@ DEFAULT_DATABASE_CONFIG["CONN_MAX_AGE"] = get_int(
     0,
     description="Maximum age of connection to Postgres in seconds",
 )
+# If True, disables server-side database cursors to prevent invalid cursor errors when using pgbouncer
 DEFAULT_DATABASE_CONFIG["DISABLE_SERVER_SIDE_CURSORS"] = get_bool(
     "MITXPRO_DB_DISABLE_SS_CURSORS", True
 )

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -260,6 +260,10 @@ DEFAULT_DATABASE_CONFIG["CONN_MAX_AGE"] = get_int(
     0,
     description="Maximum age of connection to Postgres in seconds",
 )
+DEFAULT_DATABASE_CONFIG["DISABLE_SERVER_SIDE_CURSORS"] = get_bool(
+    "MITXPRO_DB_DISABLE_SS_CURSORS", True
+)
+
 
 if get_bool(
     "MITXPRO_DB_DISABLE_SSL",

--- a/mitxpro/settings_test.py
+++ b/mitxpro/settings_test.py
@@ -166,21 +166,18 @@ class TestSettings(TestCase):
 
     def test_server_side_cursors_disabled(self):
         """DISABLE_SERVER_SIDE_CURSORS should be true by default"""
-        with mock.patch.dict("os.environ", REQUIRED_SETTINGS):
-            settings_vars = self.reload_settings()
-            assert (
-                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
-                is True
-            )
+        settings_vars = self.patch_settings(REQUIRED_SETTINGS)
+        assert (
+            settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
+            is True
+        )
 
     def test_server_side_cursors_enabled(self):
         """DISABLE_SERVER_SIDE_CURSORS should be false if MITXPRO_DB_DISABLE_SS_CURSORS is false"""
-        with mock.patch.dict(
-            "os.environ",
-            {**REQUIRED_SETTINGS, "MITXPRO_DB_DISABLE_SS_CURSORS": "False"},
-        ):
-            settings_vars = self.reload_settings()
-            assert (
-                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
-                is False
-            )
+        settings_vars = self.patch_settings(
+            {**REQUIRED_SETTINGS, "MITXPRO_DB_DISABLE_SS_CURSORS": "False"}
+        )
+        assert (
+            settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
+            is False
+        )

--- a/mitxpro/settings_test.py
+++ b/mitxpro/settings_test.py
@@ -163,3 +163,24 @@ class TestSettings(TestCase):
         assert json.dumps(app_json, sort_keys=True, indent=2) == json.dumps(
             generated_app_json, sort_keys=True, indent=2
         ), "Generated app.json does not match the app.json file. Please use the 'generate_app_json' management command to update app.json"
+
+    def test_server_side_cursors_disabled(self):
+        """DISABLE_SERVER_SIDE_CURSORS should be true by default"""
+        with mock.patch.dict("os.environ", REQUIRED_SETTINGS):
+            settings_vars = self.reload_settings()
+            assert (
+                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
+                is True
+            )
+
+    def test_server_side_cursors_enabled(self):
+        """DISABLE_SERVER_SIDE_CURSORS should be false if MITXPRO_DB_DISABLE_SS_CURSORS is false"""
+        with mock.patch.dict(
+            "os.environ",
+            {**REQUIRED_SETTINGS, "MITXPRO_DB_DISABLE_SS_CURSORS": "False"},
+        ):
+            settings_vars = self.reload_settings()
+            assert (
+                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
+                is False
+            )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Similar to #902

#### What's this PR do?
Disables server-side cursors by default, because they can cause invalid cursor errors when query iterators are used in conjunction with pgbouncer.  Adds an optional .env setting to override this.

#### How should this be manually tested?
- Nothing should break and tests should pass.

#### Any background context you want to provide?
https://code.djangoproject.com/ticket/28062
