### PR TITLE
Fixed bug with column definition for refund request sheet

### DIFF
--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -169,7 +169,7 @@ class CouponAssignSheetMetadata(
         self.num_columns = len(self.column_headers)
 
         self.LAST_COL_LETTER = get_column_letter(self.num_columns - 1)
-        self.STATUS_COL = (
+        self.STATUS_COL = next(
             i for i, header in enumerate(self.column_headers) if header == "Status"
         )
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket - Fixes bug introduced in #1503 

#### What's this PR do?
Fixes status column definition for the refund spreadsheet so it's an integer again, not a generator

#### How should this be manually tested?
Code review only
