### PR TITLE
remove users from the dataconsentagreement admin page

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -493,19 +493,6 @@ class DataConsentUserAdmin(TimestampedModelAdmin):
     model = DataConsentUser
 
 
-class DataConsentUserInline(admin.StackedInline):
-    """Admin Inline for DataConsentUser objects"""
-
-    model = DataConsentUser
-    raw_id_fields = ("user", "coupon")
-    extra = 1
-    show_change_link = True
-
-    def get_queryset(self, request):
-        """Overrides base method to improve performance"""
-        return super().get_queryset(request).select_related("user", "agreement")
-
-
 class DataConsentAgreementAdmin(TimestampedModelAdmin):
     """Admin for DataConsentAgreement"""
 
@@ -514,7 +501,6 @@ class DataConsentAgreementAdmin(TimestampedModelAdmin):
     list_display = ("id", "company")
     search_fields = ("company", "content")
     raw_id_fields = ("courses",)
-    inlines = [DataConsentUserInline]
 
     model = DataConsentAgreement
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/2ndIBWMy/123-application-error-attempting-to-access-admin-ecommerce-dataconsentagreement-2-in-production

#### What's this PR do?
Removed the users from the page

#### How should this be manually tested?
Just visit the dataconsentagreement page on admin like http://xpro.odl.local:8053/admin/ecommerce/dataconsentagreement/

#### Screenshots (if appropriate)
**Before**
<img width="1440" alt="Screenshot 2020-04-13 at 04 00 40" src="https://user-images.githubusercontent.com/4043989/79081950-6f2d3e80-7d3b-11ea-9ad6-67950435a99e.png">


**After**
<img width="1440" alt="Screenshot 2020-04-13 at 04 00 01" src="https://user-images.githubusercontent.com/4043989/79081948-6b99b780-7d3b-11ea-8688-71e5d05ab658.png">
