### PR TITLE
Fixed off-by-one error with coupon assignment sheet enrolled status

### DIFF
--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -91,7 +91,7 @@ def set_assignment_rows_to_enrolled(sheet_update_map):
                     (assignment_row.row_index, ASSIGNMENT_SHEET_ENROLLED_STATUS, now)
                 )
         coupon_assignment_handler.update_sheet_with_new_statuses(
-            sheet_id, status_row_updates
+            sheet_id, status_row_updates, zero_based_indices=False
         )
         result_summary[sheet_id] = len(assignment_code_email_pairs)
     return result_summary


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1493

#### What's this PR do?
Fixes an issue where if a user enrolled in a coupon assigned via an assignment sheet, that status would be reflected one row below the correct cell in the assignment sheet

#### How should this be manually tested?
Code review only

