### PR TITLE
Fixed Receipt admin class

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -187,7 +187,7 @@ class ReceiptAdmin(TimestampedModelAdmin):
 
     def get_order_user(self, obj):
         """Returns the related Order's user email"""
-        return obj.order.purchaser.email
+        return obj.order.purchaser.email if obj.order is not None else None
 
     get_order_user.short_description = "User"
     get_order_user.admin_order_field = "order__purchaser__email"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket

#### What's this PR do?
Fixes the `Receipt` admin class to work with receipt objects that have null orders

#### How should this be manually tested?
Ensure that you have some receipt record with a null order, then visit the receipt admin page. It should load
