### PR TITLE
Retire users by email address in addition to username

### DIFF
--- a/users/management/commands/retire_users_test.py
+++ b/users/management/commands/retire_users_test.py
@@ -51,3 +51,23 @@ def test_multiple_success():
         assert user.is_active is False
         assert "retired_email" in user.email
         assert UserSocialAuth.objects.filter(user=user).count() == 0
+
+
+@pytest.mark.django_db
+def test_retire_user_with_email():
+    """test retire_users command success with user email"""
+    test_email = "test@email.com"
+
+    user = UserFactory.create(email=test_email, is_active=True)
+    UserSocialAuthFactory.create(user=user, provider="edX")
+
+    assert user.is_active is True
+    assert "retired_email" not in user.email
+    assert UserSocialAuth.objects.filter(user=user).count() == 1
+
+    COMMAND.handle("retire_users", users=[test_email])
+
+    user.refresh_from_db()
+    assert user.is_active is False
+    assert "retired_email" in user.email
+    assert UserSocialAuth.objects.filter(user=user).count() == 0


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/gshJi9u0/108-retire-users-by-email-address-in-addition-to-username

#### What's this PR do?
Update retire_users management command to retire users by email address in addition to username.

#### How should this be manually tested?
```
Retire one or multiple users. Username or email can be used to identify a user.

    For single user use:\n
    `./manage.py retire_users --user=foo` or do \n
    `./manage.py retire_users -u foo` \n or do \n
    `./manage.py retire_users -u foo@email.com` \n or do \n

    For multiple users, add arg `--user` for each user i.e:\n
    `./manage.py retire_users --user=foo --user=bar --user=baz` or do \n
    `./manage.py retire_users --user=foo@email.com --user=bar@email.com --user=baz` or do \n
    `./manage.py retire_users -u foo -u bar -u baz`
```