### PR TITLE
Removed course run preselect logic in checkout

### DIFF
--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -280,9 +280,6 @@ describe("CheckoutForm", () => {
       basketItem.courses.forEach((course, i) => {
         const select = inner.find("select").at(i)
 
-        const runId = selectedRuns[course.id]
-        assert.equal(select.prop("value"), runId)
-
         const runs = course.courseruns
         assert.equal(select.find("option").length, runs.length + 1)
         const firstOption = select.find("option").at(0)

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -61,43 +61,11 @@ export const calcSelectedRunIds = (
     }
   }
 
-  const selectedRunIds = {}
-  let preselectCourseId, preselectedRunId, preselectedRunDate
-  if (preselectId) {
-    for (const course of item.courses) {
-      const matchingRun = course.courseruns.find(run => run.id === preselectId)
-      if (matchingRun) {
-        preselectCourseId = course.id
-        preselectedRunDate = moment(matchingRun.start_date)
-        selectedRunIds[preselectCourseId] = matchingRun.id
-        break
-      }
-    }
-  }
-  if (!preselectCourseId) {
-    for (const course of item.courses) {
-      if (course.next_run_id) {
-        selectedRunIds[course.id] = course.next_run_id
-      }
-    }
-    return selectedRunIds
-  }
-
-  const otherCourses = R.reject(R.propEq("id", preselectCourseId), item.courses)
-  for (const course of otherCourses) {
-    // Course runs are sorted by start date, so we just need the first one we find with a
-    // start date that is the same or later than the preselected run.
-    const runClosestToPreselect = course.courseruns.find(run =>
-      sameDayOrLater(moment(run.start_date), preselectedRunDate)
-    )
-    const selectedRunId = runClosestToPreselect
-      ? runClosestToPreselect.id
-      : course.next_run_id
-    if (selectedRunId) {
-      selectedRunIds[course.id] = selectedRunId
-    }
-  }
-  return selectedRunIds
+  // NOTE: Due to a bug, the logic for preselecting course runs for courses in a program is disabled. In other words,
+  // all course run select boxes should start with no selection at all. This will change when we decide on desired
+  // course run pre-selection behavior. The following code replaces logic that was last changed in this PR:
+  // https://github.com/mitodl/mitxpro/pull/1515
+  return {}
 }
 
 export class CheckoutPage extends React.Component<Props, State> {

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -89,25 +89,6 @@ describe("CheckoutPage", () => {
     assert.equal(inner.find("CheckoutForm").prop("couponCode"), code)
   })
 
-  it("parses the preselect ID from the query parameter and verifies it exists in selected runs", async () => {
-    const course = basket.items[0].courses[0]
-    const courseId = course.id
-    const courseRunId = course.courseruns[0].id
-    const { inner } = await renderPage(
-      {},
-      {
-        location: {
-          search: `product=4567&preselect=${courseRunId}`
-        }
-      }
-    )
-    // Verify that the preselected courseRunId is included against the courseId in selectedRuns
-    assert.equal(
-      inner.find("CheckoutForm").prop("selectedRuns")[courseId],
-      courseRunId
-    )
-  })
-
   it("submits the coupon code", async () => {})
   ;[true, false].forEach(hasCouponCode => {
     [true, false].forEach(hasError => {
@@ -376,24 +357,7 @@ describe("CheckoutPage", () => {
     it("calculates selected run ids from a basket item", () => {
       const item = basket.items[0]
       item.type = PRODUCT_TYPE_PROGRAM
-      const expected = {}
-      for (const runId of item.run_ids) {
-        for (const course of item.courses) {
-          expected[course.id] = course.next_run_id
-        }
-      }
-      assert.deepEqual(calcSelectedRunIds(item), expected)
-    })
-
-    it("uses the next_run_id for a default selected course run", () => {
-      const item = basket.items[0]
-      item.type = PRODUCT_TYPE_PROGRAM
-      const expected = {}
-      for (const course of item.courses) {
-        expected[course.id] = course.next_run_id
-      }
-      item.run_ids = []
-      assert.deepEqual(calcSelectedRunIds(item), expected)
+      assert.deepEqual(calcSelectedRunIds(item), {})
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. This is related to a bug that #1515 only partially fixed

#### What's this PR do?
Initializes all course run selection boxes in the checkout page such that there is no selection

#### How should this be manually tested?
Go to the checkout page with a program or course run. You can also test using a `preselect` querystring param to indicate a preselected course run. In all cases, the course run select boxes for a program in the checkout page should _not_ have a selection, even if `preselect` was provided.

#### Any background context you want to provide?
We've had a lot of issues with users enrolling in a program, having incorrect/unexpected course runs preselected, and completing checkout without changing them. The cause of the underlying bug is that we have always considered the soonest unexpired course run to be the one that should be preselected for each course, when we should have been thinking about course runs in a series, or "program run". For example, if a program has 3 courses, someone is most likely going to want to take 1, 2, and 3 in series. These courses are offered multiple times, so there will be multiple series of course runs. The start dates for one series might be 2/2020, 4/2020, and 6/2020, then the first course for another series might start at 8/2020, or it might overlap with the previous series and start at 4/2020. Choosing the soonest unexpired course run pays no attention to these series of courses which our learners are most likely to enroll in. An example of the bug would be if one series of courses started at 2/2020, 4/2020, and 6/2020, and the start date of the last course of the previous series was also 2/2020. Before this PR, the preselected run of the last course would be 2/2020 instead of 6/2020.

Eventually we will reimplement this preselection, but we need to discuss desired behavior first. In the meantime this PR is intended to prevent further faulty program enrollments.

#### Screenshots (if appropriate)
<img width="1029" alt="ss 2020-02-20 at 15 18 42 " src="https://user-images.githubusercontent.com/14932219/74976006-f920f100-53f5-11ea-9f36-2b3072704674.png">

