### PR TITLE
handlebars plus django version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "flow-bin": "^0.95.1",
     "flow-typed": "^2.5.1",
     "formik": "^1.5.1",
-    "handlebars": "4.5.3",
     "history": "^4.6.3",
     "hls.js": "^0.13.1",
     "isomorphic-fetch": "^2.2.1",
@@ -140,6 +139,7 @@
   "resolutions": {
     "mixin-deep": "^1.3.2",
     "set-value": "^2.0.1",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "**/handlebars": "4.5.3"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ django-templated-mail==1.1.1  # via djoser
 django-treebeard==4.3     # via wagtail
 django-user-agents==0.4.0
 django-webpack-loader==0.5.0
-django==2.2.8
+django==2.2.9
 djangorestframework==3.9.4
 djoser==1.7.0
 docutils==0.14            # via botocore

--- a/yarn.lock
+++ b/yarn.lock
@@ -4581,21 +4581,10 @@ gud@^1.0.0:
   resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
   integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
-handlebars@4.5.3:
+handlebars@4.5.3, handlebars@^4.1.2:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
   integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
#### Pre-Flight 
- [ ] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/network/alerts

#### What's this PR do?
Tried to fix the handlebar and django version conflicts

Handlebars version was already updated previously to `4.5.3` but `yarn.lock` contains the both `4.5.3` and `4.1.2` and another package `istanbul-reports@^2.2.4:` was dependent on `handlebar@4.1.2` so the PR added the required version under `resolutions` section of `package.json` file. 
Please let me know if anything needs to update here. 
