### PR TITLE
asadiqbal08/Add a text-only link on verification emails

### DIFF
--- a/mail/templates/verification/body.html
+++ b/mail/templates/verification/body.html
@@ -26,6 +26,12 @@
                   </td>
               </tr>
               <tr>
+                <td style="padding: 0 20px 20px;">
+                  <p>If the button doesn't work, copy and paste this link into your web browser:</p>
+                  {{ confirmation_url }}
+                </td>
+              </tr>
+              <tr>
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;">
                         Welcome and thanks!


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/RKAYqY01/117-add-a-text-only-link-on-verification-emails)

#### What's this PR do?
Add a text-only link on verification email.

#### How should this be manually tested?
- Create an account and visit inbox to verify your email. 

#### Screenshots (if appropriate)
<img width="752" alt="Screen Shot 2020-03-19 at 12 48 46 PM" src="https://user-images.githubusercontent.com/7334669/77043922-4f2a8980-69e0-11ea-926f-747a2232673a.png">


