### PR TITLE
Make sure B2BOrders have unique integration ids

### DIFF
--- a/b2b_ecommerce/models.py
+++ b/b2b_ecommerce/models.py
@@ -19,6 +19,8 @@ from ecommerce.models import (
 from mitxpro.models import AuditModel, AuditableModel, TimestampedModel
 from mitxpro.utils import serialize_model_object
 
+B2B_INTEGRATION_PREFIX = "B2B-"
+
 
 class B2BCouponManager(models.Manager):
     """
@@ -164,6 +166,17 @@ class B2BOrder(OrderAbstract, AuditableModel):
                 serialize_model_object(receipt) for receipt in self.b2breceipt_set.all()
             ],
         }
+
+    @property
+    def integration_id(self):
+        """
+        Return an integration id to be used by Hubspot as the unique deal id.
+        This is necessary to prevent overlap with Order ids.
+
+        Returns:
+            str: the integration id
+        """
+        return f"{B2B_INTEGRATION_PREFIX}{self.id}"
 
 
 class B2BOrderAudit(AuditModel):

--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -264,7 +264,7 @@ def make_b2b_deal_sync_message(order_id):
     order = B2BOrder.objects.get(id=order_id)
     properties = B2BOrderToDealSerializer(order).data
     properties["order_type"] = ORDER_TYPE_B2B
-    return [make_sync_message(order_id, properties)]
+    return [make_sync_message(order.integration_id, properties)]
 
 
 def make_deal_sync_message(order_id):


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds a prefix to `B2BOrder` integratorObjectId's sent to Hubspot to ensure they do not overlap with `Order` integratorObjectId's.

#### How should this be manually tested?
- Set `HUBSPOT_API_KEY` to the same value as CI in your .env
- Set `HUBSPOT_ID_PREFIX` to something unique like `xpro-2020-07-20a`
- On master, create an `Order` and a `B2BOrder` with the same id if you don't have them already.
- Run `manage.py sync_hubspot --deals`, then `manage.py sync_hubspot --b2bdeals`
- Log in to hubspot and search deals for `XPRO-B2BORDER-<id>`.  Check out the earliest history.  You should see `XPRO-ORDER-<id>` as the first property set, indicating the `Order` info was overwritten with the `B2BOrder` info.
- Switch to this branch and restart docker instances.
- Run `manage.py sync_hubspot --deals`, then `manage.py sync_hubspot --b2bdeals` again
- Check hubspot deals again, this time there should be both `XPRO-ORDER-<id>` and `XPRO-B2BORDER-<id>` deals with the correct properties.
