### PR TITLE
Pass readable product id to checkout page in URL

### DIFF
--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -152,7 +152,7 @@ class B2BEnrollmentCodesView(APIView):
             {
                 "code": code,
                 "url": make_checkout_url(
-                    code=code, product_id=order.product_version.product_id
+                    code=code, product=order.product_version.product
                 ),
             }
             for code in Coupon.objects.filter(

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -304,7 +304,7 @@ def test_enrollment_codes(client):
             [
                 coupon.coupon_code,
                 make_checkout_url(
-                    code=coupon.coupon_code, product_id=order.product_version.product_id
+                    code=coupon.coupon_code, product=order.product_version.product
                 ),
             ]
             for coupon in coupons

--- a/cms/models.py
+++ b/cms/models.py
@@ -697,7 +697,7 @@ class ProgramPage(ProductPage):
             **super().get_context(request, **kwargs),
             **get_base_context(request),
             "product_id": product.id if product else None,
-            "checkout_url": f"{reverse('checkout-page')}?product={ product.id }"
+            "checkout_url": f"{reverse('checkout-page')}?product={ program.readable_id }"
             if product
             else None,
             "enrolled": enrolled,
@@ -769,7 +769,7 @@ class CoursePage(ProductPage):
             **super().get_context(request, **kwargs),
             **get_base_context(request),
             "product_id": product.id if product else None,
-            "checkout_url": f"{reverse('checkout-page')}?product={ product.id }"
+            "checkout_url": f"{reverse('checkout-page')}?product={ run.courseware_id }"
             if product
             else None,
             "enrolled": enrolled,

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -298,7 +298,7 @@ def test_course_view(
     class_name = ""
     if not is_anonymous:
         if not is_enrolled and has_product and has_unexpired_run:
-            url = f'{reverse("checkout-page")}?product={product_id}'
+            url = f'{reverse("checkout-page")}?product={run.courseware_id}'
             class_name = "enroll-now"
         if is_enrolled and has_unexpired_run:
             url = reverse("user-dashboard")
@@ -367,7 +367,7 @@ def test_program_view(
     class_name = ""
     if not is_anonymous:
         if not is_enrolled and has_product and has_unexpired_run:
-            url = f'{reverse("checkout-page")}?product={product_id}'
+            url = f'{reverse("checkout-page")}?product={program.readable_id}'
             class_name = "enroll-now"
         if is_enrolled:
             url = reverse("user-dashboard")

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -34,7 +34,7 @@ def get_bulk_enroll_message_data(bulk_assignment_id, recipient, product_coupon):
         ecommerce.api.UserMessageProps: An object containing user-specific message data
     """
     enrollment_url = make_checkout_url(
-        product_id=product_coupon.product.id, code=product_coupon.coupon.coupon_code
+        product=product_coupon.product, code=product_coupon.coupon.coupon_code
     )
     company_name = (
         product_coupon.coupon.payment.versions.values_list("company__name", flat=True)

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -1,5 +1,5 @@
 """Ecommerce mail API tests"""
-from urllib.parse import urljoin
+from urllib.parse import urljoin, unquote
 
 import datetime
 from django.urls import reverse
@@ -82,10 +82,13 @@ def test_send_bulk_enroll_emails(mocker, settings):
         user_message_props = recipients_and_contexts_arg[i]
         assert isinstance(user_message_props, UserMessageProps) is True
         assert user_message_props.recipient == assignment.email
+        user_message_props.context["enrollment_url"] = unquote(
+            user_message_props.context["enrollment_url"]
+        )
         assert user_message_props.context == {
             "enrollable_title": assignment.product_coupon.product.content_object.title,
             "enrollment_url": "http://test.com/checkout/?product={}&code={}".format(
-                assignment.product_coupon.product.id,
+                assignment.product_coupon.product.content_object.courseware_id,
                 assignment.product_coupon.coupon.coupon_code,
             ),
             "company_name": (

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -82,24 +82,28 @@ def send_support_email(subject, message):
         log.exception("Exception sending email to admins")
 
 
-def make_checkout_url(*, product_id=None, code=None):
+def make_checkout_url(*, product=None, code=None):
     """
     Helper function to create a checkout URL with appropriate query parameters.
 
     Args:
-        product_id (int): A Product ID
+        product (Product): A Product instance
         code (str): The coupon code
 
     Returns:
         str: The URL for the checkout page, including product and coupon code if available
     """
     base_checkout_url = urljoin(settings.SITE_BASE_URL, reverse("checkout-page"))
-    if product_id is None and code is None:
+    if product is None and code is None:
         return base_checkout_url
 
     query_params = {}
-    if product_id is not None:
-        query_params["product"] = product_id
+    if product is not None:
+        if product.content_type.model == "courserun":
+            readable_id = product.content_object.courseware_id
+        else:
+            readable_id = product.content_object.readable_id
+        query_params["product"] = readable_id
     if code is not None:
         query_params["code"] = code
     return f"{base_checkout_url}?{urlencode(query_params)}"

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -111,7 +111,6 @@ class CheckoutView(APIView):
         Create a new unfulfilled Order from the user's basket
         and return information used to submit to CyberSource.
         """
-
         validate_basket_for_checkout(request.user.basket)
         base_url = request.build_absolute_uri("/")
         order = create_unfulfilled_order(request.user)
@@ -427,7 +426,7 @@ def bulk_assignment_csv_view(request, bulk_assignment_id):
             {
                 "email": product_coupon_assignment.email,
                 "enrollment_url": make_checkout_url(
-                    product_id=product_coupon_assignment.product_coupon.product.id,
+                    product=product_coupon_assignment.product_coupon.product,
                     code=product_coupon_assignment.product_coupon.coupon.coupon_code,
                 ),
                 "coupon_code": product_coupon_assignment.product_coupon.coupon.coupon_code,

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -21,7 +21,7 @@ import type {
 
 export type SetFieldError = (fieldName: string, fieldValue: any) => void
 export type UpdateProduct = (
-  productId: number,
+  productId: string,
   runId: number,
   setFieldError: SetFieldError
 ) => Promise<void>
@@ -153,7 +153,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                   run => run.id === selectedRunId
                 )
                 if (run && run.product_id) {
-                  await updateProduct(run.product_id, run.id, setFieldError)
+                  await updateProduct(run.readable_id, run.id, setFieldError)
                   resetForm()
                 }
               }}

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -322,7 +322,7 @@ describe("CheckoutForm", () => {
     await inner
       .find("FormikConnect(FieldInner)[component='select']")
       .prop("onChange")({ target: { value: String(run.id) } })
-    sinon.assert.calledWith(updateProductStub, run.product_id, run.id)
+    sinon.assert.calledWith(updateProductStub, run.readable_id, run.id)
     sinon.assert.calledWith(resetFormStub)
   })
 

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -111,7 +111,7 @@ export class CheckoutPage extends React.Component<Props, State> {
     } = this.props
     const params = queryString.parse(search)
     return {
-      productId:   parseInt(params.product),
+      productId:   params.product,
       preselectId: parseInt(params.preselect),
       couponCode:  params.code
     }
@@ -124,7 +124,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       await fetchBasket()
     } else {
       const basketResponse = await updateBasket({
-        items: [{ product_id: productId }]
+        items: [{ readable_id: productId }]
       })
       if (basketResponse.status !== 200) {
         if (basketResponse.body && basketResponse.body.errors) {
@@ -159,8 +159,8 @@ export class CheckoutPage extends React.Component<Props, State> {
     // update basket with selected runs
     const basketPayload = {
       items: basket.items.map(item => ({
-        product_id: item.product_id,
-        run_ids:    Object.values(values.runs).map(runId => parseInt(runId))
+        readable_id: item.readable_id,
+        run_ids:     Object.values(values.runs).map(runId => parseInt(runId))
       })),
       coupons:       values.couponCode ? [{ code: values.couponCode }] : [],
       data_consents: values.dataConsent ? [basket.data_consents[0].id] : []
@@ -249,13 +249,13 @@ export class CheckoutPage extends React.Component<Props, State> {
   }
 
   updateProduct = async (
-    productId: number,
+    productId: string,
     runId: number,
     setFieldError: SetFieldError
   ) => {
     const { updateBasket } = this.props
     const response = await updateBasket({
-      items: [{ product_id: productId, run_ids: runId ? [runId] : [] }]
+      items: [{ readable_id: productId, run_ids: runId ? [runId] : [] }]
     })
     setFieldError(
       "runs",

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -42,7 +42,7 @@ describe("CheckoutPage", () => {
     it(`updates the basket with a product id from the query parameter${
       hasError ? ", but an error is returned" : ""
     }`, async () => {
-      const productId = 4567
+      const productId = "4567"
       if (hasError) {
         helper.handleRequestStub.withArgs("/api/basket/", "PATCH").returns({
           status: 400,
@@ -65,7 +65,7 @@ describe("CheckoutPage", () => {
         "/api/basket/",
         "PATCH",
         {
-          body:        { items: [{ product_id: productId }] },
+          body:        { items: [{ readable_id: productId }] },
           credentials: undefined,
           headers:     {
             "X-CSRFTOKEN": null
@@ -194,8 +194,8 @@ describe("CheckoutPage", () => {
           body: {
             items: [
               {
-                product_id: basketItem.product_id,
-                run_ids:    []
+                readable_id: basketItem.readable_id,
+                run_ids:     []
               }
             ],
             coupons:       [],
@@ -241,8 +241,8 @@ describe("CheckoutPage", () => {
       body: {
         items: [
           {
-            product_id: basketItem.product_id,
-            run_ids:    []
+            readable_id: basketItem.readable_id,
+            run_ids:     []
           }
         ],
         coupons:       [],
@@ -290,7 +290,7 @@ describe("CheckoutPage", () => {
     sinon.assert.notCalled(submitStub)
     sinon.assert.calledWith(helper.handleRequestStub, "/api/basket/", "PATCH", {
       body: {
-        items:         [{ product_id: basket.items[0].product_id, run_ids: [runId] }],
+        items:         [{ readable_id: basket.items[0].readable_id, run_ids: [runId] }],
         coupons:       [],
         data_consents: []
       },
@@ -341,7 +341,7 @@ describe("CheckoutPage", () => {
         {
           body: {
             items: [
-              { product_id: basket.items[0].product_id, run_ids: [runId] }
+              { readable_id: basket.items[0].readable_id, run_ids: [runId] }
             ],
             coupons:       hasCoupon ? [{ code: code }] : [],
             data_consents: []

--- a/static/js/factories/course.js
+++ b/static/js/factories/course.js
@@ -30,7 +30,8 @@ export const makeCourseRun = (): CourseRun => ({
   courseware_id:    casual.word.concat(genCoursewareId.next().value),
   // $FlowFixMe
   id:               genCourseRunId.next().value,
-  product_id:       genProductId.next().value
+  product_id:       genProductId.next().value,
+  readable_id:      casual.word.concat(genCoursewareId.next().value)
 })
 
 const genCourseId = incrementer()

--- a/static/js/flow/courseTypes.js
+++ b/static/js/flow/courseTypes.js
@@ -11,7 +11,8 @@ export type BaseCourseRun = {
 }
 
 export type CourseRun = BaseCourseRun & {
-  product_id: ?number
+  product_id: ?number,
+  readable_id: string
 }
 
 export type BaseCourse = {

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -89,7 +89,7 @@ export type BasketResponse = {
 }
 
 type BasketItemPayload = {
-  product_id: number,
+  readable_id: string,
   run_ids?: Array<number>,
 }
 

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -146,7 +146,8 @@ class EnrollView(LoginRequiredMixin, View):
             voucher.product_id = product_id
             voucher.save()
             enroll_url = make_checkout_url(
-                product_id=product_id, code=voucher.coupon.coupon_code
+                product=Product.objects.get(id=product_id),
+                code=voucher.coupon.coupon_code,
             )
             return redirect(enroll_url)
         else:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/8pmf7Bnk/32-pass-readable-product-id-to-checkout-page-in-url

#### What's this PR do?
Pass readable product id to checkout page in URL

#### How should this be manually tested?
Try to enroll in a course, now it should show readable_id rather than product_id in the link.
Or open the course with `http://xpro.odl.local:8053/checkout/?product={readable_id}`.