### PR TITLE
Fixed bug b2b coupon applied to all products - #1844

### DIFF
--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -24,7 +24,7 @@ type Props = {
   fetchCouponStatus: (payload: B2BCouponStatusPayload) => Promise<*>,
   contractNumber: ?string,
   discountCode: ?string,
-  productId: Object,
+  productId: ?string,
   seats: ?string
 }
 
@@ -108,7 +108,8 @@ class B2BPurchaseForm extends React.Component<Props> {
       products,
       requestPending,
       couponStatus,
-      contractNumber
+      contractNumber,
+      clearCouponStatus
     } = this.props
 
     let itemPrice = new Decimal(0),
@@ -123,12 +124,19 @@ class B2BPurchaseForm extends React.Component<Props> {
       itemPrice = new Decimal(productVersion.price)
       if (!isNaN(numSeats)) {
         totalPrice = itemPrice.times(numSeats)
-
-        if (couponStatus) {
+        // $FlowFixMe: product.id is not undefined
+        if (couponStatus && couponStatus.product_id === product.id) {
           discount = new Decimal(couponStatus.discount_percent)
             .times(itemPrice)
             .times(numSeats)
           totalPrice = totalPrice.minus(discount)
+        } else if (
+          couponStatus &&
+          product &&
+          couponStatus.product_id !== product.id
+        ) {
+          values.coupon = ""
+          clearCouponStatus()
         }
       }
     }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1844 

#### What's this PR do?
Modifies `B2BPurchaseForm` to:
- only apply a coupon if the `product.id` and `couponStatus.product_id` match
- reset `couponStatus` and `values.coupon` if the coupon isn't for selected product

#### How should this be manually tested?
Go to `/ecommerce/bulk/?contract_number=abcd&code=ANLG&product_id=17&seats=3` (change values as needed) and verify the coupon code is applied, the discount shows up. Change the program/course selected and verify the coupon code field is reset and the discount is removed.