### PR TITLE
Fixed unenrollment email start date text

### DIFF
--- a/mail/templates/course_run_unenrollment/body.html
+++ b/mail/templates/course_run_unenrollment/body.html
@@ -9,7 +9,13 @@
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
                       <p style="margin: 0 0 10px;">
-                        You have been unenrolled in {{ enrollment.run }} starting {{ run.start_date|date:"F j, Y"}}. The course will no longer appear on your <a href="{{ base_url }}{% url 'user-dashboard' %}">{{ site_name }} dashboard</a>.
+                        You have been unenrolled in
+                        {% if enrollment.run.start_date %}
+                          {{ enrollment.run }} starting {{ enrollment.run.start_date|date:"F j, Y"}}.
+                        {% else %}
+                          {{ enrollment.run }}.
+                        {% endif %}
+                        The course will no longer appear on your <a href="{{ base_url }}{% url 'user-dashboard' %}">{{ site_name }} dashboard</a>.
                       </p>
                   </td>
               </tr>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. Discovered during spreadsheet enrollment testing

#### What's this PR do?
Changes unenrollment email template text to respect course runs that have no start date

#### How should this be manually tested?
In a Django shell, run `ecommerce.mail_api.send_course_run_unenrollment_email` using an enrollment for a course run with and without a start date value.

#### Screenshots (if appropriate)
![ss 2020-02-03 at 12 02 30 ](https://user-images.githubusercontent.com/14932219/73673919-7ec64200-467d-11ea-80fa-230dacabe78f.png)
![ss 2020-02-03 at 12 02 21 ](https://user-images.githubusercontent.com/14932219/73673920-7ec64200-467d-11ea-934b-8e91980f33b2.png)

