### PR TITLE
Actually fixed enrollment change sheet file watch renewal

### DIFF
--- a/sheets/api.py
+++ b/sheets/api.py
@@ -31,12 +31,18 @@ from sheets.constants import (
     GOOGLE_API_FILE_WATCH_KIND,
     GOOGLE_API_NOTIFICATION_TYPE,
     DEFAULT_GOOGLE_EXPIRE_TIMEDELTA,
-    SHEETS_VALUE_REQUEST_PAGE_SIZE,
+    SHEET_TYPE_COUPON_REQUEST,
+    SHEET_TYPE_ENROLL_CHANGE,
+    WORKSHEET_TYPE_REFUND,
+    SHEET_TYPE_COUPON_ASSIGN,
 )
 from sheets.utils import (
     format_datetime_for_google_timestamp,
     google_timestamp_to_datetime,
     build_drive_file_email_share_request,
+    CouponRequestSheetMetadata,
+    RefundRequestSheetMetadata,
+    CouponAssignSheetMetadata,
 )
 from sheets.exceptions import FailedBatchRequestException
 
@@ -464,3 +470,25 @@ def renew_sheet_file_watch(sheet_metadata, force=False):
             file_watch.version += 1
         file_watch.save()
         return file_watch, created, True
+
+
+def get_sheet_metadata_from_type(sheet_type):
+    """
+    Gets sheet metadata associated with the given sheet type
+
+    Args:
+        sheet_type (str):
+
+    Returns:
+        type(sheets.utils.SheetMetadata): An object with metadata about some sheet type
+
+    Raises:
+         ValueError: Raised if there is no metadata class associated with the given sheet type
+    """
+    if sheet_type == SHEET_TYPE_COUPON_REQUEST:
+        return CouponRequestSheetMetadata()
+    elif sheet_type == SHEET_TYPE_COUPON_ASSIGN:
+        return CouponAssignSheetMetadata()
+    elif sheet_type in {SHEET_TYPE_ENROLL_CHANGE, WORKSHEET_TYPE_REFUND}:
+        return RefundRequestSheetMetadata()
+    raise ValueError(f"No sheet metadata exists matching the type '{sheet_type}'")

--- a/sheets/constants.py
+++ b/sheets/constants.py
@@ -11,8 +11,9 @@ DEFAULT_GOOGLE_EXPIRE_TIMEDELTA = dict(minutes=60)
 SHEETS_VALUE_REQUEST_PAGE_SIZE = 50
 SHEET_TYPE_COUPON_REQUEST = "enrollrequest"
 SHEET_TYPE_COUPON_ASSIGN = "enrollassign"
-SHEET_TYPE_REFUND = "refund"
-SHEET_TYPE_DEFERRAL = "defer"
+SHEET_TYPE_ENROLL_CHANGE = "enrollchange"
+WORKSHEET_TYPE_REFUND = "refund"
+WORKSHEET_TYPE_DEFERRAL = "defer"
 
 # The index of the first row of a spreadsheet according to Google
 GOOGLE_SHEET_FIRST_ROW = 1

--- a/sheets/enrollment_change_api.py
+++ b/sheets/enrollment_change_api.py
@@ -191,8 +191,9 @@ class EnrollmentChangeRequestHandler:
         ignored_row_results = row_result_dict.get(ResultType.IGNORED, [])
         if ignored_row_results:
             log.warning(
-                "Ignored rows in %s: %s",
+                "Ignored rows in %s (%s): %s",
                 self.sheet_metadata.sheet_name,
+                self.sheet_metadata.worksheet_name,
                 [row_result.row_index for row_result in ignored_row_results],
             )
         return row_result_dict

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -18,9 +18,10 @@ from sheets.constants import (
     GOOGLE_SERVICE_ACCOUNT_EMAIL_DOMAIN,
     SHEETS_VALUE_REQUEST_PAGE_SIZE,
     SHEET_TYPE_COUPON_REQUEST,
-    SHEET_TYPE_REFUND,
+    WORKSHEET_TYPE_REFUND,
     SHEET_TYPE_COUPON_ASSIGN,
-    SHEET_TYPE_DEFERRAL,
+    WORKSHEET_TYPE_DEFERRAL,
+    SHEET_TYPE_ENROLL_CHANGE,
 )
 
 
@@ -62,6 +63,8 @@ class SheetMetadata:
 
     sheet_type = None
     sheet_name = None
+    worksheet_type = None
+    worksheet_name = None
     first_data_row = None
     non_input_column_indices = set()
     num_columns = 0
@@ -134,8 +137,10 @@ class RefundRequestSheetMetadata(
     SKIP_ROW_COL = 14
 
     def __init__(self):
-        self.sheet_type = SHEET_TYPE_REFUND
-        self.sheet_name = "Refund Request sheet"
+        self.sheet_type = SHEET_TYPE_ENROLL_CHANGE
+        self.sheet_name = "Enrollment Change Request sheet"
+        self.worksheet_type = WORKSHEET_TYPE_REFUND
+        self.worksheet_name = "Refunds"
         self.first_data_row = settings.SHEETS_REFUND_FIRST_ROW
         self.num_columns = self.SKIP_ROW_COL + 1
         self.non_input_column_indices = set(
@@ -163,8 +168,10 @@ class DeferralRequestSheetMetadata(
     SKIP_ROW_COL = 10
 
     def __init__(self):
-        self.sheet_type = SHEET_TYPE_DEFERRAL
-        self.sheet_name = "Deferral Request sheet"
+        self.sheet_type = SHEET_TYPE_ENROLL_CHANGE
+        self.sheet_name = "Enrollment Change Request sheet"
+        self.worksheet_type = WORKSHEET_TYPE_DEFERRAL
+        self.worksheet_name = "Deferrals"
         self.first_data_row = settings.SHEETS_DEFERRAL_FIRST_ROW
         self.num_columns = self.SKIP_ROW_COL + 1
         self.non_input_column_indices = set(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket

#### What's this PR do?
Solves a problem that PR #1548 didn't quite fix. This fully sets up deferral requests to be processed when the enrollment change spreadsheet is changed.

#### How should this be manually tested?
Code review only. No manual testing needed.

#### Any background context you want to provide?
The problem with the PR mentioned above is that file watch requests (aka webhooks) are sent when anything in an entire spreadsheet changes, and those requests are not limited to specific worksheets within the spreadsheet. In the PR above I conflated spreadsheets and worksheets, and during testing I was looking for the wrong changes.
