### PR TITLE
Change URL routing to allow for program run ids

### DIFF
--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -323,3 +323,24 @@ def test_program_page_checkout_url_program_run(client, wagtail_basics):
     resp = client.get(program_page.get_url())
     checkout_url = resp.context["checkout_url"]
     assert f"product={program_run.full_readable_id}" in checkout_url
+
+
+def test_program_page_for_program_run(client):
+    """
+    Test that prgram page URL works with program run id
+    """
+    program_page = ProgramPageFactory.create()
+    program_page.save_revision().publish()
+    program_run = ProgramRunFactory.create(
+        program=program_page.program,
+        run_tag="R1",
+        start_date=(now_in_utc() + timedelta(days=10)),
+    )
+
+    page_base_url = program_page.get_url().rstrip("/")
+    good_url = "{}+{}/".format(page_base_url, program_run.run_tag)
+    resp = client.get(good_url)
+    assert resp.status_code == 200
+    bad_url = "{}+R2/".format(page_base_url)
+    resp = client.get(bad_url)
+    assert resp.status_code == 404


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1647  , https://trello.com/c/JscVy4nk/142-change-url-routing-to-allow-for-program-run-ids

#### What's this PR do?
fixes #1647  

#### How should this be manually tested?
Just visit the following page
http://xpro.odl.local:8053/programs/<Program Run id>/
e.g.
http://xpro.odl.local:8053/programs/program-v1:xPRO+DgtlLearn+R1/

#### Screenshots (if appropriate)

**Now**

<img width="1440" alt="Screenshot 2020-04-16 at 13 29 45" src="https://user-images.githubusercontent.com/4043989/79433469-9196b480-7fe6-11ea-99af-38b386f61678.png">

**Before**

<img width="1440" alt="Screenshot 2020-04-16 at 13 30 18" src="https://user-images.githubusercontent.com/4043989/79433478-978c9580-7fe6-11ea-9d2b-ff5271445ccf.png">
