### PR TITLE
Added warning for 'automatic' option in coupon creation form

### DIFF
--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -172,10 +172,6 @@ export const CouponForm = ({
         </div>
 
         <div>
-          <div>
-            <Field type="checkbox" name="automatic" />
-            Automatically apply coupon to eligible products in basket
-          </div>
           <div className="block">
             <label htmlFor="discount">
               Percentage Discount (1 to 100)*
@@ -344,9 +340,26 @@ export const CouponForm = ({
           </label>
           <ErrorMessage name="company" component={FormError} />
         </div>
-        <button type="submit" disabled={isSubmitting}>
-          Create coupons
-        </button>
+        <div className="block">
+          <div className="dangerous">
+            <strong>⚠️WARNING: You probably do not want this option. ⚠️</strong>
+            <br />
+            <br />
+            Enabling this option will automatically apply this code to{" "}
+            <strong>EVERY USER</strong> who purchases this course run/program.
+            In other words, the code will be automatically applied and they will
+            not need to enter any coupon code during checkout.
+          </div>
+          <div className="flex dangerous">
+            <Field type="checkbox" name="automatic" />
+            Automatically apply coupon to eligible products in basket
+          </div>
+        </div>
+        <div>
+          <button type="submit" disabled={isSubmitting}>
+            Create coupons
+          </button>
+        </div>
       </Form>
     )}
   />

--- a/static/scss/ecommerce-admin.scss
+++ b/static/scss/ecommerce-admin.scss
@@ -24,6 +24,10 @@
   div {
     padding-bottom: 20px;
     padding-right: 10px;
+
+    .no-pad {
+      padding: 0;
+    }
   }
 
   input[type='checkbox']   {
@@ -63,5 +67,11 @@
 
   .picky__dropdown {
     z-index: unset;
+  }
+
+  .dangerous {
+    background-color: #ef5350;
+    color: #ffffff;
+    padding: 15px;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
No ticket - this is in response to a mistaken intention of this option in some production coupon codes

#### What's this PR do?
Adds clearer messaging around the 'automatic' option for the bulk coupon creation form

#### How should this be manually tested?
Make sure the form looks reasonable and still works as expected

#### Screenshots (if appropriate)
<img width="1233" alt="ss 2019-12-27 at 16 38 52 " src="https://user-images.githubusercontent.com/14932219/71533632-e7c0da00-28c7-11ea-8c0f-f48608638356.png">
