### PR TITLE
Changed pytest mocker usages to stop using context processors

### DIFF
--- a/compliance/api_test.py
+++ b/compliance/api_test.py
@@ -104,11 +104,11 @@ def test_verify_user_with_exports_temporary_errors(mocker, user, reason_code):
         last_sent={"envelope": etree.Element("sent")},
         last_received={"envelope": etree.Element("received")},
     )
-    with mocker.patch(
+    mocker.patch(
         "compliance.api.get_cybersource_client",
         return_value=(mock_client, mock_history),
-    ):
-        assert api.verify_user_with_exports(user) is None
+    )
+    assert api.verify_user_with_exports(user) is None
     mock_log.error.assert_called_once_with(
         "Unable to verify exports controls, received reasonCode: %s", reason_code
     )
@@ -133,11 +133,11 @@ def test_verify_user_with_exports_sanctions_lists(
         last_sent={"envelope": etree.Element("sent")},
         last_received={"envelope": etree.Element("received")},
     )
-    with mocker.patch(
+    mocker.patch(
         "compliance.api.get_cybersource_client",
         return_value=(mock_client, mock_history),
-    ):
-        api.verify_user_with_exports(user)
+    )
+    api.verify_user_with_exports(user)
 
     payload = mock_client.service.runTransaction.call_args[1]
 

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -53,6 +53,7 @@ if [[ $(
     grep -v 'ignored, nothing could be mapped' |
     grep -v "This browser doesn't support the \`onScroll\` event" |
     grep -v "process.on(SIGPROF) is reserved while debugging" |
+    grep -v "Browserslist: caniuse-lite is outdated" |
     wc -l |
     awk '{print $1}'
     ) -ne 0 ]]  # is file empty?


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
No ticket. Fixes build failures

#### What's this PR do?
Changes `mocker` usage in tests to stop using context processors (`with mocker...:`)
