### PR TITLE
Fixed case-sensitivity bug with coupon assignment sheets

### DIFF
--- a/sheets/coupon_assign_api.py
+++ b/sheets/coupon_assign_api.py
@@ -503,7 +503,7 @@ class CouponAssignmentHandler:
         # created and which ones do not exist in the desired assignments and should therefore be removed.
         for existing_assignment in existing_assignment_qset.all():
             assignment_tuple = (
-                existing_assignment.email,
+                existing_assignment.email.lower(),
                 existing_assignment.product_coupon_id,
             )
             if assignment_tuple in desired_assignments:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. Related to these sentry errors: [1](https://sentry.io/organizations/mit-office-of-digital-learning/issues/1815360075/?project=1413655), [2](https://sentry.io/organizations/mit-office-of-digital-learning/issues/1815360105/?project=1413655 )

#### What's this PR do?
Fixes a case sensitivity bug that happens when a coupon assignment sheet is being processed and some existing product coupon assignments have non-lowercase emails

#### How should this be manually tested?
N/A
