### PR TITLE
Pass readable product id to checkout page in URL

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -1142,3 +1142,16 @@ def fulfill_order(request_data):
 
     # Save to log everything to an audit table including enrollments created in complete_order
     order.save_and_log(None)
+
+
+def get_product_from_querystring_id(qs_product_id):
+    """Get product from querystring (product_id)"""
+    if isinstance(qs_product_id, int) or qs_product_id.isdigit():
+        return Product.objects.get(id=int(qs_product_id))
+    else:
+        # Text IDs for Programs/CourseRuns have '+' characters, which represent spaces in URL-encoded strings
+        product_text_id = qs_product_id.replace(" ", "+")
+        return Product.objects.get(
+            Q(courseruns__courseware_id=product_text_id)
+            | Q(programs__readable_id=product_text_id)
+        )

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -21,7 +21,7 @@ import type {
 
 export type SetFieldError = (fieldName: string, fieldValue: any) => void
 export type UpdateProduct = (
-  productId: number,
+  productId: number | string,
   runId: number,
   setFieldError: SetFieldError
 ) => Promise<void>

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -111,7 +111,7 @@ export class CheckoutPage extends React.Component<Props, State> {
     } = this.props
     const params = queryString.parse(search)
     return {
-      productId:   parseInt(params.product),
+      productId:   params.product,
       preselectId: parseInt(params.preselect),
       couponCode:  params.code
     }
@@ -249,7 +249,7 @@ export class CheckoutPage extends React.Component<Props, State> {
   }
 
   updateProduct = async (
-    productId: number,
+    productId: number | string,
     runId: number,
     setFieldError: SetFieldError
   ) => {

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -42,7 +42,7 @@ describe("CheckoutPage", () => {
     it(`updates the basket with a product id from the query parameter${
       hasError ? ", but an error is returned" : ""
     }`, async () => {
-      const productId = 4567
+      const productId = "4567"
       if (hasError) {
         helper.handleRequestStub.withArgs("/api/basket/", "PATCH").returns({
           status: 400,

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -89,7 +89,7 @@ export type BasketResponse = {
 }
 
 type BasketItemPayload = {
-  product_id: number,
+  product_id: number|string,
   run_ids?: Array<number>,
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/8pmf7Bnk/32-pass-readable-product-id-to-checkout-page-in-url

#### What's this PR do?
Pass readable product id to checkout page in URL

#### How should this be manually tested?
Just try to load the Checkout out page with `?product={product_id}/{readable_id}`.

#### Screenshots

**In Active Course**

http://xpro.odl.local:8053/checkout/?product=course-v1:edX+DemoX+Demo_Course

<img width="1423" alt="Screenshot 2020-01-28 at 18 44 27" src="https://user-images.githubusercontent.com/4043989/73269385-8b224900-41fe-11ea-911f-a511451e02fd.png">

http://xpro.odl.local:8053/checkout/?product=2

<img width="1437" alt="Screenshot 2020-01-28 at 18 49 11" src="https://user-images.githubusercontent.com/4043989/73269610-f5d38480-41fe-11ea-8296-ffc75b80be91.png">

**Offer courses that are open for enrollment**

<img width="1430" alt="Screenshot 2020-01-30 at 13 52 43" src="https://user-images.githubusercontent.com/4043989/73434250-31d62900-4368-11ea-882e-d6765918824d.png">

<img width="1429" alt="Screenshot 2020-01-30 at 13 53 52" src="https://user-images.githubusercontent.com/4043989/73434251-326ebf80-4368-11ea-8564-53139069a421.png">
