### PR TITLE
Fixed coupon redemption handling to account for non-spreadsheet bulk enrollments

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -482,11 +482,12 @@ def set_coupons_to_redeemed(assignee_email, coupon_ids):
                 assignment.redeemed = True
                 assignment.save()
                 updated_assignments.append(assignment)
-
+    # If the redeemed coupons were assigned in bulk enrollment spreadsheets, update those spreadsheets
+    # to reflect that they were redeemed
     updated_assignments_in_bulk = [
         assignment
         for assignment in updated_assignments
-        if assignment.bulk_assignment_id
+        if assignment.bulk_assignment and assignment.bulk_assignment.assignment_sheet_id
     ]
     if updated_assignments_in_bulk:
         sheet_update_map = defaultdict(list)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1481

#### What's this PR do?
Fixes situations where a bulk enrollment coupon was redeemed that was _not_ created in a bulk enrollment sheet (i.e.: created in the ecommerce admin form)

#### How should this be manually tested?
- Create a coupon and assign it via the ecommerce admin (`/ecommerce/admin/`)
- Redeem it

The product coupon assignment for that coupon should be set to redeemed=True, and there should be no error in your logs

