### PR TITLE
Removed 'get_embed' Wagtail library function tests

### DIFF
--- a/cms/embeds_test.py
+++ b/cms/embeds_test.py
@@ -1,11 +1,6 @@
 """Tests for custom embed providers and finders"""
-from urllib.parse import parse_qs, urlparse
-
 import pytest
-from bs4 import BeautifulSoup
 from django.core.exceptions import ImproperlyConfigured
-from wagtail.embeds.embeds import get_embed
-from wagtail.embeds.exceptions import EmbedNotFoundException
 from wagtail.embeds.oembed_providers import vimeo
 
 from cms.embeds import YouTubeEmbedFinder
@@ -20,37 +15,3 @@ def test_youtube_finder_invalid_config():
     """
     with pytest.raises(ImproperlyConfigured):
         assert YouTubeEmbedFinder(providers=[vimeo])
-
-
-def test_youtube_embed():
-    """
-    Test that the Youtube embed works with a Youtube link.
-    """
-    embed = get_embed("https://www.youtube.com/watch?v=C0DPdy98e4c")
-    assert embed
-    assert embed.html
-
-
-def test_youtube_embed_parameters():
-    """
-    Test that the Youtube embed works with a Youtube link.
-    """
-    embed = get_embed("https://www.youtube.com/watch?v=C0DPdy98e4c")
-    assert embed
-    assert embed.html
-
-    embed_tag = BeautifulSoup(embed.html, "html.parser")
-    iframe_url = embed_tag.find("iframe").attrs["src"]
-    _, _, _, _, query, _ = urlparse(iframe_url)
-
-    querydict = parse_qs(query)
-    assert querydict["rel"] == ["0"]
-    assert querydict["enablejsapi"] == ["1"]
-
-
-def test_youtube_embed_invalid_link():
-    """
-    Test that the Youtube embed throws an exception on an invalid link
-    """
-    with pytest.raises(EmbedNotFoundException):
-        assert get_embed("https://www.youtube.com/watch?v=DUMMY")


### PR DESCRIPTION
#### Pre-Flight checklist
N/A

#### What are the relevant tickets?
No ticket - reverts some test cases introduced in #705

#### What's this PR do?
Removes test cases that test the 'get_embed' Wagtail library function

#### How should this be manually tested?
Build should pass

#### Any background context you want to provide?
These test cases should not exist for at least 2 reasons:
1. They test a library function
1. They make live HTTP requests to an external service
