### PR TITLE
Added support for ignored rows in a coupon request spreadsheet

### DIFF
--- a/sheets/conftest.py
+++ b/sheets/conftest.py
@@ -87,4 +87,6 @@ def coupon_req_row(base_data):  # pylint: disable=redefined-outer-name
         expiration=datetime(2020, 2, 2, 2, 2, 2, tzinfo=pytz.UTC),
         date_processed=False,
         error=None,
+        skip_row=False,
+        requester="email@example.com",
     )

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -126,6 +126,7 @@ class CouponRequestSheetMetadata(SingletonSheetMetadata):
     COUPON_NAME_COL_INDEX = 1
     PROCESSED_COL = settings.SHEETS_REQ_PROCESSED_COL
     ERROR_COL = settings.SHEETS_REQ_ERROR_COL
+    SKIP_ROW_COL = ERROR_COL + 1
 
     def __init__(self):
         self.sheet_type = SHEET_TYPE_COUPON_REQUEST


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1587 

#### What's this PR do?
Adds support for ignored rows in a coupon request spreadsheet. This means that an admin can set a simple value in the spreadsheet data to ensure that xpro does not attempt to process the row and create enrollment codes. This is useful when a user has entered a request for enrollment codes that is invalid and we have no intention of "repairing" the entry.

#### How should this be manually tested?
Like other xPro sheets features, this is code review only. This will be manually tested in RC

#### Any background context you want to provide?
The coupon request sheet was my first attempt at spreadsheets-as-an-admin-tool. A bunch of lessons were learned (i.e.: the fact that rows can't be deleted and should instead be set to ignored) and they were applied to the change of enrollment spreadsheets. This PR just applies that same functionality to the coupon request sheet.
