### PR TITLE
#1395 Delay automated certificate creation by a number of hours

### DIFF
--- a/app.json
+++ b/app.json
@@ -51,6 +51,10 @@
       "description": null,
       "required": false
     },
+    "CERTIFICATE_CREATION_DELAY_IN_HOURS": {
+      "description": "The number of hours to delay automated certificate creation after a course run ends.",
+      "required": false
+    },
     "CLOUDFRONT_DIST": {
       "description": null,
       "required": false

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -2,6 +2,8 @@
 Tasks for the courses app
 """
 import logging
+from datetime import timedelta
+from django.conf import settings
 from django.db.models import Q
 from requests.exceptions import HTTPError
 from mitxpro.celery import app
@@ -23,7 +25,9 @@ def generate_course_certificates():
     Task to generate certificates for courses.
     """
     now = now_in_utc()
-    course_runs = CourseRun.objects.filter(end_date__lt=now).exclude(
+    course_runs = CourseRun.objects.filter(
+        end_date__lt=now - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
+    ).exclude(
         id__in=CourseRunCertificate.objects.values_list("course_run__id", flat=True)
     )
 

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -642,6 +642,12 @@ FEATURES = {
     if key.startswith(MITXPRO_FEATURES_PREFIX)
 }
 
+CERTIFICATE_CREATION_DELAY_IN_HOURS = get_int(
+    "CERTIFICATE_CREATION_DELAY_IN_HOURS",
+    48,
+    description="The number of hours to delay automated certificate creation after a course run ends.",
+)
+
 # Celery
 USE_CELERY = True
 REDISCLOUD_URL = get_string(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Fixes #1395 

#### What's this PR do?
Adds a `CERTIFICATE_CREATION_DELAY_IN_HOURS` environment variable which defines how long (in number of hours) is the automated certificate creation delayed for all courses.

#### How should this be manually tested?
Have course runs end less than the configured (default: 48) delay from current time. Run the task. The task should exclude all course runs that have ended more recent than the delay period.