### PR TITLE
Don't display courses that have ended in Boeing voucher upload

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -91,6 +91,12 @@ class CourseRunQuerySet(models.QuerySet):  # pylint: disable=missing-docstring
         """Applies a filter for Course runs with live=True"""
         return self.filter(live=True)
 
+    def available(self):
+        """Applies a filter for Course runs with end_date in future"""
+        return self.filter(
+            models.Q(end_date__isnull=True) | models.Q(end_date__gt=now_in_utc())
+        )
+
     def with_text_id(self, text_id):
         """Applies a filter for the CourseRun's courseware_id"""
         return self.filter(courseware_id=text_id)
@@ -104,6 +110,10 @@ class CourseRunManager(models.Manager):  # pylint: disable=missing-docstring
     def live(self):
         """Returns a queryset of Course runs with live=True"""
         return self.get_queryset().live()
+
+    def available(self):
+        """Returns a querset of Couse runs with end_date in future"""
+        return self.get_queryset().available()
 
     def with_text_id(self, text_id):
         """Returns a queryset filtered by text id (i.e.: courseware_id)"""

--- a/voucher/utils.py
+++ b/voucher/utils.py
@@ -64,6 +64,7 @@ def get_eligible_coupon_choices(voucher):
                 start_date__date=voucher.course_start_date_input,
             )
             .live()
+            .available()
             .order_by("start_date")
         )
 
@@ -85,6 +86,7 @@ def get_eligible_coupon_choices(voucher):
                 | Q(start_date__date=voucher.course_start_date_input)
             )
             .live()
+            .available()
             .order_by("start_date")
         )
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://trello.com/c/2JJKQIqu/129-bug-dont-display-courses-that-have-ended-in-boeing-voucher-upload

#### What's this PR do?
Don't display courses that have ended in Boeing voucher upload

#### How should this be manually tested?
Just try to upload `voucher/.test` on `/boeing/upload` page

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)

**Before**

<img width="1440" alt="Screenshot 2020-04-08 at 17 19 47" src="https://user-images.githubusercontent.com/4043989/78788458-461c4f00-79c5-11ea-9aef-21d612580d44.png">


**After**

**No Course Avaialble**

<img width="1440" alt="Screenshot 2020-04-08 at 17 47 16" src="https://user-images.githubusercontent.com/4043989/78788505-5a604c00-79c5-11ea-9459-b7d735990fce.png">

**One Course with `end_date = None`**

<img width="1439" alt="Screenshot 2020-04-08 at 18 12 19" src="https://user-images.githubusercontent.com/4043989/78788520-60eec380-79c5-11ea-9e3b-3d8928a8bcdd.png">

#### What GIF best describes this PR or how it makes you feel?
(Optional)
