### PR TITLE
Upgrade postgres version in docker-compose, and update to Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM python:3.6.8-stretch
+FROM python:3.7
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
 WORKDIR /tmp
 
-# Install packages and add repo needed for postgres 9.6
+# Install packages
 COPY apt.txt /tmp/apt.txt
-RUN echo deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main > /etc/apt/sources.list.d/pgdg.list
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 
@@ -15,8 +13,7 @@ RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 # NOTE: if you need to add a package dependency that is required in all envs, please add it to apt.txt
 #############################################
 
-# Add repo needed for postgres 9.6 and install it
-RUN apt-get update && apt-get install libpq-dev postgresql-client-9.6 -y
+RUN apt-get update && apt-get install libpq-dev postgresql-client -y
 
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ x-extra-hosts:
 
 services:
   db:
-    image: postgres
+    image: postgres:11.6
     ports:
       - "5432"
 

--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -106,7 +106,7 @@ def mock_hubspot_errors(mocker):
     """Mock the get_sync_errors API call, assuming a limit of 2"""
     yield mocker.patch(
         "hubspot.api.paged_sync_errors",
-        side_effect=[error_response_json[0:2], error_response_json[2:]],
+        side_effect=[error_response_json[0:2], error_response_json[2:], []],
     )
 
 
@@ -114,7 +114,7 @@ def mock_hubspot_errors(mocker):
 def mock_hubspot_line_error(mocker):
     """Mock the get_sync_errors API call and return a line sync error with an invalid association property"""
     yield mocker.patch(
-        "hubspot.api.paged_sync_errors", side_effect=[line_error_response_json[0:1]]
+        "hubspot.api.paged_sync_errors", side_effect=[line_error_response_json[0:1], []]
     )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
- Fixes test failures due to mismatching postgres versions. Since the current postgres version used by heroku is 11.6, this PR will pin the docker  container to the same version
 - Upgrades to python 3.7. With postgresql-client-9.6 no longer needed it was easiest to specify the Python 3.7 docker container which includes an updated postgresql-client version

#### How should this be manually tested?
Website should load correctly. docker-compose.yml is only used in testing and development so there should not be any change in production
