### PR TITLE
asadiqbal08/fix currency should have two decimal places

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -225,8 +225,9 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                                 if lines
                                 else None,
                                 "lines": lines,
-                                "order_total": sum(
-                                    float(line["total_paid"]) for line in lines
+                                "order_total": format(
+                                    sum(float(line["total_paid"]) for line in lines),
+                                    ".2f",
                                 ),
                                 "order": order,
                                 "receipt": receipt,

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -249,7 +249,7 @@ def test_send_ecommerce_order_receipt(mocker, receipt_data):
                     "content_title": "test_run_title",
                 }
             ],
-            "order_total": 100.0,
+            "order_total": "100.00",
             "order": {
                 "id": 1,
                 "created_on": line.order.created_on,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/Shqq43bL/70-bug-in-email-receipt-currency-should-have-two-decimal-places)

#### What's this PR do?
Fix the issue as pointed out in the ticket.

#### How should this be manually tested?
- Enable the `ENABLE_ORDER_RECEIPTS` env variable
- Created a new free product. (price tag should be 0)
- Enroll a user in this product and verify the generated email. 
- Try to execute the same scenario for a priced product. 

#### Screenshots (if appropriate)
<img width="621" alt="Screen Shot 2020-02-10 at 3 47 05 PM" src="https://user-images.githubusercontent.com/7334669/74144845-4dbab400-4c1f-11ea-8176-3193ed50b97c.png">


