### PR TITLE
Bulk purchase form product alphabetic sorting - #137

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -134,6 +134,17 @@ class ProductViewSet(ReadOnlyModelViewSet):
         """
         return {"has_ordered_versions": True}
 
+    def list(self, request, *args, **kwargs):
+        """
+        Sort the default response if indicated in query string
+        """
+        response = super().list(request, *args, **kwargs)
+        sort = request.GET.get("sort")
+
+        if status.is_success(response.status_code) and sort == "title":
+            response.data.sort(key=lambda item: item["title"].lower())
+        return response
+
 
 class CompanyViewSet(ReadOnlyModelViewSet):
     """API view set for Companies"""

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1221,6 +1221,35 @@ def test_products_viewset_list(user_drf_client, coupon_product_ids):
         )
 
 
+def test_products_viewset_list_sort(user_drf_client):
+    """ Test that the ProductViewSet returns all products sorted by title when requested"""
+    product_version_1 = ProductVersionFactory.create(product__content_object__title="B")
+    product_version_2 = ProductVersionFactory.create(product__content_object__title="D")
+    product_version_3 = ProductVersionFactory.create(product__content_object__title="C")
+    product_version_4 = ProductVersionFactory.create(product__content_object__title="A")
+
+    # In alphabetical orders per product__content_object__title
+    product_versions_sorted = [
+        product_version_4,
+        product_version_1,
+        product_version_3,
+        product_version_2,
+    ]
+    product_ids_sorted = [
+        product_version.product.id for product_version in product_versions_sorted
+    ]
+
+    response = user_drf_client.get(reverse("products_api-list"))
+    assert response.status_code == status.HTTP_200_OK
+    products = response.json()
+    assert [product.get("id") for product in products] != product_ids_sorted
+
+    response_sorted = user_drf_client.get(reverse("products_api-list") + "?sort=title")
+    assert response_sorted.status_code == status.HTTP_200_OK
+    products = response_sorted.json()
+    assert [product.get("id") for product in products] == product_ids_sorted
+
+
 def test_products_viewset_list_missing_unchecked_bulk_visibility(user_drf_client):
     """ Test that the ProductViewSet returns all products
         which are visible_in_bulk_form

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -65,7 +65,7 @@ export default {
   productsSelector:  pathOr(null, ["entities", "products"]),
   fullProductsQuery: () => ({
     queryKey:  "products",
-    url:       "/api/products/",
+    url:       "/api/products/?sort=title",
     transform: (json: Array<ProductDetail>) => ({
       products: json
     }),
@@ -75,7 +75,7 @@ export default {
   }),
   productsQuery: (productType?: string) => ({
     queryKey: "products",
-    url:      "/api/products/",
+    url:      "/api/products/?sort=title",
     body:     {
       nested: false,
       ...(productType ? { type: productType } : {})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Ticket](https://trello.com/c/2TjIRf2V/137-bulk-purchase-alphabetically-list-courses-in-the-drop-down)

#### What's this PR do?
Adds sorting capabilities to the product API and uses that to alphabetically list products in the drop downs on the bulk purchase page.

#### How should this be manually tested?
Visit `/ecommerce/bulk/` and verify the changes are correct.
