### PR TITLE
Added setting for overriding host used in SSL redirect

### DIFF
--- a/app.json
+++ b/app.json
@@ -331,6 +331,10 @@
       "description": "E-mail to use for reply-to address of emails",
       "required": false
     },
+    "MITXPRO_SECURE_SSL_HOST": {
+      "description": "Hostame to redirect non-secure requests to. Overrides value from HOST header.",
+      "required": false
+    },
     "MITXPRO_SECURE_SSL_REDIRECT": {
       "description": "Application-level SSL redirect setting.",
       "required": false

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -73,6 +73,13 @@ SECURE_SSL_REDIRECT = get_bool(
     description="Application-level SSL redirect setting.",
 )
 
+SECURE_SSL_HOST = get_string(
+    "MITXPRO_SECURE_SSL_HOST",
+    None,
+    description="Hostame to redirect non-secure requests to. "
+    "Overrides value from HOST header.",
+)
+
 ZENDESK_CONFIG = {
     "HELP_WIDGET_ENABLED": get_string(
         "ZENDESK_HELP_WIDGET_ENABLED",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
N/A

#### What's this PR do?
With the introduction of Fastly to production the `HOST` header isn't the actual domain that we want SSL redirects sent to. Adding override of that value through an environment variable.