### PR TITLE
#1418 Fix course run sync from edX

### DIFF
--- a/app.json
+++ b/app.json
@@ -383,6 +383,10 @@
       "description": "Active access token with staff level permissions to use with OpenEdX API client for service tasks",
       "required": false
     },
+    "OPENEDX_SERVICE_WORKER_USERNAME": {
+      "description": "Username of the user whose token has been set in OPENEDX_SERVICE_WORKER_API_TOKEN",
+      "required": false
+    },
     "OPENEDX_TOKEN_EXPIRES_HOURS": {
       "description": "The number of hours until an access token for the Open edX API expires",
       "required": false

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -4,6 +4,7 @@ Utilities for courses/certificates
 import logging
 from requests.exceptions import HTTPError
 from rest_framework.status import HTTP_404_NOT_FOUND
+from django.conf import settings
 from django.db import transaction
 from courses.models import (
     CourseRunGrade,
@@ -225,7 +226,10 @@ def sync_course_runs(runs):
     # Iterate all eligible runs and sync if possible
     for run in runs:
         try:
-            course_detail = api_client.get_detail(run.courseware_id)
+            course_detail = api_client.get_detail(
+                course_id=run.courseware_id,
+                username=settings.OPENEDX_SERVICE_WORKER_USERNAME,
+            )
         except HTTPError as e:
             failure_count += 1
             if e.response.status_code == HTTP_404_NOT_FOUND:

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -940,6 +940,11 @@ OPENEDX_SERVICE_WORKER_API_TOKEN = get_string(
     None,
     "Active access token with staff level permissions to use with OpenEdX API client for service tasks",
 )
+OPENEDX_SERVICE_WORKER_USERNAME = get_string(
+    "OPENEDX_SERVICE_WORKER_USERNAME",
+    None,
+    "Username of the user whose token has been set in OPENEDX_SERVICE_WORKER_API_TOKEN",
+)
 EDX_API_CLIENT_TIMEOUT = get_int(
     "EDX_API_CLIENT_TIMEOUT",
     60,

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-oauth-toolkit==1.2.0
 django-user-agents==0.4.0
 djangorestframework==3.9.4
 djoser
-edx-api-client==0.8.0
+edx-api-client==0.9.0
 django-storages==1.7.1
 google-api-python-client==1.7.11
 google-auth==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ djangorestframework==3.9.4
 djoser==1.7.0
 docutils==0.14            # via botocore
 draftjs-exporter==2.1.6   # via wagtail
-edx-api-client==0.8.0
+edx-api-client==0.9.0
 elasticsearch==7.0.2      # via django-server-status
 google-api-python-client==1.7.11
 google-auth-httplib2==0.0.3  # via google-api-python-client


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#1418 

#### What's this PR do?
Updates the sync course run method to include the username in the request for course details in edX in order for the requesting service worker user to be identified correctly. This should fix any issues with edX configured to display course details only to `staff` users.

#### How should this be manually tested?
Make sure:
- edX is configured to display course details only to `staff` users (details in #1418 ). 
- `OPENEDX_SERVICE_WORKER_USERNAME` is set in the environment to the username of the user whose api token is set in `OPENEDX_SERVICE_WORKER_API_TOKEN`.

Run the `sync_courseruns` management command. It should be able to sync titles and dates from edX to xPRO given matching courses (runs) exist on both sides (matching readable_id).
