### PR TITLE
Create a ProgramEnrollment along with ProgramCertificate

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -398,12 +398,13 @@ class ProgramEnrollmentSerializer(serializers.ModelSerializer):
         """
         Resolve a receipt for this enrollment
         """
-        return (
-            enrollment.order_id
-            if enrollment.order.status == enrollment.order.FULFILLED
-            and settings.ENABLE_ORDER_RECEIPTS
-            else None
-        )
+        if enrollment.order:
+            return (
+                enrollment.order_id
+                if enrollment.order.status == enrollment.order.FULFILLED
+                and settings.ENABLE_ORDER_RECEIPTS
+                else None
+            )
 
     def __init__(self, *args, **kwargs):
         assert (

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -11,6 +11,7 @@ from courses.models import (
     ProgramCertificate,
     Program,
     CourseRun,
+    ProgramEnrollment,
 )
 from mitxpro.utils import has_equal_properties
 from courseware.api import get_edx_api_course_detail_client
@@ -97,7 +98,8 @@ def process_course_run_grade_certificate(course_run_grade):
 def generate_program_certificate(user, program):
     """
     Create a program certificate if the user has a course certificate
-    for each course in the program
+    for each course in the program. Also, It will create the
+    program enrollment if it does not exist for the user.
 
     Args:
         user (User): a Django user.
@@ -133,6 +135,16 @@ def generate_program_certificate(user, program):
             user.username,
             program.title,
         )
+        _, created = ProgramEnrollment.objects.get_or_create(
+            program=program, user=user, defaults={"active": True, "change_status": None}
+        )
+
+        if created:
+            log.info(
+                "Program enrollment for [%s] in program [%s] is created.",
+                user.username,
+                program.title,
+            )
 
     return program_cert, True
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#1434 

#### What's this PR do?
- If user earned a ProgramCertificate then corresponding ProgramEnrollment should be present in the system for that user and program.
- On the dashboard, there should be a link to each courserun's certificate, as well as a link to the program certificate.

#### How should this be manually tested?
- Execute the scenarios that mentioned in #1434 
- Test all other scenarios as well e.g. Receipt functionality etc. 


