### PR TITLE
Fix user login for non-new, not yet activated users

### DIFF
--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -217,7 +217,7 @@ def activate_user(
         backend (social_core.backends.base.BaseAuth): the backend being used to authenticate
         user (User): the current user
     """
-    if user.is_active or not is_new:
+    if user.is_active:
         return {}
 
     export_inquiry = compliance_api.get_latest_exports_inquiry(user)

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -506,7 +506,7 @@ def test_activate_user(
 
     assert user_actions.activate_user(None, None, user=user, is_new=is_new) == {}
 
-    if not user.is_active and is_new:
+    if not user.is_active:
         # only if the user is inactive and just registered
         assert user.is_active is expected
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #948

#### What's this PR do?
Fixes an edge case where a user logs in but is inactive and should be activated.

#### How should this be manually tested?
On master, verify you see the behavior:

- For an existing user whom you can login with, set `is_active = False`
- Attempt to login, verify that you see the described behavior

On this branch, verify that you are able to successfully login and the user is activated.