### PR TITLE
Make Account Settings page private

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -108,7 +108,7 @@ export class App extends React.Component<Props, void> {
             path={urljoin(match.url, String(routes.ecommerceBulk))}
             component={EcommerceBulkPages}
           />
-          <Route
+          <PrivateRoute
             path={urljoin(match.url, String(routes.accountSettings))}
             component={AccountSettingsPage}
           />


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/ZbfEpf7L/68-bug-account-settings-page-displays-to-the-anonymous-user

#### What's this PR do?
Make Account Settings private, it should not be accessible to Anonymous User

#### How should this be manually tested?
Log out and go to the page [Account Settings](http://xpro.odl.local:8053/account-settings/)

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-02-07 at 14 53 32" src="https://user-images.githubusercontent.com/4043989/74019606-bf91c400-49b9-11ea-9bb0-910ec9ea0883.png">

