### PR TITLE
add loading spinner to bulk purchase page

### DIFF
--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -233,7 +233,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       return (
         <DocumentTitle title={`${SETTINGS.site_name} | ${CHECKOUT_PAGE_TITLE}`}>
           {isLoading ? (
-            <div className="checkout-page  checkout-loader text-center align-self-center">
+            <div className="checkout-page page-loader text-center align-self-center">
               <div className="loader-area">
                 <img
                   src="/static/images/loader.gif"

--- a/static/js/containers/pages/b2b/B2BPurchasePage_test.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage_test.js
@@ -26,6 +26,11 @@ describe("B2BPurchasePage", () => {
       {
         entities: {
           products
+        },
+        queries: {
+          products: {
+            isPending: false
+          }
         }
       },
       {
@@ -46,6 +51,15 @@ describe("B2BPurchasePage", () => {
       body:   undefined,
       status: 200
     })
+  })
+
+  it("displays loader", async () => {
+    const { inner } = await renderPage()
+    inner.setProps({ isLoading: true })
+    assert.equal(
+      inner.find(".page").text(),
+      "One moment while we prepare bulk purchase page"
+    )
   })
 
   it("renders a form", async () => {
@@ -215,6 +229,9 @@ describe("B2BPurchasePage", () => {
   it("sets requestPending when a request is in progress", async () => {
     const { inner } = await renderPage({
       queries: {
+        products: {
+          isPending: false
+        },
         b2bCheckoutMutation: {
           isPending: true
         }

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -60,6 +60,7 @@ export default {
   }),
   productsSelector: pathOr(null, ["entities", "products"]),
   productsQuery:    () => ({
+    queryKey:  "products",
     url:       "/api/products/",
     transform: (json: Array<ProductDetail>) => ({
       products: json
@@ -122,7 +123,8 @@ export default {
       b2b_order_status: (prev: B2BOrderStatus, next: B2BOrderStatus) => next
     }
   }),
-  b2bCouponStatus: (payload: B2BCouponStatusPayload) => ({
+  b2bCouponStatusSelector: pathOr(null, ["entities", "b2b_coupon_status"]),
+  b2bCouponStatus:         (payload: B2BCouponStatusPayload) => ({
     queryKey:  "b2bCouponStatus",
     url:       "/api/b2b/coupon_status/",
     transform: (json: B2BCouponStatusPayload) => ({

--- a/static/scss/checkout.scss
+++ b/static/scss/checkout.scss
@@ -455,26 +455,3 @@
     margin-top: 30px;
   }
 }
-
-.checkout-loader {
-  position: fixed;
-  width: 100%;
-  top: 90px;
-  left: 0;
-  height: calc(100vh - 90px);
-  z-index: 9;
-  right: 0;
-  max-width: initial;
-  display: flex;
-  flex-flow: wrap;
-  align-content: center;
-  padding-top: 0;
-
-  .loader-area {
-    width: 100%;
-
-    img {
-      margin-bottom: 15px;
-    }
-  }
-}

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -154,3 +154,35 @@ a.link-button {
   border-bottom: 2px dashed #8a8b8c;
   margin-top: 25px;
 }
+
+.page {
+  margin: 0 auto;
+  max-width: 1000px;
+  background-color: #f5f5f5;
+  font-weight: 600;
+  padding-top: 50px;
+  padding-bottom: 50px;
+}
+
+.page-loader {
+  position: fixed;
+  width: 100%;
+  top: 90px;
+  left: 0;
+  height: calc(100vh - 90px);
+  z-index: 9;
+  right: 0;
+  max-width: initial;
+  display: flex;
+  flex-flow: wrap;
+  align-content: center;
+  padding-top: 0;
+
+  .loader-area {
+    width: 100%;
+
+    img {
+      margin-bottom: 15px;
+    }
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
[Ticket](https://trello.com/c/ftyJTt7s/82-bulk-purchase-add-loading-spinner-to-form)

#### What's this PR do?
Bulk Purchase: add loading spinner to form until products are ready to list down

#### How should this be manually tested?
Just load the `/ecommerce/bulk/` page and see if right on loading it list downs the products.

#### Screenshots
<img width="1436" alt="Screenshot 2020-03-04 at 19 38 04" src="https://user-images.githubusercontent.com/4043989/75967914-5afd5280-5eee-11ea-81a9-644430376c49.png">

