### PR TITLE
asadiqbal08/Display correct course name over receipt email

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -220,6 +220,9 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                             user=None,
                             extra_context={
                                 "coupon": coupon,
+                                "content_title": lines[0].get("content_title")
+                                if lines
+                                else None,
                                 "lines": lines,
                                 "order_total": sum(
                                     int(line["total_paid"]) for line in lines

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -233,6 +233,7 @@ def test_send_ecommerce_order_receipt(mocker, receipt_data):
         user=None,
         extra_context={
             "coupon": None,
+            "content_title": "test_run_title",
             "lines": [
                 {
                     "quantity": 1,

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -5,7 +5,7 @@
     <table style="margin: 0 20px !important;">
     <td class="rec-head" style="color: rgba(0,0,0,0.85); font: 14px/20px 'Arial', sans-serif; max-width: 696px; ">
         <p style="font-weight: normal; margin: 0 0 20px;">Dear {{ purchaser.name }},</p>
-        <p style="font-weight: normal; margin: 0 0 20px;">You have been enrolled in Negotiating and Applying Influence and Power.
+        <p style="font-weight: normal; margin: 0 0 20px;">You have been enrolled {% if content_title %} in {{ content_title }}{% endif %}.
             The course should now appear on your MIT xPRO <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}/receipt/{{order.id }}">clicking here</a>.
         </p>
         <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of you receipt:</p>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#1410 

#### What's this PR do?
Display the course/content title properly in email body. 

#### How should this be manually tested?
Enable the receipt feature flag
Purchase a course/program
email should be sent with proper course title.

