### PR TITLE
Added batch Drive file sharing

### DIFF
--- a/sheets/api_test.py
+++ b/sheets/api_test.py
@@ -67,6 +67,7 @@ def pygsheets_fixtures(mocker, db, coupon_req_raw_data):
     mocked_spreadsheet = MagicMock(spec=Spreadsheet, sheet1=mocked_worksheet)
     mocked_pygsheets_client = MagicMock(
         spec=PygsheetsClient,
+        oauth=Mock(),
         open_by_key=Mock(return_value=mocked_spreadsheet),
         drive=MagicMock(spec=DriveAPIWrapper),
         sheet=MagicMock(spec=SheetAPIWrapper),
@@ -365,7 +366,7 @@ def test_coupon_req_handler_update_processed(
         processed_requests
     )
     pygsheets_fixtures.worksheet.update_values.assert_any_call(
-        crange="H2:I2",
+        crange="I2:J2",
         values=[
             [
                 format_datetime_for_sheet_formula(
@@ -376,7 +377,7 @@ def test_coupon_req_handler_update_processed(
         ],
     )
     pygsheets_fixtures.worksheet.update_values.assert_any_call(
-        crange="H3:I3",
+        crange="I3:J3",
         values=[
             [
                 format_datetime_for_sheet_formula(

--- a/sheets/conftest.py
+++ b/sheets/conftest.py
@@ -10,6 +10,28 @@ from ecommerce.factories import CompanyFactory, ProductVersionFactory
 from sheets.utils import CouponRequestRow
 
 
+@pytest.fixture(autouse=True)
+def sheets_settings(settings):
+    """Default settings for sheets tests"""
+    settings.FEATURES["COUPON_SHEETS"] = True
+    settings.FEATURES["COUPON_SHEETS_TRACK_REQUESTER"] = True
+    settings.SHEETS_REQ_EMAIL_COL = 7
+    settings.SHEETS_REQ_PROCESSED_COL = 8
+    settings.SHEETS_REQ_ERROR_COL = 9
+    settings.SHEETS_REQ_CALCULATED_COLUMNS = {
+        settings.SHEETS_REQ_EMAIL_COL,
+        settings.SHEETS_REQ_PROCESSED_COL,
+        settings.SHEETS_REQ_ERROR_COL,
+    }
+    _uppercase_a_ord = ord("A")
+    settings.SHEETS_REQ_PROCESSED_COL_LETTER = chr(
+        settings.SHEETS_REQ_PROCESSED_COL + _uppercase_a_ord
+    )
+    settings.SHEETS_REQ_ERROR_COL_LETTER = chr(
+        settings.SHEETS_REQ_ERROR_COL + _uppercase_a_ord
+    )
+
+
 @pytest.fixture()
 def base_data(db):  # pylint: disable=unused-argument
     """Fixture that creates basic objects that are necessary to support a coupon request"""
@@ -32,6 +54,7 @@ def coupon_req_raw_data(base_data):
         base_data.company.name,
         "01/01/2019 01:01:01",
         "02/02/2020 02:02:02",
+        "",
         "",
         "",
     ]

--- a/sheets/exceptions.py
+++ b/sheets/exceptions.py
@@ -47,3 +47,9 @@ class InvalidSheetProductException(Exception):
     """
     Exception for an invalid product entered into the coupon request spreadsheet
     """
+
+
+class FailedBatchRequestException(Exception):
+    """
+    General exception for a failure during a Google batch API request
+    """

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -18,6 +18,7 @@ from sheets.constants import (
     ASSIGNMENT_SHEET_PREFIX,
     GOOGLE_SHEET_FIRST_ROW,
     ASSIGNMENT_SHEET_ENROLLED_STATUS,
+    GOOGLE_SERVICE_ACCOUNT_EMAIL_DOMAIN,
 )
 from sheets.exceptions import InvalidSheetProductException, SheetRowParsingException
 
@@ -704,3 +705,28 @@ def build_protected_range_request_body(
             }
         }
     }
+
+
+def build_drive_file_email_share_request(file_id, email_to_share):
+    """
+    Builds the body of a Drive file share request
+
+    Args:
+        file_id (str): The file id of the Drive file being shared
+        email_to_share (str): The email of the user to whom the file will be shared
+
+    Returns:
+        dict: A dictionary of parameters for the body of a share request
+    """
+    added_kwargs = (
+        {"sendNotificationEmail": False}
+        if email_to_share.endswith(GOOGLE_SERVICE_ACCOUNT_EMAIL_DOMAIN)
+        else {}
+    )
+    return dict(
+        fileId=file_id,
+        body={"type": "user", "role": "writer", "emailAddress": email_to_share},
+        fields="id",
+        supportsTeamDrives=True,
+        **added_kwargs,
+    )

--- a/sheets/utils_test.py
+++ b/sheets/utils_test.py
@@ -16,7 +16,6 @@ from sheets.utils import CouponRequestRow
 
 def test_generate_google_client_config(settings):
     """generate_google_client_config should return a dict with expected values"""
-    settings.FEATURES["COUPON_SHEETS"] = True
     settings.DRIVE_CLIENT_ID = "some-id"
     settings.DRIVE_CLIENT_SECRET = "some-secret"
     settings.DRIVE_API_PROJECT_ID = "some-project-id"

--- a/sheets/views_test.py
+++ b/sheets/views_test.py
@@ -12,12 +12,6 @@ from mitxpro.test_utils import set_request_session
 lazy = pytest.lazy_fixture
 
 
-@pytest.fixture(autouse=True)
-def auto_settings(settings):
-    """Fixture that sets default settings values for all tests in the module"""
-    settings.FEATURES["COUPON_SHEETS"] = True
-
-
 @pytest.fixture()
 def google_api_auth(user):
     """Fixture that creates a google auth object"""
@@ -112,7 +106,6 @@ def test_handle_coupon_request_sheet_update(mocker, settings):
     View that handles push notifications for file changes in Google should call a task to
     create coupons and write the results to the necessary Sheets.
     """
-    settings.FEATURES["COUPON_SHEETS"] = True
     settings.COUPON_REQUEST_SHEET_ID = "abc123"
     GoogleFileWatchFactory.create(
         file_id=settings.COUPON_REQUEST_SHEET_ID, channel_id="file-watch-channel"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1417 

#### What's this PR do?
Attempts to use Google Drive API batch requests to share coupon assignment sheets with a list of emails, and defaults to individual sharing requests (as we had before) if that fails

#### How should this be manually tested?
Code review only

#### Any background context you want to provide?
There is some detail in the `share_drive_file_with_emails` and `batch_share_callback` function docstrings regarding the decision to attempt a batch share, then default to individual sharing requests if that fails.
