### PR TITLE
API v1 routes

### DIFF
--- a/courses/urls.py
+++ b/courses/urls.py
@@ -2,19 +2,18 @@
 from django.urls import include, re_path
 from rest_framework import routers
 
-from courses import views
+from courses.views import v1
 
 
 router = routers.SimpleRouter()
-router.register(r"programs", views.ProgramViewSet, basename="programs_api")
-router.register(r"courses", views.CourseViewSet, basename="courses_api")
-router.register(r"course_runs", views.CourseRunViewSet, basename="course_runs_api")
+router.register(r"programs", v1.ProgramViewSet, basename="programs_api")
+router.register(r"courses", v1.CourseViewSet, basename="courses_api")
+router.register(r"course_runs", v1.CourseRunViewSet, basename="course_runs_api")
 
 urlpatterns = [
+    re_path(r"^api/v1/", include(router.urls)),
     re_path(r"^api/", include(router.urls)),
     re_path(
-        r"^api/enrollments/",
-        views.UserEnrollmentsView.as_view(),
-        name="user-enrollments",
+        r"^api/enrollments/", v1.UserEnrollmentsView.as_view(), name="user-enrollments"
     ),
 ]

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -1,4 +1,4 @@
-"""Course views"""
+"""Course views verson 1"""
 from rest_framework import viewsets, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -395,14 +395,14 @@ def test_user_enrollments_view(mocker, client, user):
         past_non_program_runs=[],
     )
     patched_get_user_enrollments = mocker.patch(
-        "courses.views.get_user_enrollments", return_value=user_enrollments
+        "courses.views.v1.get_user_enrollments", return_value=user_enrollments
     )
     patched_program_enroll_serializer = mocker.patch(
-        "courses.views.ProgramEnrollmentSerializer",
+        "courses.views.v1.ProgramEnrollmentSerializer",
         return_value=mocker.Mock(data=[{"program": "enrollment"}]),
     )
     patched_course_enroll_serializer = mocker.patch(
-        "courses.views.CourseRunEnrollmentSerializer",
+        "courses.views.v1.CourseRunEnrollmentSerializer",
         return_value=mocker.Mock(data=[{"courserun": "enrollment"}]),
     )
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/vfPJO16Y/45-add-version-number-to-course-and-program-apis)

#### What's this PR do?
Adds the course/program APIs to `/api/v1/` path as well. The existing `/api/` URLs still work.

#### How should this be manually tested?
The new `/api/v1/` URLs should work as expected as well as the old `/api/` ones.