### PR TITLE
pin isort to fix the build error

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,6 +7,7 @@ factory_boy==2.11.1
 faker
 freezegun==0.3.12
 ipdb
+isort==4.3.21
 nplusone>=0.8.1
 pdbpp
 pip-tools


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fix build error because of isort
```
Linting files
..INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pytest_pylint.py", line 238, in pytest_collection_finish
INTERNALERROR>     result = lint.Run(args_list, reporter=reporter, exit=False)
INTERNALERROR> TypeError: __init__() got an unexpected keyword argument 'exit'
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 209, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 248, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 258, in pytest_collection
INTERNALERROR>     return session.perform_collect()
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 500, in perform_collect
INTERNALERROR>     hook.pytest_collection_finish(session=self)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pytest_pylint.py", line 240, in pytest_collection_finish
INTERNALERROR>     result = lint.Run(args_list, reporter=reporter, do_exit=False)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 1394, in __init__
INTERNALERROR>     linter.check(args)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 801, in check
INTERNALERROR>     self._do_check(files_or_modules)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 938, in _do_check
INTERNALERROR>     self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 1018, in check_astroid_module
INTERNALERROR>     walker.walk(ast_node)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/utils.py", line 1164, in walk
INTERNALERROR>     cb(astroid)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/checkers/imports.py", line 448, in leave_module
INTERNALERROR>     std_imports, ext_imports, loc_imports = self._check_imports_order(node)
INTERNALERROR>   File "/usr/local/lib/python3.7/site-packages/pylint/checkers/imports.py", line 595, in _check_imports_order
INTERNALERROR>     isort_obj = isort.SortImports(
INTERNALERROR> AttributeError: module 'isort' has no attribute 'SortImports'
```

https://travis-ci.com/github/mitodl/mitxpro/jobs/358400986#L928

#### What's this PR do?
Pins isort==4.3.21 in order to have the tests and build pass.
Same as we did in `bootcamp-ecommerce`  https://github.com/mitodl/bootcamp-ecommerce/pull/885

#### How should this be manually tested?
Build should pass