### PR TITLE
Fix product title/nested sorting on Product API - #146

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -139,10 +139,15 @@ class ProductViewSet(ReadOnlyModelViewSet):
         Sort the default response if indicated in query string
         """
         response = super().list(request, *args, **kwargs)
+        nested, _ = self._get_request_properties()
         sort = request.GET.get("sort")
 
         if status.is_success(response.status_code) and sort == "title":
-            response.data.sort(key=lambda item: item["title"].lower())
+            response.data.sort(
+                key=lambda item: item["parent"]["title"].lower()
+                if (not nested) and item["parent"]
+                else item["title"].lower()
+            )
         return response
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
[Trello Ticket](https://trello.com/c/sFpsFNeq/146-fix-sorting-attribute-on-bulk-purchase-form)

#### What's this PR do?
Fixes the sorting on Product API to sort on `(parent.title, title)` when flat results are requested, and sort on `title` when nested results are requested.

#### How should this be manually tested?
Go to `/ecommerce/bulk/` and verify both programs and courses are properly sorted in the dropdowns.
