### PR TITLE
asadiqbal08/mitxpro: Users with bad edX auth can complete orders

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -14,6 +14,7 @@ from courseware.api import unenroll_edx_course_run, enroll_in_edx_course_runs
 from courseware.exceptions import (
     UnknownEdxApiEnrollException,
     EdxApiEnrollErrorException,
+    NoEdxApiAuthError,
 )
 from ecommerce import mail_api
 from mitxpro.utils import partition, first_or_none
@@ -102,7 +103,11 @@ def create_run_enrollments(user, runs, order=None, company=None):
     """
     try:
         enroll_in_edx_course_runs(user, runs)
-    except (EdxApiEnrollErrorException, UnknownEdxApiEnrollException):
+    except (
+        EdxApiEnrollErrorException,
+        UnknownEdxApiEnrollException,
+        NoEdxApiAuthError,
+    ):
         log.exception(
             "edX enrollment failure for user: %s, runs: %s (order: %s)",
             user,

--- a/courses/management/utils.py
+++ b/courses/management/utils.py
@@ -7,6 +7,7 @@ from courses.models import CourseRun, CourseRunEnrollment, Program, ProgramEnrol
 from courseware.exceptions import (
     EdxApiEnrollErrorException,
     UnknownEdxApiEnrollException,
+    NoEdxApiAuthError,
 )
 from courseware.api import enroll_in_edx_course_runs
 from ecommerce import mail_api
@@ -212,6 +213,10 @@ class EnrollmentChangeCommand(BaseCommand):
         try:
             enroll_in_edx_course_runs(user, course_runs)
             return True
-        except (EdxApiEnrollErrorException, UnknownEdxApiEnrollException) as exc:
+        except (
+            EdxApiEnrollErrorException,
+            UnknownEdxApiEnrollException,
+            NoEdxApiAuthError,
+        ) as exc:
             self.stdout.write(self.style.WARNING(str(exc)))
         return False


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
[Ticket](https://trello.com/c/dsdx9q4h/71-bug-user-with-bad-edx-auth-can-complete-orders-and-end-up-with-no-enrollment-records)

#### What's this PR do?
Fix if the course run enrollment in edX fails, but a CourseRunEnrollment record in xpro should exist.

#### How should this be manually tested?
Yet just introduced to catch the `NoEdxApiAuthError` that seems as a blocker to the xPro flow. 
- If `OpenEdxApiAuth` model does not have the corresponding user entry then raising `NoEdxApiAuthError` in code base. 
