### PR TITLE
#1850 inconsistent behavior on bulk purchase page

### DIFF
--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -248,6 +248,7 @@ export class ProductSelector extends React.Component<Props, State> {
     let selectedCoursewareObj, selectedCourseDate
     if (productType === PRODUCT_TYPE_PROGRAM) {
       selectedCoursewareObj = buildProgramOption(props.selectedProduct)
+      props.fetchProgramRuns(selectedCoursewareObj.value)
     } else {
       selectedCoursewareObj = buildCourseOption(props.selectedProduct)
       // $FlowFixMe: selectedProduct can't be null/undefined
@@ -269,7 +270,7 @@ export class ProductSelector extends React.Component<Props, State> {
       selectedCourseDate
     } = this.state
 
-    const { programRuns, programRunsLoading } = this.props
+    const { programRunsLoading } = this.props
 
     return (
       <div className="product-selector">
@@ -344,7 +345,7 @@ const mapDispatchToProps = dispatch => ({
 const mapStateToProps = state => ({
   programRuns:        state.entities.programRuns,
   programRunsLoading: R.pathOr(
-    true,
+    false,
     ["queries", "programRuns", "isPending"],
     state
   )

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -179,6 +179,7 @@ export default {
     }),
     update: {
       programRuns: (prev: [ProgramRunDetail], next: [ProgramRunDetail]) => next
-    }
+    },
+    force: true
   })
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1849 
Fixes #1850 

#### What's this PR do?
Fixes inconsistent behavior relating to the course/program dates selector on bulk purchases page.

#### How should this be manually tested?
Visit `/ecommerce/bulk/` and play around with the controls. Everything should work as expected. Now visit `/ecommerce/bulk/?contract_number=abcd&code=hi&product_id=1&seats=3` and make sure the controls work as expected, the loading spinner does not stay on screen after data has been loaded and the dates dropdown should not be hidden when it should be visible.
