### PR TITLE
Pin redis version to 5.0.5 in docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "5432"
 
   redis:
-    image: redis
+    image: redis:5.0.5
     ports:
       - "6379"
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/mPKs84cj/112-pin-redis-version-to-505-in-docker-config)

#### What's this PR do?
Pins `redis` to version `5.0.5` in docker config in order to avoid unintentional upgrades.

#### How should this be manually tested?
App should function as expected, redis should report version number `5.0.5`.