### PR TITLE
make create, defer, transfer and refund enrollment commands atomic with the edX enrollments

### DIFF
--- a/courses/management/commands/create_enrollment.py
+++ b/courses/management/commands/create_enrollment.py
@@ -32,7 +32,15 @@ class Command(BaseCommand):
         parser.add_argument(
             "--code", type=str, help="The enrollment code for the course", required=True
         )
+        parser.add_argument(
+            "-k",
+            "--keep-failed-enrollments",
+            action="store_true",
+            dest="keep_failed_enrollments",
+            help="If provided, enrollment records will be kept even if edX enrollment fails",
+        )
         super().add_arguments(parser)
+        # pylint: disable=too-many-locals
 
     def handle(self, *args, **options):
         """Handle command execution"""
@@ -73,7 +81,7 @@ class Command(BaseCommand):
             )
 
         successful_enrollments, edx_request_success = create_run_enrollments(
-            user, [run]
+            user, [run], keep_failed_enrollments=options["keep_failed_enrollments"]
         )
         if not successful_enrollments:
             raise CommandError("Failed to create the enrollment record")

--- a/courses/management/commands/defer_enrollment.py
+++ b/courses/management/commands/defer_enrollment.py
@@ -35,6 +35,13 @@ class Command(EnrollmentChangeCommand):
             help="The 'courseware_id' value for the CourseRun that you are deferring to",
             required=True,
         )
+        parser.add_argument(
+            "-k",
+            "--keep-failed-enrollments",
+            action="store_true",
+            dest="keep_failed_enrollments",
+            help="If provided, enrollment records will be kept even if edX enrollment fails",
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -45,7 +52,11 @@ class Command(EnrollmentChangeCommand):
 
         try:
             from_enrollment, to_enrollment = defer_enrollment(
-                user, from_courseware_id, to_courseware_id, force=options["force"]
+                user,
+                from_courseware_id,
+                to_courseware_id,
+                keep_failed_enrollments=options["keep_failed_enrollments"],
+                force=options["force"],
             )
         except ObjectDoesNotExist as exc:
             if isinstance(exc, CourseRunEnrollment.DoesNotExist):

--- a/courses/management/commands/refund_enrollment.py
+++ b/courses/management/commands/refund_enrollment.py
@@ -36,42 +36,67 @@ class Command(EnrollmentChangeCommand):
         parser.add_argument(
             "--order", type=str, help="The 'order_id' value for an user's order ID."
         )
+        parser.add_argument(
+            "-k",
+            "--keep-failed-enrollments",
+            action="store_true",
+            dest="keep_failed_enrollments",
+            help="If provided, enrollment records will be kept even if edX enrollment fails",
+        )
+
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
         """Handle command execution"""
         user = fetch_user(options["user"])
+        keep_failed_enrollments = options["keep_failed_enrollments"]
         enrollment, _ = self.fetch_enrollment(user, options)
 
         if options["program"]:
             program_enrollment, run_enrollments = deactivate_program_enrollment(
-                enrollment, change_status=ENROLL_CHANGE_STATUS_REFUNDED
+                enrollment,
+                change_status=ENROLL_CHANGE_STATUS_REFUNDED,
+                keep_failed_enrollments=keep_failed_enrollments,
             )
         else:
             program_enrollment = None
-            run_enrollments = [
-                deactivate_run_enrollment(
-                    enrollment, change_status=ENROLL_CHANGE_STATUS_REFUNDED
-                )
-            ]
-
-        success_msg = "Refunded enrollments for user: {} ({})\nEnrollments affected: {}".format(
-            enrollment.user.username,
-            enrollment.user.email,
-            enrollment_summaries(filter(bool, [program_enrollment] + run_enrollments)),
-        )
-
-        if enrollment.order:
-            enrollment.order.status = Order.REFUNDED
-            enrollment.order.save_and_log(None)
-            success_msg += "\nOrder status set to '{}' (order id: {})".format(
-                enrollment.order.status, enrollment.order.id
+            run_enrollments = []
+            run_enrollment = deactivate_run_enrollment(
+                enrollment,
+                change_status=ENROLL_CHANGE_STATUS_REFUNDED,
+                keep_failed_enrollments=keep_failed_enrollments,
             )
+            if run_enrollment:
+                run_enrollments.append(run_enrollment)
+
+        if program_enrollment or run_enrollments:
+            success_msg = "Refunded enrollments for user: {} ({})\nEnrollments affected: {}".format(
+                enrollment.user.username,
+                enrollment.user.email,
+                enrollment_summaries(
+                    filter(bool, [program_enrollment] + run_enrollments)
+                ),
+            )
+
+            if enrollment.order:
+                enrollment.order.status = Order.REFUNDED
+                enrollment.order.save_and_log(None)
+                success_msg += "\nOrder status set to '{}' (order id: {})".format(
+                    enrollment.order.status, enrollment.order.id
+                )
+            else:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "The given enrollment is not associated with an order, so no order status will be changed."
+                    )
+                )
+
+            self.stdout.write(self.style.SUCCESS(success_msg))
         else:
             self.stdout.write(
-                self.style.WARNING(
-                    "The given enrollment is not associated with an order, so no order status will be changed."
+                self.style.ERROR(
+                    "Failed to refund the enrollment – 'for' user: {} ({}) from course / program ({})\n".format(
+                        user.username, user.email, options["run"] or options["program"]
+                    )
                 )
             )
-
-        self.stdout.write(self.style.SUCCESS(success_msg))

--- a/courses/management/utils_test.py
+++ b/courses/management/utils_test.py
@@ -1,11 +1,18 @@
 """Tests for command utils"""
-
+from datetime import timedelta
 import pytest
 from django.contrib.auth import get_user_model
 
 from courses.factories import CourseRunEnrollmentFactory, ProgramEnrollmentFactory
 from courses.management.utils import EnrollmentChangeCommand
+from courses.factories import CourseRunFactory
+from courseware.exceptions import (
+    UnknownEdxApiEnrollException,
+    EdxApiEnrollErrorException,
+)
 from users.factories import UserFactory
+from mitxpro.test_utils import MockHttpError
+from mitxpro.utils import now_in_utc
 
 User = get_user_model()
 
@@ -37,3 +44,44 @@ def test_fetch_enrollment(order):
 
     assert enrolled_obj == program_enrollment.program
     assert enrollment_obj == program_enrollment
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("keep_failed_enrollments", [True, False])
+@pytest.mark.parametrize(
+    "exception_cls,inner_exception",
+    [
+        [EdxApiEnrollErrorException, MockHttpError()],
+        [UnknownEdxApiEnrollException, Exception()],
+    ],
+)
+def test_create_run_enrollment_edx_failure(
+    mocker, keep_failed_enrollments, exception_cls, inner_exception
+):
+    """Test that create_run_enrollment behaves as expected when the enrollment fails in edX"""
+    now = now_in_utc()
+    user = UserFactory()
+    existing_enrollment = CourseRunEnrollmentFactory(user=user)
+    non_program_run = CourseRunFactory.create(
+        course__no_program=True, start_date=(now + timedelta(days=1))
+    )
+    expected_enrollment = CourseRunEnrollmentFactory(user=user, run=non_program_run)
+
+    patched_edx_enroll = mocker.patch(
+        "courses.management.utils.enroll_in_edx_course_runs",
+        side_effect=exception_cls(user, non_program_run, inner_exception),
+    )
+
+    new_enrollment = EnrollmentChangeCommand().create_run_enrollment(
+        existing_enrollment=existing_enrollment,
+        to_user=user,
+        to_run=non_program_run,
+        keep_failed_enrollments=keep_failed_enrollments,
+    )
+
+    patched_edx_enroll.assert_called_once_with(user, [non_program_run])
+
+    if keep_failed_enrollments:
+        assert new_enrollment == expected_enrollment
+    else:
+        assert new_enrollment is None

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -565,7 +565,11 @@ def enroll_user_in_order_items(order):
     successful_run_enrollments = []
     if runs:
         successful_run_enrollments, _ = create_run_enrollments(
-            order.purchaser, runs, order=order, company=company
+            order.purchaser,
+            runs,
+            order=order,
+            company=company,
+            keep_failed_enrollments=True,
         )
 
     voucher = (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1012

#### What's this PR do?
Create / Defer / Transfer / Refund enrollment commands rollback xPRO enrollments on edX failure or don't rollback with `keep_failed_enrollments ` flag.

#### How should this be manually tested?
Run all the enrollment management commands (`create, deffer, refund and transfer`) with `-k / --keep-failed-enrollments ` for admin which will enroll xPRO even on edX enrollment failures and vice versa.

#### Screenshots (if appropriate)
**Create Enrollment (Course Run)**

<img width="720" alt="Screenshot 2020-07-16 at 15 05 20" src="https://user-images.githubusercontent.com/4043989/87658631-e973c180-c775-11ea-90e7-ee5f5d9777ba.png">
<img width="726" alt="Screenshot 2020-07-16 at 14 58 34" src="https://user-images.githubusercontent.com/4043989/87658639-ec6eb200-c775-11ea-8bb1-6d6511d8aa4c.png">

**Defer Enrollment (Course Run)**

<img width="1440" alt="Screenshot 2020-07-16 at 15 08 29" src="https://user-images.githubusercontent.com/4043989/87659093-7e76ba80-c776-11ea-8daf-0ffd3b334240.png">
<img width="1440" alt="Screenshot 2020-07-16 at 15 08 50" src="https://user-images.githubusercontent.com/4043989/87659106-83d40500-c776-11ea-9068-ab21cdecdecb.png">

**Transfer Enrollment (Course Run)**

<img width="717" alt="Screenshot 2020-07-16 at 13 56 08" src="https://user-images.githubusercontent.com/4043989/87654478-6439de00-c770-11ea-9b61-e176df7ebfd9.png">
<img width="722" alt="Screenshot 2020-07-16 at 13 56 17" src="https://user-images.githubusercontent.com/4043989/87654493-67cd6500-c770-11ea-82fa-07fcd4918ac6.png">

**Transfer Enrollment (Program Run)**

<img width="723" alt="Screenshot 2020-07-17 at 17 22 24" src="https://user-images.githubusercontent.com/4043989/87786969-4e9de480-c854-11ea-9ff9-b875e187ef26.png">
<img width="1440" alt="Screenshot 2020-07-17 at 17 28 08" src="https://user-images.githubusercontent.com/4043989/87786978-52316b80-c854-11ea-81ef-ed289a24feb7.png">

**Refund Enrollment (Course Run)**

<img width="719" alt="Screenshot 2020-07-16 at 14 21 35" src="https://user-images.githubusercontent.com/4043989/87654495-69972880-c770-11ea-9f29-acf949aff95c.png">
<img width="717" alt="Screenshot 2020-07-16 at 14 22 21" src="https://user-images.githubusercontent.com/4043989/87654498-6a2fbf00-c770-11ea-9379-368d8726ea2e.png">

**Refund Enrollment (Program Run)**

<img width="1440" alt="Screenshot 2020-07-16 at 19 00 43" src="https://user-images.githubusercontent.com/4043989/87683937-15556e00-c79b-11ea-90f4-212edb201fd2.png">
<img width="1440" alt="Screenshot 2020-07-16 at 19 01 11" src="https://user-images.githubusercontent.com/4043989/87684223-6ebd9d00-c79b-11ea-8f6f-f33a9e0d7f11.png">

