### PR TITLE
Remove py-call-osafterfork setting from uwsgi.ini

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,6 @@
 [uwsgi]
 strict = true
 need-app = true
-py-call-osafterfork = true
 auto-procname = true
 if-env = DEV_ENV
 socket = :$(PORT)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?

https://trello.com/c/upfutK0A/44-update-all-uwsgi-configs-with-recommendations-from-bloomberg-article

#### What's this PR do?

It removes one problematic uWSGI configuration setting from uwsgi.ini.

The uWSGI process would run in one case that we observed (Micromasters), but would generate an exception on startup.

See
https://github.com/mitodl/micromasters/pull/4569#issuecomment-611130601
and the other related comments in that thread.

#### How should this be manually tested?

If you examine the log output from your Docker container, you should not see any exception saying "cannot release un-acquired lock."
