### PR TITLE
Sticky Enroll Button Changes

### DIFF
--- a/cms/templates/partials/enroll_button.html
+++ b/cms/templates/partials/enroll_button.html
@@ -1,0 +1,49 @@
+{% if page.about_mit_xpro.video_url and action_title and action_url %}
+<a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="{{ action_url }}">{{ action_title }}</a>
+{% elif page.is_external_course_page %}
+<a class="enroll-button enroll-now" href="{{ page.external_url }}">
+  Apply Now
+</a>
+{% elif page.product %}
+  {% if not user.is_anonymous %}
+    {% if not enrolled and product_id and page.product.first_unexpired_run %}
+      <a class="enroll-button enroll-now" href="{{ checkout_url }}">
+        Enroll Now
+      </a>
+    {% elif enrolled %}
+      <a class="enroll-button enrolled" href="{% url "user-dashboard" %}">
+        Enrolled <i class="material-icons">check</i>
+      </a>
+    {% endif %}
+  {% elif product_id and page.product.first_unexpired_run %}
+    <div class="enroll-dropdown">
+      <a class="enroll-button dropdown-toggle" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="true">
+        Enroll Now
+      </a>
+      <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <div class="login-popup">
+          <div class="triangle"></div>
+          <h4>
+            <span>Sign In/Create Account</span>
+            <a class="close-btn">
+              ×
+            </a>
+          </h4>
+          <div class="popup-text">
+            Please Sign In to MITx PRO to enroll in a course
+          </div>
+          <div class="bottom-row">
+            <div class="popup-buttons">
+              <a class="sign-in-link link-button" href="{% url 'login' %}?next={{ checkout_url|urlencode:'' }}">
+                Sign In
+              </a>
+              <a class="create-account-link link-button" href="{% url 'signup' %}?next={{ checkout_url|urlencode:'' }}">
+                Create Account
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endif %}

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -38,56 +38,9 @@
           <h2>{{ page.subhead }}</h2>
         </div>
         <div class="mt-5 mb-5">
-          {% if page.about_mit_xpro.video_url and action_title and action_url %}
-            <a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="{{ action_url }}">{{ action_title }}</a>
-          {% elif page.is_external_course_page %}
-            <a class="enroll-button enroll-now" href="{{ page.external_url }}">
-              Apply Now
-            </a>
-          {% elif page.product %}
-            {% if not user.is_anonymous %}
-              {% if not enrolled and product_id and page.product.first_unexpired_run %}
-                <a class="enroll-button enroll-now" href="{{ checkout_url }}">
-                  Enroll Now
-                </a>
-              {% elif enrolled %}
-                <a class="enroll-button enrolled" href="{% url "user-dashboard" %}">
-                  Enrolled <i class="material-icons">check</i>
-                </a>
-              {% endif %}
-            {% elif product_id and page.product.first_unexpired_run %}
-              <div class="enroll-dropdown">
-                <a class="enroll-button dropdown-toggle" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="true">
-                  Enroll Now
-                </a>
-                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                  <div class="login-popup">
-                    <div class="triangle"></div>
-                    <h4>
-                      <span>Sign In/Create Account</span>
-                      <a class="close-btn">
-                        ×
-                      </a>
-                    </h4>
-                    <div class="popup-text">
-                      Please Sign In to MITx PRO to enroll in a course
-                    </div>
-                    <div class="bottom-row">
-                      <div class="popup-buttons">
-                        <a class="sign-in-link link-button" href="{% url 'login' %}?next={{ checkout_url|urlencode:'' }}">
-                          Sign In
-                        </a>
-                        <a class="create-account-link link-button" href="{% url 'signup' %}?next={{ checkout_url|urlencode:'' }}">
-                          Create Account
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            {% endif %}
-          {% endif %}
+          {% include "partials/enroll_button.html" %}
         </div>
+      </div>
       </div>
       <div class="col-lg-5">
         {% if page.video_url %}

--- a/cms/templates/partials/subnav.html
+++ b/cms/templates/partials/subnav.html
@@ -2,6 +2,9 @@
   <a class="navbar-toggler collapsed active-block" data-toggle="collapse" data-target="#subNavBar">
     <span id="subNavBarSelector" class="collapsed-header">Who Should Enroll</span>
   </a>
+  <div class="sub-nav-enroll-button-block">
+    {% include "partials/enroll_button.html" %}
+  </div>
   <div id="subNavBar" class="collapse navbar-collapse justify-content-center">
     <ul class="navbar-nav container justify-content-center">
       {% if page.outcomes %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#learningOutcomes">What You Will Learn</a></li> {% endif %}

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -1,7 +1,8 @@
 // sass-lint:disable mixins-before-declarations
 .sub-nav-bar {
   background: $gray-bg;
-  display: block;
+  display: flex;
+  justify-content: center;
   box-shadow: 0 0 13px rgba(0, 0, 0, 0.5);
 
   .navbar-nav > li > a {
@@ -12,9 +13,18 @@
     }
   }
 
+  &.navbar-expand-md {
+    .navbar-collapse {
+      @include media-breakpoint-up(md) {
+        flex-grow: initial;
+      }
+    }
+  }
+
   .navbar-toggler {
     border: unset;
     color: $blue !important;
+    width: calc(100% - 160px);
 
     span.fa-chevron-down {
       display: none;
@@ -32,6 +42,118 @@
 
     span.fa-chevron-up {
       display: none;
+    }
+  }
+
+  .sub-nav-enroll-button-block {
+    position: relative;
+    @include media-breakpoint-up(md) {
+      order: 2;
+    }
+
+    .enroll-button {
+      width: 140px;
+      display: inline-flex;
+      margin: 0;
+      border-radius: 5px;
+      background-color: $primary;
+      color: white !important;
+      padding: 15px 25px;
+      text-transform: uppercase;
+      cursor: pointer;
+      font-weight: 600;
+      font-size: 16px;
+      margin-left: 20px;
+
+      &.enrolled {
+        border: 4px solid $primary;
+        background-color: white;
+        color: $primary !important;
+      }
+
+      &:hover {
+        // underline is at different levels since we centered the text and checkmark vertically, so it looks strange
+        text-decoration: none;
+      }
+    }
+
+    .enroll-dropdown {
+      .dropdown-toggle::after {
+        display: none;
+      }
+
+      .login-popup {
+        max-width: 350px;
+        margin-left: 20px;
+        margin-right: 20px;
+        padding: 20px;
+        font-weight: 600;
+        font-size: 20px;
+        min-width: 320px;
+
+        .close-btn {
+          position: absolute;
+          top: 0;
+          right: 0;
+          padding: 5px;
+          margin: 20px 7px 0 0;
+          font-size: 72px;
+          font-weight: 300;
+          background-color: white !important;
+          color: black;
+          min-width: unset;
+          height: unset;
+          cursor: pointer;
+        }
+
+        h4 {
+          font-weight: 700;
+          font-size: 22px;
+        }
+
+        .popup-buttons {
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+          margin-top: 20px;
+
+          .link-button {
+            border: 2px solid $light-blue;
+            border-radius: 10px;
+            font-weight: 600;
+            font-size: 24px;
+
+            &.sign-in-link {
+              color: white;
+              background-color: $light-blue;
+            }
+
+            &.create-account-link {
+              color: black;
+            }
+          }
+        }
+      }
+
+      .triangle {
+        width: 15px;
+        height: 15px;
+        position: absolute;
+        top: -7px;
+        background: white;
+        transform: rotate(45deg);
+      }
+
+      .dropdown-menu {
+        .triangle {
+          right: 24px;
+        }
+      }
+    }
+
+    .action-button {
+      font-size: x-large;
+      font-weight: 400;
     }
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### Deployment 
[HEROKU](https://xpro-ci-pr-1512.herokuapp.com/courses/course-v1:SEED+SysEngBx3/)

#### What are the relevant tickets?
[sticky-enroll-now-button](https://trello.com/c/mPpk0Ox5/40-sticky-enroll-button)

#### What's this PR do?
Fix the position of `Enroll Now` button in navigation bar.

#### How should this be manually tested?

- Visit Product detail page and verify the position and behavior of `Enroll Now` button.
- Verify the `Enoll Now` button behavior for anonymous users.
- Verify the `Enroll Now` button look & feel for smaller screens. 
- `Enroll Now` button has different states based on these [condtions](https://github.com/mitodl/mitxpro/blob/master/cms/templates/partials/hero.html#L41-L62) so verify the other states of the button is also rendering on the sab navigation bar correctly.  

#### Screenshots (if appropriate)
<img width="1436" alt="Screen Shot 2020-01-29 at 5 36 36 PM" src="https://user-images.githubusercontent.com/7334669/73357419-25959180-42be-11ea-806b-7be478db5438.png">
<img width="1440" alt="Screen Shot 2020-01-29 at 5 36 23 PM" src="https://user-images.githubusercontent.com/7334669/73357420-25959180-42be-11ea-9738-8aa7d1229ec9.png">


