### PR TITLE
Choose future program run from catalog instead of active one

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -697,11 +697,13 @@ class ProgramPage(ProductPage):
             else False
         )
         now = now_in_utc()
-        active_program_run = program.programruns.filter(
-            start_date__lte=now, end_date__gt=now
-        ).first()
-        if active_program_run:
-            checkout_product_id = active_program_run.full_readable_id
+        soonest_future_program_run = (
+            program.programruns.filter(start_date__gt=now)
+            .order_by("start_date")
+            .first()
+        )
+        if soonest_future_program_run:
+            checkout_product_id = soonest_future_program_run.full_readable_id
         elif product:
             checkout_product_id = product.id
         else:
@@ -715,9 +717,7 @@ class ProgramPage(ProductPage):
                 None
                 if not checkout_product_id
                 else f"{reverse('checkout-page')}?product={ checkout_product_id }"
-            )
-            if product
-            else None,
+            ),
             "enrolled": enrolled,
             "user": request.user,
         }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/Xuu2fpzc/113-bug-suggest-future-program-run-on-a-program-catalog-page-instead-of-a-currently-active-one

#### What's this PR do?
On a program detail page (as accessed from the catalog), this fixes the "Enroll Now" link so that a future program run is set as the product in checkout instead of a currently-active one

#### How should this be manually tested?
- Create 2 `ProgramRun` objects for one `Program`. One with a start and end date that are before and after todays date, and one with a future start date
- Visit that program's detail page and click "Enroll Now"

The `product` param in the checkout URL should match the `full_readable_id` for the future program (`full_readable_id` can be seen in Django admin, e.g.: `program-v1:xPRO+DgtlLearn+R2`)
