### PR TITLE
js test debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       /bin/bash -c './webpack_dev_server.sh --install'
     ports:
       - "8052:8052"
+      - "9229:9229"
     environment:
       NODE_ENV: 'production'
       DOCKER_HOST: ${DOCKER_HOST:-missing}

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -10,6 +10,9 @@ then
 elif [[ ! -z "$WATCH" ]]
 then
     export CMD="node ./node_modules/mocha/bin/_mocha --watch"
+elif [[ ! -z "$DEBUG" ]]
+then
+    export CMD="node --inspect-brk=0.0.0.0:9229 ./node_modules/mocha/bin/_mocha"
 else
     export CMD="node ./node_modules/mocha/bin/_mocha"
 fi


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
- update docker-compose file for js test debugging

#### How should this be manually tested?
- try running js tests with `DEBUG=true`
- add debugger in a code
- e.g `DEBUG=true ./scripts/test/js_test.sh static/js/containers/pages/b2b/B2BPurchasePage_test.js`
- debugger should start
- go to chrome browser
- run `chrome://inspect`

**NOTE:** I am not sure if this is a best way to debug js tests locally. If you have any better/easier solution to this, please share it.