### PR TITLE
Program certificate fix for missing enrollment - #126

### DIFF
--- a/courses/utils.py
+++ b/courses/utils.py
@@ -117,6 +117,9 @@ def generate_program_certificate(user, program):
         user=user, program=program
     )
     if existing_cert_queryset.exists():
+        ProgramEnrollment.objects.get_or_create(
+            program=program, user=user, defaults={"active": True, "change_status": None}
+        )
         return existing_cert_queryset.first(), False
 
     courses_in_program_ids = set(program.courses.values_list("id", flat=True))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/9b1Mu17D/126-bug-no-program-enrollment-created-when-user-passed-all-courses-in-a-program)

#### What's this PR do?
Modifies `generate_program_certificate` to ensure that a `ProgramEnrollment` exists if a `ProgramCertificate` already exists.

This edge case happens if a `ProgramCertificate` has already been created for a user manually before they have passed all courses in a program. In that scenario once the user passes all the courses and the certificates are being generated, the method ejects early without looking at `ProgramEnrollment` being present. Given the way certificate links are displayed on the dashboard, an enrollment is necessary for the link to be returned from the API. The change in this PR takes care of the potential bug.

#### How should this be manually tested?
Create a program with course A and course B. Enroll user in course A. Create a `ProgramCertificate` for user for the program. Create user certificate for course A. Create user certificate for course B. Ensure now a `ProgramEnrollment` exists for this user for the specific program.
