### PR TITLE
Move static/hash.txt rule before the generic static rule

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -47,15 +47,15 @@ http {
             try_files /static/images/favicon.ico /favicon.ico;
         }
 
+        location ~* /static/hash.txt {
+            expires -1;
+            add_header Cache-Control private;
+        }
+
         location ~* /static/(.*$) {
             expires max;
             add_header Access-Control-Allow-Origin *;
             try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
-        }
-
-        location ~* /static/hash.txt {
-            expires -1;
-            add_header Cache-Control private;
         }
 
         location = /.well-known/dnt-policy.txt {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes fastly cache behavior so `static/hash.txt` is not cached. This will fix Doof's behavior so that he looks up the right hash and gets the right version number.

#### How should this be manually tested?
Go to https://xpro-ci-pr-1658.herokuapp.com/static/hash.txt on the PR build. Open up the network tab and verify that you are receiving a header "Cache-Control: private". If you go to https://xpro-ci.odl.mit.edu/static/hash.txt you should see something like "Cache-Control: max-age=..." instead.

