### PR TITLE
Sync B2B contact with existing user if it exists

### DIFF
--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -8,6 +8,7 @@ from ecommerce import models
 from ecommerce.api import get_product_version_price_with_discount, round_half_up
 from ecommerce.models import CouponVersion, ProductVersion, CouponRedemption
 from hubspot.api import format_hubspot_id
+from users.models import User
 
 ORDER_STATUS_MAPPING = {
     models.Order.FULFILLED: "processed",
@@ -163,7 +164,8 @@ class B2BOrderToDealSerializer(serializers.ModelSerializer):
     def get_purchaser(self, instance):
         """Get the purchaser id"""
         if instance.email:
-            user_id = instance.email
+            existing_user = User.objects.filter(email=instance.email).first()
+            user_id = existing_user.id if existing_user else instance.email
             return format_hubspot_id(user_id)
 
     class Meta:

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -139,9 +139,14 @@ def test_serialize_order_with_coupon():
 
 
 @pytest.mark.parametrize("status", [Order.FULFILLED, Order.CREATED])
-def test_serialize_b2b_order(status):
+@pytest.mark.parametrize("existing_user", [True, False])
+def test_serialize_b2b_order(status, existing_user, user):
     """Test that B2BOrderToDealSerializer produces the correct serialized data"""
     order = B2BOrderFactory.create(status=status, num_seats=10)
+    purchaser_id = order.email
+    if existing_user:
+        order.email = user.email
+        purchaser_id = user.id
     serialized_data = B2BOrderToDealSerializer(instance=order).data
     assert serialized_data == {
         "id": order.id,
@@ -161,7 +166,7 @@ def test_serialize_b2b_order(status):
         "discount_percent": None,
         "num_seats": 10,
         "status": order.status,
-        "purchaser": format_hubspot_id(order.email),
+        "purchaser": format_hubspot_id(purchaser_id),
     }
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1860 

#### What's this PR do?
When syncing a B2B contact, check to see if there is an existing user with the same email.  If so, the hubspot id is generated from the user id.  Otherwise, it is generated from the B2B order email.

#### How should this be manually tested?
- Set `HUBSPOT_API_KEY` in your .env file
- Create 2 B2B orders, one with an email of an existing user, the other with a new email not associated with any users.
- Wait a few minutes then login to Hubspot and find these `XPRO-B2BORDER-*` deals.  Check that both have a contact with the expected email address.  
