### PR TITLE
Fixed conflicting ecommerce migration file names

### DIFF
--- a/ecommerce/migrations/0029_bulk_assignment_date_fields.py
+++ b/ecommerce/migrations/0029_bulk_assignment_date_fields.py
@@ -22,7 +22,7 @@ def backfill_last_assignment_date(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    dependencies = [("ecommerce", "0026_coupon_include_future_runs")]
+    dependencies = [("ecommerce", "0028_include_future_runs_default")]
 
     operations = [
         migrations.RenameField(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. The build on master was broken b/c of a name conflict in ecommerce migration files

#### How should this be manually tested?
Run migrations
