### PR TITLE
Pillow upgrade - #132

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ pygsheets==2.0.2
 ipython
 newrelic
 pdftotext==2.1.1
-Pillow==6.2.0
+Pillow==6.2.2
 psycopg2==2.8.3
 pycountry==19.7.15
 PyNaCl==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ parso==0.5.1              # via jedi
 pdftotext==2.1.1          # via -r requirements.in
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pillow==6.2.0             # via -r requirements.in, wagtail
+pillow==6.2.2             # via -r requirements.in, wagtail
 prompt-toolkit==2.0.9     # via ipython
 psycopg2==2.8.3           # via -r requirements.in, django-server-status
 ptyprocess==0.6.0         # via pexpect


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[#132](https://trello.com/c/L5FsIbjl/132-upgrade-pillow-to-version-622-or-later)

#### What's this PR do?
Upgrades Pillow to `6.2.2`. Cannot go any higher right now because Wagtail requires `<7.0.0`.

#### How should this be manually tested?
Use image specific functionality, nothing should break.
