### PR TITLE
Add error logging for program orders with no run selections

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -535,6 +535,15 @@ def enroll_user_in_order_items(order):
     programs = get_order_programs(order)
     company = get_company_affiliation(order)
 
+    if programs and not runs:
+        log.error(
+            "An order is being completed for a program, but does not have any course run selections. "
+            "(Order: %d, purchaser: '%s', program(s): %s)",
+            order.id,
+            order.purchaser.email,
+            [program.readable_id for program in programs],
+        )
+
     try:
         enroll_in_edx_course_runs(order.purchaser, runs)
         edx_request_success = True


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket – related to Zendesk ticket [44392](https://odl.zendesk.com/agent/tickets/44392)

#### What's this PR do?
Adds error logging if a program order is being completed and no course run selections are found

#### How should this be manually tested?
Tests passing should be enough

#### Any background context you want to provide?
This obviously isn't intended to fix the underlying problem in the Zendesk ticket linked above. We're not positive about what caused that issue. The intent behind the logging in this PR is to help us narrow down the cause if a similar issue happens again in the future.
