### PR TITLE
course run on program checkout page

### DIFF
--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -379,11 +379,7 @@ describe("CheckoutPage", () => {
       const expected = {}
       for (const runId of item.run_ids) {
         for (const course of item.courses) {
-          for (const run of course.courseruns) {
-            if (run.id === runId) {
-              expected[course.id] = run.id
-            }
-          }
+          expected[course.id] = course.next_run_id
         }
       }
       assert.deepEqual(calcSelectedRunIds(item), expected)

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -240,3 +240,9 @@ export const getProductSelectLabel = (product: ProductDetail) => {
     return `${product.latest_version.readable_id} | ${product.title}`
   }
 }
+
+export const sameDayOrLater = (
+  momentDate1: Moment,
+  momentDate2: Moment
+): boolean =>
+  momentDate1.startOf("day").isSameOrAfter(momentDate2.startOf("day"))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/dQDZAb4f/39-on-checkout-page-for-program-all-courseruns-should-be-from-the-same-run

#### What's this PR do?
On checkout page for program, all courseruns should be from the same  run

#### How should this be manually tested?

- Create a Program with multiple courses and multiple runs.
- Go to the program page.
- Try enrolling in next run from "more dates"
- Preselected course runs should be selected
- All course runs should be selected according to first course run. (all other course runs should start at the same time or after the first select course run)

#### Any background context you want to provide?
As a user, when I check out I expect the dropdown for course dates to default to a set of dates in order. In other words, if the next available run of the first course is R5, I expect all the course runs to default to R5. It is confusing if, for example, the second course has a start date before the first course.

As a user, I'd still like the flexibility to choose from all available course run dates.
