### PR TITLE
Bulk Purchase: change error message to an HREF instead of a MAILTO

### DIFF
--- a/static/js/components/notifications/index.js
+++ b/static/js/components/notifications/index.js
@@ -3,7 +3,11 @@ import React from "react"
 
 import MixedLink from "../MixedLink"
 import { routes } from "../../lib/urls"
-import { ALERT_TYPE_TEXT, ALERT_TYPE_UNUSED_COUPON } from "../../constants"
+import {
+  ALERT_TYPE_TEXT,
+  ALERT_TYPE_UNUSED_COUPON,
+  ALTER_TYPE_B2B_ORDER_STATUS
+} from "../../constants"
 
 import type {
   TextNotificationProps,
@@ -38,7 +42,26 @@ export const UnusedCouponNotification = (
   )
 }
 
+export const B2BOrderStatusNotification = (props: ComponentProps) => {
+  const { dismiss } = props
+
+  return (
+    <span>
+      Something went wrong. Please contact us at{" "}
+      <a
+        href="https://xpro.zendesk.com/hc/en-us/requests/new"
+        onClick={dismiss}
+        className="alert-link"
+      >
+        Customer Support
+      </a>
+      .
+    </span>
+  )
+}
+
 export const notificationTypeMap = {
-  [ALERT_TYPE_TEXT]:          TextNotification,
-  [ALERT_TYPE_UNUSED_COUPON]: UnusedCouponNotification
+  [ALERT_TYPE_TEXT]:             TextNotification,
+  [ALERT_TYPE_UNUSED_COUPON]:    UnusedCouponNotification,
+  [ALTER_TYPE_B2B_ORDER_STATUS]: B2BOrderStatusNotification
 }

--- a/static/js/components/notifications/index_test.js
+++ b/static/js/components/notifications/index_test.js
@@ -3,7 +3,11 @@ import React from "react"
 import { assert } from "chai"
 import { shallow } from "enzyme"
 
-import { TextNotification, UnusedCouponNotification } from "."
+import {
+  TextNotification,
+  UnusedCouponNotification,
+  B2BOrderStatusNotification
+} from "."
 import { routes } from "../../lib/urls"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 
@@ -41,6 +45,24 @@ describe("Notification component", () => {
     assert.isTrue(link.exists())
     assert.deepInclude(link.props(), {
       dest:      `${routes.checkout}?product=${productId}&code=${couponCode}`,
+      onClick:   dismissStub,
+      className: "alert-link"
+    })
+  })
+
+  it("B2BOrderStatusNotification", () => {
+    const wrapper = shallow(
+      <B2BOrderStatusNotification dismiss={dismissStub} />
+    )
+    assert.equal(
+      wrapper.text(),
+      "Something went wrong. Please contact us at Customer Support."
+    )
+    const link = wrapper.find("a")
+    assert.isTrue(link.exists())
+    assert.equal(link.text(), "Customer Support")
+    assert.deepInclude(link.props(), {
+      href:      "https://xpro.zendesk.com/hc/en-us/requests/new",
       onClick:   dismissStub,
       className: "alert-link"
     })

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -109,6 +109,7 @@ export const HIGHEST_EDUCATION_CHOICES = [
 
 export const ALERT_TYPE_TEXT = "text"
 export const ALERT_TYPE_UNUSED_COUPON = "unused-coupon"
+export const ALTER_TYPE_B2B_ORDER_STATUS = "b2b-order-status"
 
 // HTML title for different pages
 export const CHECKOUT_PAGE_TITLE = "Checkout"

--- a/static/js/containers/pages/b2b/B2BReceiptPage.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage.js
@@ -14,7 +14,7 @@ import queries from "../../../lib/queries"
 import { addUserNotification } from "../../../actions"
 import { wait } from "../../../lib/util"
 import { formatPrice } from "../../../lib/ecommerce"
-import { ALERT_TYPE_TEXT } from "../../../constants"
+import { ALTER_TYPE_B2B_ORDER_STATUS } from "../../../constants"
 import { bulkReceiptCsvUrl } from "../../../lib/urls"
 
 import type { B2BOrderStatus } from "../../../flow/ecommerceTypes"
@@ -90,11 +90,8 @@ export class B2BReceiptPage extends React.Component<Props, State> {
     } else {
       addUserNotification({
         "b2b-order-status": {
-          type:  ALERT_TYPE_TEXT,
-          color: "danger",
-          props: {
-            text: `Something went wrong. Please contact support at ${SETTINGS.support_email}.`
-          }
+          type:  ALTER_TYPE_B2B_ORDER_STATUS,
+          color: "danger"
         }
       })
     }

--- a/static/js/containers/pages/b2b/B2BReceiptPage_test.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage_test.js
@@ -155,10 +155,7 @@ describe("B2BReceiptPage", () => {
         assert.deepEqual(store.getState().ui.userNotifications, {
           "b2b-order-status": {
             color: "danger",
-            type:  "text",
-            props: {
-              text: `Something went wrong. Please contact support at ${SETTINGS.support_email}.`
-            }
+            type:  "b2b-order-status"
           }
         })
       } else {

--- a/static/js/reducers/notifications.js
+++ b/static/js/reducers/notifications.js
@@ -2,7 +2,11 @@
 import { mergeRight, omit } from "ramda"
 
 import { ADD_USER_NOTIFICATION, REMOVE_USER_NOTIFICATION } from "../actions"
-import { ALERT_TYPE_TEXT, ALERT_TYPE_UNUSED_COUPON } from "../constants"
+import {
+  ALERT_TYPE_TEXT,
+  ALERT_TYPE_UNUSED_COUPON,
+  ALTER_TYPE_B2B_ORDER_STATUS
+} from "../constants"
 
 import type { Action } from "../flow/reduxTypes"
 
@@ -22,6 +26,11 @@ export type UserNotificationSpec =
       type: ALERT_TYPE_UNUSED_COUPON,
       color: string,
       props: UnusedCouponNotificationProps
+    }
+  | {
+      type: ALTER_TYPE_B2B_ORDER_STATUS,
+      color: string,
+      props: TextNotificationProps
     }
 
 export type UserNotificationMapping = { [string]: UserNotificationSpec }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
[Ticket](https://trello.com/c/YoqSYlC5/93-bulk-purchase-change-error-message-to-an-href-instead-of-a-mailto)

#### What's this PR do?
Bulk Purchase: change error message to an HREF instead of a MAILTO

#### How should this be manually tested?
(Required)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
<img width="1432" alt="Screenshot 2020-03-09 at 19 01 49" src="https://user-images.githubusercontent.com/4043989/76232540-a7c38f00-6248-11ea-9082-7699f587f860.png">


#### What GIF best describes this PR or how it makes you feel?
(Optional)
