### PR TITLE
Load products on coupon page with visible_in_bulk_form=false

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -163,7 +163,7 @@ class BaseProductSerializer(serializers.ModelSerializer):
         return instance.content_type.model
 
     class Meta:
-        fields = ["id", "product_type"]
+        fields = ["id", "product_type", "visible_in_bulk_form"]
         model = models.Product
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -6,7 +6,6 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.db.models import Q
 from django.http import Http404
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework import status
@@ -82,9 +81,7 @@ class ProductViewSet(ReadOnlyModelViewSet):
     permission_classes = ()
 
     serializer_class = ProductDetailSerializer
-    queryset = Product.objects.exclude(
-        Q(visible_in_bulk_form=False) | Q(productversions=None)
-    )
+    queryset = Product.objects.exclude(productversions=None)
 
 
 class CompanyViewSet(ReadOnlyModelViewSet):

--- a/static/js/containers/pages/b2b/B2BPurchasePage.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage.js
@@ -122,7 +122,9 @@ export class B2BPurchasePage extends React.Component<Props, State> {
       <React.Fragment>
         <B2BPurchaseForm
           onSubmit={this.onSubmit}
-          products={products}
+          products={products.filter(
+            product => product.visible_in_bulk_form === true
+          )}
           checkout={checkout}
           couponStatus={couponStatus}
           contractNumber={contractNumber}

--- a/static/js/containers/pages/b2b/B2BPurchasePage_test.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage_test.js
@@ -51,7 +51,10 @@ describe("B2BPurchasePage", () => {
   it("renders a form", async () => {
     const { inner } = await renderPage()
     const props = inner.find("B2BPurchaseForm").props()
-    assert.deepEqual(props.products, products)
+    assert.deepEqual(
+      props.products,
+      products.filter(product => product.visible_in_bulk_form === true)
+    )
   })
 
   describe("submission", () => {

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -101,10 +101,11 @@ export const makeProduct = (
   readableId: string = casual.text
 ): ProductDetail => ({
   // $FlowFixMe
-  id:             genProductId.next().value,
-  title:          casual.word,
-  product_type:   productType,
-  latest_version: makeItem(productType, readableId)
+  id:                   genProductId.next().value,
+  title:                casual.word,
+  product_type:         productType,
+  visible_in_bulk_form: casual.boolean,
+  latest_version:       makeItem(productType, readableId)
 })
 
 export const makeCourseRunOrProgram = (

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -178,6 +178,7 @@ export type Coupon = {
 export type SimpleProduct = {
   id: number,
   product_type: string,
+  visible_in_bulk_form: boolean,
 }
 
 export type Product = SimpleProduct & {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/a8HfV6Hi/74-bug-setting-visible-in-bulk-form-to-false-hides-product-from-ecommerce-coupons-form

#### What's this PR do?
Setting "Visible in Bulk Form" to false, the product should still appear in the coupons form, because /ecommerce/admin/coupons/ is not the bulk form.

#### How should this be manually tested?
Just set the "Visible in Bulk Form" to false on /admin/product/ and it should not hide the product from coupon page but on /ecommerce/bulk/ page

#### Screenshots (if appropriate)
<img width="1433" alt="Screenshot 2020-02-10 at 20 12 07" src="https://user-images.githubusercontent.com/4043989/74161991-c16db880-4c41-11ea-98a9-1564b1343aab.png">

<img width="1423" alt="Screenshot 2020-02-10 at 20 12 28" src="https://user-images.githubusercontent.com/4043989/74162003-c599d600-4c41-11ea-88d3-0f10e952365c.png">

<img width="1433" alt="Screenshot 2020-02-10 at 20 12 44" src="https://user-images.githubusercontent.com/4043989/74162014-ca5e8a00-4c41-11ea-9076-38a69396f2cc.png">
