### PR TITLE
#1404 display readable id when selecting courseware in cms pages

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -241,7 +241,8 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         )
 
     def __str__(self):
-        return self.title
+        title = f"{self.readable_id} | {self.title}"
+        return title if len(title) <= 100 else title[:97] + "..."
 
 
 class CourseTopic(TimestampedModel):
@@ -393,7 +394,8 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         return super().save(*args, **kwargs)
 
     def __str__(self):
-        return self.title
+        title = f"{self.readable_id} | {self.title}"
+        return title if len(title) <= 100 else title[:97] + "..."
 
 
 class CourseRun(TimestampedModel):
@@ -495,7 +497,8 @@ class CourseRun(TimestampedModel):
         return self.course.instructors
 
     def __str__(self):
-        return self.title
+        title = f"{self.courseware_id} | {self.title}"
+        return title if len(title) <= 100 else title[:97] + "..."
 
     def clean(self):
         """


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1404 

#### What's this PR do?
Displays product's readable id when selecting the connected course/program for a `CoursePage`/`ProgramPage` in CMS.

#### How should this be manually tested?
Go to the CMS to add/edit any `ProgramPage` or `CoursePage`. The course/program drop down should display the readable id as well as the title.

#### Screenshots (if appropriate)
![Screenshot from 2019-12-16 16-39-11](https://user-images.githubusercontent.com/45350418/70904630-a99ffc80-2023-11ea-85e3-90f93d0b462c.png)
![Screenshot from 2019-12-16 16-38-38](https://user-images.githubusercontent.com/45350418/70904631-a99ffc80-2023-11ea-91f1-6c04471d7151.png)
