### PR TITLE
Streamlined failed HTTP response messaging

### DIFF
--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -43,7 +43,7 @@ from courseware.exceptions import (
 from courseware.factories import OpenEdxApiAuthFactory, CoursewareUserFactory
 from courseware.models import CoursewareUser, OpenEdxApiAuth
 from mitxpro.utils import now_in_utc
-from mitxpro.test_utils import MockResponse
+from mitxpro.test_utils import MockResponse, MockHttpError
 from users.factories import UserFactory
 
 
@@ -64,14 +64,6 @@ def application(settings):
         client_type="confidential",
         authorization_grant_type="authorization-code",
         skip_authorization=True,
-    )
-
-
-@pytest.fixture()
-def mock_http_error():
-    """Mocked HTTPError with required properties"""
-    return HTTPError(
-        response=MockResponse(content={"bad": "response"}, status_code=400)
     )
 
 
@@ -422,9 +414,7 @@ def test_repair_faulty_edx_user(mocker, user, no_courseware_user, no_edx_auth):
     assert created_auth_token is no_edx_auth
 
 
-@pytest.mark.parametrize(
-    "exception_raised", [pytest.lazy_fixture("mock_http_error"), Exception, None]
-)
+@pytest.mark.parametrize("exception_raised", [MockHttpError, Exception, None])
 def test_repair_faulty_courseware_users(mocker, exception_raised):
     """
     Tests that repair_faulty_courseware_users loops through all incorrectly configured Users, attempts to repair
@@ -501,7 +491,7 @@ def test_unenroll_edx_course_run(mocker):
 @pytest.mark.parametrize(
     "client_exception_raised,expected_exception",
     [
-        [pytest.lazy_fixture("mock_http_error"), EdxApiEnrollErrorException],
+        [MockHttpError, EdxApiEnrollErrorException],
         [ValueError, UnknownEdxApiEnrollException],
         [Exception, UnknownEdxApiEnrollException],
     ],

--- a/courseware/exceptions.py
+++ b/courseware/exceptions.py
@@ -1,4 +1,5 @@
 """Courseware exceptions"""
+from mitxpro.utils import get_error_response_summary
 
 
 class CoursewareUserCreateError(Exception):
@@ -31,12 +32,11 @@ class EdxApiEnrollErrorException(Exception):
         self.http_error = http_error
         if msg is None:
             # Set some default useful error message
-            msg = "EdX API error enrolling user {} ({}) in course run '{}':\n(Status code: {}) {}".format(
+            msg = "EdX API error enrolling user {} ({}) in course run '{}'.\n{}".format(
                 self.user.username,
                 self.user.email,
                 self.course_run.courseware_id,
-                self.http_error.response.status_code,
-                self.http_error.response.json(),
+                get_error_response_summary(self.http_error.response),
             )
         super().__init__(msg)
 

--- a/courseware/management/commands/repair_missing_courseware_records.py
+++ b/courseware/management/commands/repair_missing_courseware_records.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from requests.exceptions import HTTPError
 
 from courseware.api import repair_faulty_edx_user
+from mitxpro.utils import get_error_response_summary
 
 User = get_user_model()
 
@@ -33,14 +34,15 @@ class Command(BaseCommand):
             except HTTPError as exc:
                 self.stderr.write(
                     self.style.ERROR(
-                        f"{user.username} ({user.email}): Failed to repair: {exc.response.json()}"
+                        f"{user.username} ({user.email}): "
+                        f"Failed to repair ({get_error_response_summary(exc.response)})"
                     )
                 )
                 error_count += 1
             except Exception as exc:  # pylint: disable=broad-except
                 self.stderr.write(
                     self.style.ERROR(
-                        f"{user.username} ({user.email}): Failed to repair: {str(exc)}"
+                        f"{user.username} ({user.email}): Failed to repair (Exception: {str(exc)})"
                     )
                 )
                 error_count += 1

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -84,6 +84,7 @@ from ecommerce.models import (
 )
 from ecommerce.test_utils import unprotect_version_tables
 from mitxpro.utils import now_in_utc
+from mitxpro.test_utils import MockHttpError
 from voucher.factories import VoucherFactory
 from voucher.models import Voucher
 
@@ -1055,9 +1056,15 @@ def test_enroll_user_in_order_items_reactivate(mocker, user):
 
 
 @pytest.mark.parametrize(
-    "exception_cls", [EdxApiEnrollErrorException, UnknownEdxApiEnrollException]
+    "exception_cls,inner_exception",
+    [
+        [EdxApiEnrollErrorException, MockHttpError()],
+        [UnknownEdxApiEnrollException, Exception()],
+    ],
 )
-def test_enroll_user_in_order_items_api_fail(mocker, user, exception_cls):
+def test_enroll_user_in_order_items_api_fail(
+    mocker, user, exception_cls, inner_exception
+):
     """
     Test that enroll_user_in_order_items logs a message and still creates local enrollment records
     when the edX API request fails
@@ -1065,7 +1072,7 @@ def test_enroll_user_in_order_items_api_fail(mocker, user, exception_cls):
     course_run = CourseRunFactory.build()
     patched_enroll_in_runs = mocker.patch(
         "ecommerce.api.enroll_in_edx_course_runs",
-        side_effect=exception_cls(user, course_run, mocker.Mock()),
+        side_effect=exception_cls(user, course_run, inner_exception),
     )
     patched_log_exception = mocker.patch("ecommerce.api.log.exception")
     order = OrderFactory.create(purchaser=user, status=Order.FULFILLED)

--- a/mitxpro/test_utils_test.py
+++ b/mitxpro/test_utils_test.py
@@ -55,18 +55,20 @@ def test_assert_drf_json_equall():
 
 
 @pytest.mark.parametrize(
-    "content,expected_content",
+    "content,expected_content,expected_json",
     [
-        ['{"test": "content"}', {"test": "content"}],
-        [{"test": "content"}, {"test": "content"}],
+        ['{"test": "content"}', '{"test": "content"}', {"test": "content"}],
+        [{"test": "content"}, '{"test": "content"}', {"test": "content"}],
+        [["test", "content"], '["test", "content"]', ["test", "content"]],
+        [123, "123", 123],
     ],
 )
-def test_mock_response(content, expected_content):
+def test_mock_response(content, expected_content, expected_json):
     """ assert MockResponse returns correct values """
     response = MockResponse(content, 404)
     assert response.status_code == 404
     assert response.content == expected_content
-    assert response.json() == expected_content
+    assert response.json() == expected_json
 
 
 def test_pickleable_mock():

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -321,6 +321,38 @@ def has_all_keys(dict_to_scan, keys):
     return all(key in dict_to_scan for key in keys)
 
 
+def get_error_response_summary(response):
+    """
+    Returns a summary of an error raised from a failed HTTP request using the requests library
+
+    Args:
+        response (requests.models.Response): The requests library response object
+
+    Returns:
+        str: A summary of the error response
+    """
+    # If the response is an HTML document, include the URL in the summary but not the raw HTML
+    if "text/html" in response.headers.get("Content-Type", ""):
+        summary_dict = {"url": response.url, "content": "(HTML body ignored)"}
+    else:
+        summary_dict = {"content": response.text}
+    summary_dict_str = ", ".join([f"{k}: {v}" for k, v in summary_dict.items()])
+    return f"Response - code: {response.status_code}, {summary_dict_str}"
+
+
+def is_json_response(response):
+    """
+    Returns True if the given response object is JSON-parseable
+
+    Args:
+        response (requests.models.Response): The requests library response object
+
+    Returns:
+        bool: True if this response is JSON-parseable
+    """
+    return response.headers.get("Content-Type") == "application/json"
+
+
 class ValidateOnSaveMixin(models.Model):
     """Mixin that calls field/model validation methods before saving a model object"""
 

--- a/users/utils.py
+++ b/users/utils.py
@@ -5,6 +5,8 @@ import re
 from requests.exceptions import HTTPError
 
 from django.contrib.auth import get_user_model
+
+from mitxpro.utils import get_error_response_summary
 from users.constants import USERNAME_MAX_LEN
 
 User = get_user_model()
@@ -120,12 +122,10 @@ def ensure_active_user(user):
                 log.info("Created edX auth token for %s", user.email)
         except HTTPError as exc:
             log.error(
-                "%s (%s): Failed to repair: %s",
+                "%s (%s): Failed to repair (%s)",
                 user.username,
                 user.email,
-                exc.response.json(),
+                get_error_response_summary(exc.response),
             )
-        except Exception as exc:  # pylint: disable=broad-except
-            log.error(
-                "%s (%s): Failed to repair: %s", user.username, user.email, str(exc)
-            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception("%s (%s): Failed to repair", user.username, user.email)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1461 

#### What's this PR do?
Streamlines handling and messaging for responses to failed HTTP requests

#### How should this be manually tested?
The easiest way to test the error handling for the issue described in the linked issue is this:
- Delete the courseware user for one of your users (http://xpro.odl.local:8053/admin/courseware/coursewareuser/)
- Also delete the user in edx (http://edx.odl.local:18000/admin/auth/user/)
- Change the OAuth application client ID value in edX so it doesn't match the client ID in your xpro settings anymore (http://edx.odl.local:18000/admin/oauth2_provider/application/)
- Run `courseware.api.repair_faulty_courseware_users` in an xpro django shell

You should see a log message like this: `Failed to repair faulty user gavin-sidebottom (gwsidebottommit+2@gmail.com). Response - code: 400, url: http://host.docker.internal:18000/oauth2/authorize/confirm, content: (HTML body ignored)`. Doing the same on master would raise a JSON decode error since we assumed that response had JSON content.

After that, change the Client ID value in edX to what it was before and re-run `courseware.api.repair_faulty_courseware_users` in the xpro django shell

#### Any background context you want to provide?
Initially this PR was only going to address a specific case where we incorrectly assumed that an error HTTP response was JSON-parseable. While fixing that, I discovered that (1) there were many instances in our codebase where we incorrectly make the same assumption, and (2) there was a lot of custom log messaging around those error responses. It made sense to fix both of those issues in this PR.
