### PR TITLE
Filter out old coupon versions

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -321,7 +321,7 @@ def get_valid_coupon_versions(
 
     global_coupon_version_subquery = global_coupon_version_subquery.order_by(
         "coupon", "-created_on"
-    )
+    ).distinct("coupon")
 
     combined_coupon_versions_list = list(
         coupon_version_subquery.values_list("pk", flat=True)

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -67,7 +67,8 @@ from ecommerce.factories import (
     BulkCouponAssignmentFactory,
     BasketItemFactory,
     LineRunSelectionFactory,
-    CouponPaymentFactory)
+    CouponPaymentFactory,
+)
 from ecommerce.models import (
     BasketItem,
     Coupon,
@@ -323,39 +324,34 @@ def test_get_valid_coupon_versions_after_redemption(user, is_global):
     """
     payment = CouponPaymentFactory()
     civ_old = CouponPaymentVersionFactory(
-        payment=payment, amount=Decimal("0.50000"), max_redemptions_per_user=1, num_coupon_codes=1
+        payment=payment,
+        amount=Decimal("0.50000"),
+        max_redemptions_per_user=1,
+        num_coupon_codes=1,
     )
-    # Coupon payment for best coupon, more recent than previous so takes precedence
     civ_new = CouponPaymentVersionFactory(
-        payment=payment, amount=Decimal("1.00000"), max_redemptions_per_user=1, num_coupon_codes=1
+        payment=payment,
+        amount=Decimal("1.00000"),
+        max_redemptions_per_user=1,
+        num_coupon_codes=1,
     )
-    coupon = CouponFactory(payment=payment, coupon_code="TESTCOUPON1", is_global=is_global)
+    coupon = CouponFactory(
+        payment=payment, coupon_code="TESTCOUPON1", is_global=is_global
+    )
     CouponVersionFactory(payment_version=civ_old, coupon=coupon)
     cv_new = CouponVersionFactory(payment_version=civ_new, coupon=coupon)
 
-    # Both best and worst coupons eligible for the product
     product = ProductFactory()
-
     if not is_global:
         CouponEligibilityFactory.create(coupon=coupon, product=product)
 
-    coupon_versions = list(
-        get_valid_coupon_versions(
-            product,
-            user
-        )
-    )
+    coupon_versions = list(get_valid_coupon_versions(product, user))
     expected_versions = [cv_new]
     assert coupon_versions == expected_versions
 
     order = OrderFactory.create(purchaser=user, status=Order.FULFILLED)
     redeem_coupon(cv_new, order)
-    assert list(
-        get_valid_coupon_versions(
-            product,
-            user
-        )
-    ) == []
+    assert list(get_valid_coupon_versions(product, user)) == []
 
 
 def test_global_coupons_apply_all_products(user):

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -67,7 +67,7 @@ from ecommerce.factories import (
     BulkCouponAssignmentFactory,
     BasketItemFactory,
     LineRunSelectionFactory,
-)
+    CouponPaymentFactory)
 from ecommerce.models import (
     BasketItem,
     Coupon,
@@ -314,6 +314,48 @@ def test_get_valid_coupon_versions(basket_and_coupons, auto_only):
     if not auto_only:
         expected_versions.append(basket_and_coupons.coupongroup_best.coupon_version)
     assert set(best_versions) == set(expected_versions)
+
+
+@pytest.mark.parametrize("is_global", [True, False])
+def test_get_valid_coupon_versions_after_redemption(user, is_global):
+    """
+    Verify that the correct valid CouponPaymentVersions are returned before and after redemption
+    """
+    payment = CouponPaymentFactory()
+    civ_old = CouponPaymentVersionFactory(
+        payment=payment, amount=Decimal("0.50000"), max_redemptions_per_user=1, num_coupon_codes=1
+    )
+    # Coupon payment for best coupon, more recent than previous so takes precedence
+    civ_new = CouponPaymentVersionFactory(
+        payment=payment, amount=Decimal("1.00000"), max_redemptions_per_user=1, num_coupon_codes=1
+    )
+    coupon = CouponFactory(payment=payment, coupon_code="TESTCOUPON1", is_global=is_global)
+    CouponVersionFactory(payment_version=civ_old, coupon=coupon)
+    cv_new = CouponVersionFactory(payment_version=civ_new, coupon=coupon)
+
+    # Both best and worst coupons eligible for the product
+    product = ProductFactory()
+
+    if not is_global:
+        CouponEligibilityFactory.create(coupon=coupon, product=product)
+
+    coupon_versions = list(
+        get_valid_coupon_versions(
+            product,
+            user
+        )
+    )
+    expected_versions = [cv_new]
+    assert coupon_versions == expected_versions
+
+    order = OrderFactory.create(purchaser=user, status=Order.FULFILLED)
+    redeem_coupon(cv_new, order)
+    assert list(
+        get_valid_coupon_versions(
+            product,
+            user
+        )
+    ) == []
 
 
 def test_global_coupons_apply_all_products(user):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1772 

#### What's this PR do?
Adds `distinct()` to the global coupon version subquery

#### How should this be manually tested?
See https://mitodl.slack.com/archives/GG8B4C3JP/p1589301132281200
