### PR TITLE
Change recaptcha domain

### DIFF
--- a/static/js/components/ScaledRecaptcha.js
+++ b/static/js/components/ScaledRecaptcha.js
@@ -27,6 +27,9 @@ export default class ScaledRecaptcha extends React.Component<Props, State> {
   recaptcha: null
 
   constructor(props: Props) {
+    window.recaptchaOptions = {
+      useRecaptchaNet: true,
+    }
     super(props)
     // use old-style ref so we can resize when it mounts
     this.recaptcha = null

--- a/static/js/components/ScaledRecaptcha.js
+++ b/static/js/components/ScaledRecaptcha.js
@@ -28,7 +28,7 @@ export default class ScaledRecaptcha extends React.Component<Props, State> {
 
   constructor(props: Props) {
     window.recaptchaOptions = {
-      useRecaptchaNet: true,
+      useRecaptchaNet: true
     }
     super(props)
     // use old-style ref so we can resize when it mounts


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1859

#### What's this PR do?
Switches the source domain of the recaptcha script from google.com to recaptcha.net

#### How should this be manually tested?
- Set `RECAPTCHA_` variables in your .env
- Go to `/create-account` and verify that the main recaptcha script comes from `recaptcha.net` instead of `google.com`

#### Any background context you want to provide?
Looks like some associated scripts/images still come from `gstatic.com`, hopefully no one is blocking that domain.

<img width="492" alt="Screen Shot 2020-08-12 at 4 11 00 PM" src="https://user-images.githubusercontent.com/187676/90063374-4ac87b00-dcb7-11ea-8427-6d4eaab39db0.png">
