### PR TITLE
Changed default renewal period for Drive webhooks to 12hrs

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -725,7 +725,7 @@ DRIVE_WEBHOOK_EXPIRATION_MINUTES = get_int(
 )
 DRIVE_WEBHOOK_RENEWAL_PERIOD_MINUTES = get_int(
     "DRIVE_WEBHOOK_RENEWAL_PERIOD_MINUTES",
-    30,
+    60 * 12,
     description=(
         "The maximum time difference (in minutes) from the present time to a webhook expiration "
         "date to consider a webhook 'fresh', i.e.: not in need of renewal. If the time difference "


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket. Related to repeated Sentry errors regarding expired webhooks (aka file watches)

#### What's this PR do?
Changes the default renewal period for file watch/webhook renewal to 12 hours instead of 23.5 hours

#### How should this be manually tested?
Code review only

#### Any background context you want to provide?
This is a stop-gap solution for the many expired file watches we're experiencing in all environments due to unreliable scheduled task execution. https://github.com/mitodl/mitxpro/issues/1458 will address the reliability, at which point this can be reverted.