### PR TITLE
remove sharing header from the certificate page

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -21,50 +21,39 @@
 
 {% block content %}
 <div class="container-fluid certificate-page">
-    <div class="row no-print">
-        <div class="col px-0">
-            <div class="cer-head">
-                <div class="certificate-logo">
-                    <a href="https://web.mit.edu/" class="mit"></a>
-                    <a href="/" class="xpro"></a>
-                    <img src="{% static 'images/certificates/transparent-mit-xpro-logo.png' %}" alt="MIT xPro">
-                </div>
-            </div>
-        </div>
-    </div>
-    {% if certificate_user == user %}
-        <div class="row no-print">
-            <div class="col px-0">
-                <div class="cer-user-info">
-                    <div class="user-info-holder">
-                        <ul class="social-links">
-                        <li>
-                            <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri|urlencode }}&text={{ share_text|urlencode }}">
-                                <img src="{% static 'images/certificates/icon-twitter.svg' %}" alt="Share to Twitter">
-                            </a>
-                        </li>
-                        <li>
-                            <a href="http://www.facebook.com/share.php?u={{ request.build_absolute_uri|urlencode }}" target="_blank">
-                                <img src="{% static 'images/certificates/icon-facebook.svg' %}" alt="Share to Facebook">
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://www.linkedin.com/profile/add?startTask={{ page.product_name|urlencode }}" target="_blank">
-                                <img src="{% static 'images/certificates/icon-linkedin.svg' %}" alt="Share to LinkedIn">
-                            </a>
-                        </li>
-                        <li>
-                            <a href="javascript:window.print();">
-                                <img src="{% static 'images/certificates/icon-print.svg' %}" alt="Print">
-                            </a>
-                        </li>
-                    </ul>
-                        <h2>Congratulations, {{ learner_name }}!</h2>
-                        <p>You have successfully completed {{ page.product_name }}. Share your accomplishment with your friends, family and colleagues. </p>
-                    </div>
-                </div>
-            </div>
-        </div>
+    {% if certificate_user == user %}	
+        <div class="row no-print">	
+            <div class="col px-0">	
+                <div class="cer-user-info">	
+                    <div class="user-info-holder">	
+                        <ul class="social-links">	
+                        <li>	
+                            <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri|urlencode }}&text={{ share_text|urlencode }}">	
+                                <img src="{% static 'images/certificates/icon-twitter.svg' %}" alt="Share to Twitter">	
+                            </a>	
+                        </li>	
+                        <li>	
+                            <a href="http://www.facebook.com/share.php?u={{ request.build_absolute_uri|urlencode }}" target="_blank">	
+                                <img src="{% static 'images/certificates/icon-facebook.svg' %}" alt="Share to Facebook">	
+                            </a>	
+                        </li>	
+                        <li>	
+                            <a href="https://www.linkedin.com/profile/add?startTask={{ page.product_name|urlencode }}" target="_blank">	
+                                <img src="{% static 'images/certificates/icon-linkedin.svg' %}" alt="Share to LinkedIn">	
+                            </a>	
+                        </li>	
+                        <li>	
+                            <a href="javascript:window.print();">	
+                                <img src="{% static 'images/certificates/icon-print.svg' %}" alt="Print">	
+                            </a>	
+                        </li>	
+                    </ul>	
+                        <h2>Congratulations, {{ learner_name }}!</h2>	
+                        <p>You have successfully completed {{ page.product_name }}. Share your accomplishment with your friends, family and colleagues. </p>	
+                    </div>	
+                </div>	
+            </div>	
+        </div>	
     {% endif %}
     <div class="row">
         <div class="col certificate-wrapper">
@@ -136,8 +125,8 @@
 
 {% block scripts %}
     {{ block.super }}
-    {% if certificate_user == user %}
-        <script type="text/javascript" async src="https://platform.twitter.com/widgets.js"></script>
+    {% if certificate_user == user %}	
+        <script type="text/javascript" async src="https://platform.twitter.com/widgets.js"></script>	
     {% endif %}
 {% endblock %}
 

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -34,7 +34,7 @@
     {% block extrahead %}
     {% endblock %}
     {% endspaceless %}
-      {% if zendesk_config.help_widget_enabled %}
+      {% if zendesk_config.help_widget_enabled and not request.path|startswith:'/certificate/' %}
           <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key={{zendesk_config.help_widget_key}}"> </script>
       {% endif %}
   </head>
@@ -43,7 +43,7 @@
     {% include "partials/gtm_body.html" %}
     {% hijack_notification %}
     {# Site-wide notifications should not show up on the ecommerce bulk pages #}
-    {% if not request.path|startswith:'/ecommerce/bulk/' %}
+    {% if not request.path|startswith:'/ecommerce/bulk/,/certificate/' %}
       {% latest_notification %}
     {% endif %}
     {% block headercontent %}
@@ -62,7 +62,7 @@
     {% render_bundle 'django' %}
     {% block scripts %}
     {% endblock %}
-    {% if zendesk_config.help_widget_enabled %}
+    {% if zendesk_config.help_widget_enabled and not request.path|startswith:'/certificate/' %}
     <script type="text/javascript">
         zE('webWidget', 'prefill', {
             name: {

--- a/mitxpro/templatetags/startswith.py
+++ b/mitxpro/templatetags/startswith.py
@@ -8,5 +8,8 @@ register = template.Library()
 def startswith(text, starts):
     """Filter to check if a string starts with a specific format"""
     if isinstance(text, str):
-        return text.startswith(starts)
+        starts = starts.split(",")
+        for start in starts:
+            if text.startswith(start):
+                return True
     return False


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1762 

#### What's this PR do?
#fixes #1762, remove the header from the certificate page

#### How should this be manually tested?
Just visit the certificate page

#### Screenshots (if appropriate)
**Before**

<img width="1440" alt="Screenshot 2020-07-02 at 17 10 05" src="https://user-images.githubusercontent.com/4043989/86357313-15c41400-bc87-11ea-9465-6c7cd1b4123c.png">

**Now**

<img width="1440" alt="Screenshot 2020-07-07 at 19 56 39" src="https://user-images.githubusercontent.com/4043989/86800033-0d574900-c08c-11ea-9a8c-64a85efb64ae.png">
