### PR TITLE
Pin nginx to 1.16.1 in docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "6379"
 
   nginx:
-    image: nginx
+    image: nginx:1.16.1
     ports:
       - "8053:8053"
     links:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/etErLc2S/111-pin-nginx-to-1161-in-docker-configuration)

#### What's this PR do?
Pins `nginx` version to `1.16.1` in order to avoid unnecessary updates.

#### How should this be manually tested?
Application should function as normal. Version of the `nginx` service should now always be `1.16.1`.