### PR TITLE
Added versioned image URL template tag to enable CMS image caching

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static wagtailimages_tags %}
+{% load static wagtailimages_tags image_version_url %}
 
 {% block title %}{{ site_name }} | Certificate for: {{ page.product_name }}{% endblock %}
 
@@ -88,7 +88,7 @@
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-md-3 certify-by">
                                 <div class="signature-area">
-                                    <img src="{% image_url signatory.signature_image "max-150x50" %}" alt="{{ signatory.name }} signature" />
+                                    <img src="{% image_version_url signatory.signature_image "max-150x50" %}" alt="{{ signatory.name }} signature" />
                                 </div>
                                 <span class="title">{{ signatory.name }}</span>
                                 {% if signatory.title_1 %}

--- a/cms/templates/partials/card_details_top.html
+++ b/cms/templates/partials/card_details_top.html
@@ -1,11 +1,11 @@
-{% load static humanize wagtailcore_tags wagtailimages_tags %}
+{% load static humanize wagtailcore_tags wagtailimages_tags image_version_url %}
 
 <div class="cover-image">
   <div class="cover-image-frame">
     {% if courseware_page.thumbnail_image %}
-      {% image courseware_page.thumbnail_image fill-275x155 %}
+      <img src="{% image_version_url courseware_page.thumbnail_image "fill-275x155" %}" alt="{{ courseware_page.thumbnail_image.title }}" />
     {% else %}
-      <img src="{% static default_image_path %}" alt="Preview image">
+      <img src="{% static default_image_path %}" alt="Preview image" />
     {% endif %}
   </div>
 </div>

--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -1,12 +1,11 @@
-{% load static wagtailcore_tags wagtailimages_tags %}
+{% load static wagtailcore_tags  image_version_url %}
 {% for courseware_page in pages %}
   <div class="slide" data-url="{{ courseware_page.full_url }}">
     <div class="slide-holder">
       {% if courseware_page.thumbnail_image %}
-        {% image courseware_page.thumbnail_image fill-480x275 as course_image %}
-        <img src="{{ course_image.url }}" alt="{{ courseware_page.title }}">
+        <img src="{% image_version_url courseware_page.thumbnail_image "fill-480x275" %}" alt="{{ courseware_page.title }}" />
       {% else %}
-        <img src="{% static 'images/mit-dome.png' %}" alt="{{ courseware_page.title }}">
+        <img src="{% static 'images/mit-dome.png' %}" alt="{{ courseware_page.title }}" />
       {% endif %}
       <a class="title" href="{% pageurl courseware_page %}">{{ courseware_page.title }}</a>
       <p>{{ courseware_page.subhead }}</p>

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailcore_tags image_version_url %}
 <div id="faculty" class="faculty-block">
   <div class="container">
     <div class="head">
@@ -11,7 +11,7 @@
       {% for member in page.members %}
         <div class="slide">
           <div class="slide-holder">
-            <img src="{% image_url member.value.image "fill-300x300" %}" alt="{{ member.value.name }}">
+            <img src="{% image_version_url member.value.image "fill-300x300" %}" alt="{{ member.value.name }}">
             <h2>{{ member.value.name }}</h2>
             <div class="text-holder">
               {{ member.value.description|richtext }}

--- a/cms/templates/partials/for-teams.html
+++ b/cms/templates/partials/for-teams.html
@@ -1,4 +1,4 @@
-{% load static wagtailimages_tags %}
+{% load static wagtailimages_tags image_version_url %}
 <div id="forTeams" class="for-teams-block {% if page.dark_theme %} dark-theme {% endif %}">
   <div class="container">
     <div class="row">
@@ -12,7 +12,7 @@
       <div class="col-lg-5">
         <div class="img-holder {% if page.switch_layout %}stick-left{% endif %}">
           {% if page.image %}
-            {% image page.image fill-750x505 %}
+            <img src="{% image_version_url page.image "fill-750x505" %}" alt="{{ page.image.title }}" />
           {% else %}
             <img src="{% static 'images/default-for-teams-image.jpg' %}" alt="For Teams">
           {% endif%}

--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -1,17 +1,15 @@
-{% load wagtailembeds_tags wagtailimages_tags %}
+{% load wagtailembeds_tags image_version_url %}
 
 {% block extrahead %}
   <style>
   {% if page.background_image %}
     .header-block {
-      {% image page.background_image fill-768x576 as background_image %}
-      background-image: url('{{ background_image.url }}');
+      background-image: url('{% image_version_url page.background_image "fill-768x576" %}');
     }
 
     @media screen and (min-width: 768px) {
       .header-block {
-        {% image page.background_image fill-1920x1080 as background_image %}
-        background-image: url('{{ background_image.url }}');
+        background-image: url('{% image_version_url page.background_image "fill-1920x1080" %}');
       }
       {% if page.background_video_url %}
         .header-block {

--- a/cms/templates/partials/image-carousel.html
+++ b/cms/templates/partials/image-carousel.html
@@ -1,4 +1,4 @@
-{% load static wagtailimages_tags %}
+{% load static image_version_url %}
 <div class="companies-trust-block">
     <div class="container">
         <h1>{{ page.title }}</h1>
@@ -6,7 +6,7 @@
             {% for image in page.images %}
             <div class="slide">
                 <div class="img-holder">
-                    <img src="{% image_url image.value "format-png" %}" alt="{{ image.value.title }}" />
+                    <img src="{% image_version_url image.value "format-png" %}" alt="{{ image.value.title }}" />
                 </div>
             </div>
             {% endfor %}

--- a/cms/templates/partials/learning-techniques.html
+++ b/cms/templates/partials/learning-techniques.html
@@ -1,11 +1,11 @@
-{% load wagtailimages_tags %}
+{% load image_version_url %}
 <div id="learningTechniques" class="container learning-techniques-block section-spacing">
   <h1>{{ page.title }}</h1>
   <ul class="learning-techniques-list">
     {% for technique in page.technique_items %}
       <li>
         <div class="img-holder">
-          <img src="{% image_url technique.value.image "height-110|format-png" %}" alt="Learning technique" />
+          <img src="{% image_version_url technique.value.image "height-110|format-png" %}" alt="Learning technique" />
         </div>
         <h3>{{ technique.value.heading }}</h3>
         <h4>{{ technique.value.sub_heading }}</h4>

--- a/cms/templates/partials/target-audience.html
+++ b/cms/templates/partials/target-audience.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load image_version_url %}
 <div id="targetAudience" class="who-should-enroll-block">
   <div class="container">
     <div class="row">
@@ -13,7 +13,7 @@
       <div class="col-lg-6">
         {% if page.image %}
           <div class="img-holder {% if page.switch_layout %}stick-left{% endif %}">
-            {% image page.image fill-870x500 %}
+            <img src="{% image_version_url page.image "fill-870x500" %}" alt="{{ page.image.title }}" />
           </div>
         {% endif %}
       </div>

--- a/cms/templates/partials/testimonial-carousel.html
+++ b/cms/templates/partials/testimonial-carousel.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags wagtailcore_tags %}
+{% load image_version_url wagtailcore_tags %}
 <div id="testimonials" class="learners-block">
   <div class="container">
     <div class="head">
@@ -12,7 +12,7 @@
       <div class="slide">
         <div class="slide-holder">
           {% if testimonial.value.image %}
-            <img src="{% image_url testimonial.value.image "fill-75x75" %}" alt="{{ testimonial.value.name }}" />
+            <img src="{% image_version_url testimonial.value.image "fill-75x75" %}" alt="{{ testimonial.value.name }}" />
           {% endif %}
           <h2>{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>
           <p>{{ testimonial.value.quote|truncatechars:150 }}</p>
@@ -36,7 +36,7 @@
             </div>
             <div class="container px-4">
               <div class="row py-2">
-                <img src="{% image_url testimonial.value.image "fill-100x100" %}" class="border rounded-circle headshot-image" alt="Testimonial image" />
+                <img src="{% image_version_url testimonial.value.image "fill-100x100" %}" class="border rounded-circle headshot-image" alt="Testimonial image" />
               </div>
               <div class="row mb-4">
                 <h2 class="modal-title text-uppercase">{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>

--- a/cms/templatetags/image_version_url.py
+++ b/cms/templatetags/image_version_url.py
@@ -1,0 +1,18 @@
+"""CMS templatetags"""
+
+from urllib.parse import quote_plus
+from django import template
+from wagtail.images.templatetags.wagtailimages_tags import image_url
+
+register = template.Library()
+
+
+@register.simple_tag()
+def image_version_url(image, filter_spec, viewname="wagtailimages_serve"):
+    """Generates an image URL using Wagtails library and appends a version to the path to enable effective caching"""
+    generated_image_url = image_url(image, filter_spec, viewname=viewname)
+    return (
+        f"{generated_image_url}?v={quote_plus(image.file_hash)}"
+        if generated_image_url
+        else ""
+    )

--- a/cms/templatetags/image_version_url_test.py
+++ b/cms/templatetags/image_version_url_test.py
@@ -1,0 +1,22 @@
+"""Tests for image_version_url templatetag"""
+import pytest
+from wagtail.images.views.serve import generate_signature
+from wagtail_factories import ImageFactory
+
+from cms.templatetags.image_version_url import image_version_url
+
+
+@pytest.mark.django_db
+def test_image_version_url():
+    """image_version_url should produce an image URL with the file hash set as the file version in the querystring"""
+    view_name = "wagtailimages_serve"
+    image_id = 1
+    file_hash = "abcdefg"
+    image_filter = "fill-75x75"
+    image = ImageFactory.build(id=image_id, file_hash=file_hash)
+    expected_signature = generate_signature(image_id, image_filter, key=None)
+    result_url = image_version_url(image, image_filter, viewname=view_name)
+    assert (
+        result_url
+        == f"/images/{expected_signature}/{image_id}/{image_filter}/?v={file_hash}"
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1645 

#### What's this PR do?
Adds a new templatetag that produces dynamic image urls in the same way that Wagtail does, but adds a querystring parameter to indicate the version of the file. If an image is replaced by a new upload, that querystring param value will change. This allows us to support image caching via our cloud provider

#### How should this be manually tested?
Visit pages that include all the templates that were updated in this PR (home page, catalog page, catalog detail pages). Make sure the images are all still visible. It would be best to use a detail page that has data for all of the affected sections (learning techniques, who should enroll, learners, faculty, etc.)

#### Any background context you want to provide?
This will help to mitigate the periodic 502/503 errors we've been seeing in prod, but it will not solve what we believe is the core issue: during certain times of the day, Wagtail apparently does not think that certain image renditions have been created, and it attempts to recreate them (with a massive RAM cost)

#### Screenshots (if appropriate)
<img width="1205" alt="ss 2020-04-13 at 14 40 39 " src="https://user-images.githubusercontent.com/14932219/79152672-9c5d0980-7d9a-11ea-9b48-5d8d2ca3cbca.png">
<img width="1205" alt="ss 2020-04-13 at 14 40 19 " src="https://user-images.githubusercontent.com/14932219/79152675-9c5d0980-7d9a-11ea-9a98-afc9c1cf7341.png">
<img width="1205" alt="ss 2020-04-13 at 14 39 54 " src="https://user-images.githubusercontent.com/14932219/79152676-9cf5a000-7d9a-11ea-8331-97d21e6c8de8.png">
