### PR TITLE
B2B/Bulk: Automatically Apply Coupon Codes Passed in URL

### DIFF
--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -57,6 +57,7 @@ describe("B2BPurchaseForm", () => {
           couponStatus={couponStatus}
           productId="test+Aug_2016"
           discountCode="1234567890"
+          seats="1"
           {...props}
         />
       </Provider>

--- a/static/js/containers/pages/b2b/B2BPurchasePage.js
+++ b/static/js/containers/pages/b2b/B2BPurchasePage.js
@@ -107,6 +107,7 @@ export class B2BPurchasePage extends React.Component<Props, State> {
     const params = new URLSearchParams(this.props.location.search)
     const contractNumber = params.get("contract_number")
     const discountCode = params.get("code")
+    const seats = params.get("seats")
     let productId = params.get("product_id")
     if (productId && isNaN(productId)) {
       // eslint-disable-next-line no-useless-escape
@@ -139,6 +140,7 @@ export class B2BPurchasePage extends React.Component<Props, State> {
             requestPending={requestPending}
             productId={productId}
             discountCode={discountCode}
+            seats={seats}
           />
         )}
       </React.Fragment>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1831 

#### What's this PR do?
B2B/Bulk: Automatically Apply Coupon Codes Passed in URL

#### How should this be manually tested?
Just pass the coupon in the link 
[http://xpro.odl.local:8053/ecommerce/bulk/?contract_number=abcd&code=hii&product_id=1&seats=3](http://xpro.odl.local:8053/ecommerce/bulk/?contract_number=abcd&code=hii&product_id=1&seats=3)

#### Screenshots
<img width="1440" alt="Screenshot 2020-07-29 at 14 32 27" src="https://user-images.githubusercontent.com/4043989/88783617-71ab8b00-d1a8-11ea-93b7-c8747fd3c08f.png">
<img width="1440" alt="Screenshot 2020-07-29 at 14 32 47" src="https://user-images.githubusercontent.com/4043989/88783632-76703f00-d1a8-11ea-8d32-264395949ad5.png">
