### PR TITLE
Choose an active course run when the current product is expired.

### DIFF
--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -43,7 +43,8 @@ type State = {
   appliedInitialCoupon: boolean,
   errors: string | Object | null,
   isLoading: boolean,
-  showGenericError: boolean
+  showGenericError: boolean,
+  basketProduct: string
 }
 
 export class CheckoutPage extends React.Component<Props, State> {
@@ -51,7 +52,8 @@ export class CheckoutPage extends React.Component<Props, State> {
     appliedInitialCoupon: false,
     errors:               null,
     isLoading:            true,
-    showGenericError:     false
+    showGenericError:     false,
+    basketProduct:        ""
   }
 
   logExceptionToSentry = (
@@ -102,6 +104,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       } else {
         this.setState({ showGenericError: false })
       }
+      this.setState({ basketProduct: productId })
     }
     this.setState({
       isLoading: false
@@ -110,6 +113,7 @@ export class CheckoutPage extends React.Component<Props, State> {
 
   submit = async (values: Values, actions: Actions) => {
     const { basket, updateBasket, checkout } = this.props
+    const { basketProduct } = this.state
 
     if (!basket) {
       // if there is no basket there shouldn't be any submit button rendered
@@ -117,10 +121,9 @@ export class CheckoutPage extends React.Component<Props, State> {
     }
 
     // update basket with selected runs
-    const { productId } = this.getQueryParams()
     const basketPayload = {
       items: basket.items.map(item => ({
-        product_id: productId,
+        product_id: basketProduct,
         run_ids:    Object.values(values.runs).map(runId => parseInt(runId))
       })),
       coupons:       values.couponCode ? [{ code: values.couponCode }] : [],
@@ -222,6 +225,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       "runs",
       response.body.errors ? response.body.errors.runs : undefined
     )
+    this.setState({ basketProduct: productId.toString() })
   }
 
   render() {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/4oHTPMeZ/104-bug-cant-choose-an-active-course-run-when-the-current-product-is-expired

#### What's this PR do?
Fix Bug: can't choose an active course run when the current product is expired.

#### How should this be manually tested?
**Steps**
- Create a two course runs associated with the same course. R1 should have an enrollment end date and course end date in the past (i.e. the run is not available for enrollment). R2 should have an enrollment end date and a course end date in the future (the run is available for enrollment.
- Create a product for R1 and R2.
- Go to the checkout page for the product for R1. Since R1 is no longer open, it shouldn't appear in the drop down. But R2 should.
- Select R2.
- Click Place Order **(You should proceed to CyberSource for checkout)**

#### Where should the reviewer start?
(Optional)

#### Screenshots (if appropriate)
<img width="1437" alt="Screenshot 2020-03-11 at 19 07 29" src="https://user-images.githubusercontent.com/4043989/76626907-d2208f80-655b-11ea-9b8a-89e4a401e604.png">

<img width="1438" alt="Screenshot 2020-03-12 at 20 02 19" src="https://user-images.githubusercontent.com/4043989/76626913-d77dda00-655b-11ea-8cf0-fd116049d571.png">
