### PR TITLE
Used dynamic image loading for select CMS pages

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -27,7 +27,7 @@
                 <div class="certificate-logo">
                     <a href="https://web.mit.edu/" class="mit"></a>
                     <a href="/" class="xpro"></a>
-                    <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="">
+                    <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="MIT xPro">
                 </div>
             </div>
         </div>
@@ -71,11 +71,11 @@
             <div class="certificate">
                 <div class="certificate-holder">
                     <div class="certificate-logo">
-                        <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="">
+                        <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="MIT xPro">
                     </div>
                     <span class="institute-text">Massachusetts Institute of Technology</span>
                     <div class="institute-logo">
-                        <img src="{% static 'images/certificates/certificate-logo.png' %}" alt="">
+                        <img src="{% static 'images/certificates/certificate-logo.png' %}" alt="MIT">
                     </div>
                     <span class="certify-text">This is to certify that</span>
                     <span class="certify-name">{{ learner_name }}</span>
@@ -86,10 +86,9 @@
                     {% endif %}
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
-
                             <div class="col-sm-4 col-md-3 certify-by">
                                 <div class="signature-area">
-                                    {% image signatory.signature_image max-150x50 %}
+                                    <img src="{% image_url signatory.signature_image "max-150x50" %}" alt="{{ signatory.name }} signature" />
                                 </div>
                                 <span class="title">{{ signatory.name }}</span>
                                 {% if signatory.title_1 %}
@@ -106,7 +105,10 @@
                     </div>
                     <div class="row justify-content-center validation-link">
                         <div class="col">
-                        <p><strong>Valid Certificate ID:</strong> <a href="{{ request.build_absolute_uri }}" target="_blank">{{ uuid }}</a>
+                          <p>
+                              <strong>Valid Certificate ID:</strong>
+                              <a href="{{ request.build_absolute_uri }}" target="_blank">{{ uuid }}</a>
+                          </p>
                         </div>
                     </div>
                 </div>
@@ -118,7 +120,7 @@
             <div class="certificate-logo">
                 <a href="https://web.mit.edu/" class="mit"></a>
                 <a href="/" class="xpro"></a>
-                <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="">
+                <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="MIT xPro">
             </div>
             <div class="cer-footer-info">
                 <ul class="links">

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -11,8 +11,7 @@
       {% for member in page.members %}
         <div class="slide">
           <div class="slide-holder">
-            {% image member.value.image fill-300x300 as faculty_image %}
-            <img src="{{ faculty_image.url }}" alt="{{ member.value.name }}">
+            <img src="{% image_url member.value.image "fill-300x300" %}" alt="{{ member.value.name }}">
             <h2>{{ member.value.name }}</h2>
             <div class="text-holder">
               {{ member.value.description|richtext }}

--- a/cms/templates/partials/image-carousel.html
+++ b/cms/templates/partials/image-carousel.html
@@ -6,7 +6,7 @@
             {% for image in page.images %}
             <div class="slide">
                 <div class="img-holder">
-                    {% image image.value format-png %}
+                    <img src="{% image_url image.value "format-png" %}" alt="{{ image.value.title }}" />
                 </div>
             </div>
             {% endfor %}

--- a/cms/templates/partials/learning-techniques.html
+++ b/cms/templates/partials/learning-techniques.html
@@ -5,7 +5,7 @@
     {% for technique in page.technique_items %}
       <li>
         <div class="img-holder">
-          {% image technique.value.image height-110 format-png %}
+          <img src="{% image_url technique.value.image "height-110|format-png" %}" alt="Learning technique" />
         </div>
         <h3>{{ technique.value.heading }}</h3>
         <h4>{{ technique.value.sub_heading }}</h4>

--- a/cms/templates/partials/testimonial-carousel.html
+++ b/cms/templates/partials/testimonial-carousel.html
@@ -12,7 +12,7 @@
       <div class="slide">
         <div class="slide-holder">
           {% if testimonial.value.image %}
-            {% image testimonial.value.image fill-75x75 %}
+            <img src="{% image_url testimonial.value.image "fill-75x75" %}" alt="{{ testimonial.value.name }}" />
           {% endif %}
           <h2>{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>
           <p>{{ testimonial.value.quote|truncatechars:150 }}</p>
@@ -36,7 +36,7 @@
             </div>
             <div class="container px-4">
               <div class="row py-2">
-                {% image testimonial.value.image fill-100x100 class="border rounded-circle headshot-image" %}
+                <img src="{% image_url testimonial.value.image "fill-100x100" %}" class="border rounded-circle headshot-image" alt="Testimonial image" />
               </div>
               <div class="row mb-4">
                 <h2 class="modal-title text-uppercase">{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>

--- a/courses/models.py
+++ b/courses/models.py
@@ -835,8 +835,8 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
     def link(self):
         """
         Get the link at which this certificate will be served
-        Format: /certificates/<uuid>/
-        Example: /certificates/93ebd74e-5f88-4b47-bb09-30a6d575328f/
+        Format: /certificate/<uuid>/
+        Example: /certificate/93ebd74e-5f88-4b47-bb09-30a6d575328f/
         """
         return "/certificate/{}/".format(str(self.uuid))
 
@@ -878,8 +878,8 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
     def link(self):
         """
         Get the link at which this certificate will be served
-        Format: /certificates/program/<uuid>/
-        Example: /certificates/program/93ebd74e-5f88-4b47-bb09-30a6d575328f/
+        Format: /certificate/program/<uuid>/
+        Example: /certificate/program/93ebd74e-5f88-4b47-bb09-30a6d575328f/
         """
         return "/certificate/program/{}/".format(str(self.uuid))
 

--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -23,6 +23,7 @@ from oauth2_provider.urls import base_urlpatterns
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
+from wagtail.images.views.serve import ServeView
 
 from mitxpro.views import (
     index,
@@ -80,6 +81,13 @@ urlpatterns = [
     re_path(r"^receipt/(?P<pk>\d+)/", index, name="order-receipt"),
     re_path(r"^account-settings/", index, name="account-settings"),
     # Wagtail
+    # NOTE: This route enables dynamic Wagtail image loading. It comes directly from the Wagtail docs:
+    #       https://docs.wagtail.io/en/v2.7/advanced_topics/images/image_serve_view.html#setup
+    re_path(
+        r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
+        ServeView.as_view(),
+        name="wagtailimages_serve",
+    ),
     re_path(
         r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"
     ),

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -106,7 +106,10 @@ export class ReceiptPage extends React.Component<Props> {
                     </a>
                   </div>
                   <div className="rec-logo">
-                    <img src="/static/images/mitx-pro-logo.png" alt="" />
+                    <img
+                      src="/static/images/mitx-pro-logo.png"
+                      alt="MIT xPro"
+                    />
                   </div>
                   <h1>Receipt</h1>
                   <div className="section-info gray">


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1566

#### What's this PR do?
Uses Wagtail's [dynamic image serve view](http://docs.wagtail.io/en/v2.0/advanced_topics/images/image_serve_view.html) to generate URLs for many of our different image renditions. See background context for an explanation.

#### How should this be manually tested?
- Fill in CMS data that will render images in each one of the subpage types that use the templates that were changed in this PR
- Visit the CMS pages and confirm that the images still show up exactly as they did 

#### Any background context you want to provide?
- From [Wagtail docs](https://docs.wagtail.io/en/v2.8/advanced_topics/images/image_serve_view.html#generating-dynamic-image-urls-in-python): "One advantage of using dynamic image URLs in the template is that they do not block the initial response while rendering like the {% image %} tag does.". These periodic 503s were likely caused by Wagtail's cache being cleared and a response being held up while all of these images were re-rendering. With this change, the pages will load successfully for these same users (though they will not see the images loaded right away)
- The addition of the custom URL rule is recommended in [the same doc](https://docs.wagtail.io/en/v2.8/advanced_topics/images/image_serve_view.html#setup)
- I only applied this change to sets of images that load in a loop, e.g.: faculty images in a carousel. There are many images for which it's probably worth it to hold up the initial server response (like the site logo), and singleton images are less likely to cause a page load to time out.
