### PR TITLE
Add a text-only link in password change email

### DIFF
--- a/mail/templates/password_reset/body.html
+++ b/mail/templates/password_reset/body.html
@@ -25,7 +25,12 @@
                       <!-- Button : END -->
                   </td>
               </tr>
-
+              <tr>
+                <td style="padding: 0 20px 20px;">
+                    <p>If the button doesn't work, copy and paste this link into your web browser:</p>
+                    {{ base_url }}{% url 'password-reset-confirm' uid=uid token=token %}
+                </td>
+            </tr>
           </table>
       </td>
   </tr>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/Ejl8HRwy/102-add-a-text-only-link-on-password-change-emails

#### What's this PR do?
Add a text-only link in the password change email

#### How should this be manually tested?

- Goto sign-in page
- Click on forgot password
- Enter your email.
- You should see an email with a text-only link.

#### Screenshots (if appropriate)
<img width="759" alt="Screenshot 2020-03-19 at 2 32 39 PM" src="https://user-images.githubusercontent.com/4245618/77052515-be0edf00-69ee-11ea-8a38-0240de6e98ad.png">
