### PR TITLE
Fix hubspot b2b product sync id

### DIFF
--- a/b2b_ecommerce/api.py
+++ b/b2b_ecommerce/api.py
@@ -15,6 +15,7 @@ from ecommerce.api import (
 )
 from ecommerce.mail_api import send_b2b_receipt_email
 from ecommerce.models import CouponPaymentVersion
+from hubspot.task_helpers import sync_hubspot_b2b_deal
 from mitxpro.utils import now_in_utc
 
 
@@ -132,6 +133,8 @@ def fulfill_b2b_order(request_data):
 
     # Save to log everything to an audit table including enrollments created in complete_order
     order.save_and_log(None)
+
+    sync_hubspot_b2b_deal(order)
 
 
 def determine_price_and_discount(*, product_version, discount_code, num_seats):

--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -320,7 +320,7 @@ def make_b2b_product_sync_message(order_id):
 
     order = B2BOrder.objects.get(id=order_id)
     properties = B2BProductVersionToLineSerializer(order).data
-    return [make_sync_message(order_id, properties)]
+    return [make_sync_message(order.integration_id, properties)]
 
 
 def make_product_sync_message(product_id):

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -19,6 +19,7 @@ from hubspot.serializers import (
     LineSerializer,
     ProductSerializer,
     B2BOrderToDealSerializer,
+    B2BProductVersionToLineSerializer,
 )
 from mitxpro.test_utils import any_instance_of
 from users.serializers import UserSerializer
@@ -193,6 +194,25 @@ def test_make_b2b_deal_sync_message(hubspot_b2b_order):
             "action": "UPSERT",
             "changeOccurredTimestamp": any_instance_of(int),
             "propertyNameToValues": serialized_order,
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_make_b2b_product_sync_message(hubspot_b2b_order):
+    """Test make_b2b_product_sync_message serializes a product and returns a properly formatted sync message"""
+    product_sync_message = api.make_b2b_product_sync_message(hubspot_b2b_order.id)
+
+    serialized_product = B2BProductVersionToLineSerializer(hubspot_b2b_order).data
+    for key in serialized_product.keys():
+        if serialized_product[key] is None:
+            serialized_product[key] = ""
+    assert product_sync_message == [
+        {
+            "integratorObjectId": f"{settings.HUBSPOT_ID_PREFIX}-{B2B_INTEGRATION_PREFIX}{hubspot_b2b_order.id}",
+            "action": "UPSERT",
+            "changeOccurredTimestamp": any_instance_of(int),
+            "propertyNameToValues": serialized_product,
         }
     ]
 

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -71,7 +71,7 @@ class B2BProductVersionToLineSerializer(serializers.ModelSerializer):
 
     def get_order(self, instance):
         """ Get the order id and return the hubspot deal integratorObject id"""
-        return format_hubspot_id(instance.id)
+        return format_hubspot_id(instance.integration_id)
 
     def get_quantity(self, instance):
         """return the number of seats associated with the b2b order"""

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -29,6 +29,7 @@ from hubspot.serializers import (
     ORDER_STATUS_MAPPING,
     ORDER_TYPE_B2C,
     ORDER_TYPE_B2B,
+    B2BProductVersionToLineSerializer,
 )
 
 pytestmark = [pytest.mark.django_db]
@@ -161,6 +162,20 @@ def test_serialize_b2b_order(status):
         "num_seats": 10,
         "status": order.status,
         "purchaser": format_hubspot_id(order.email),
+    }
+
+
+def test_serialize_b2b_product_version():
+    """Test that B2BProductVersionToLineSerializer produces the correct serialized data"""
+    order = B2BOrderFactory.create(status=Order.FULFILLED, num_seats=10)
+    serialized_data = B2BProductVersionToLineSerializer(instance=order).data
+    assert serialized_data == {
+        "id": format_hubspot_id(order.product_version.id),
+        "product": format_hubspot_id(order.product_version.product.id),
+        "order": format_hubspot_id(order.integration_id),
+        "quantity": order.num_seats,
+        "status": order.status,
+        "product_id": order.product_version.text_id,
     }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1835 

#### What's this PR do?
Uses correct integration id for b2b product syncing

#### How should this be manually tested?
- Assign `HUBSPOT_API_KEY` in your .env file
- Create a new B2B order if you don't have one, otherwise run `manage.py sync_hubspot`
- Search for your B2B deal(s) on hubspot, a product should be associated with them.
