### PR TITLE
certificate layout: line up signatures and their underlines

### DIFF
--- a/static/scss/certificates/certificate.scss
+++ b/static/scss/certificates/certificate.scss
@@ -167,9 +167,15 @@ $text-gray-light: #d2d0d1;
 
         .signature-area {
           border-bottom: 2px solid $text-gray-light;
-          padding: 0 0 15px;
+          padding: 0 0 5px;
           text-align: center;
           margin: 0 0 15px;
+          min-height: 70px;
+          display: flex;
+          align-items: center;
+          justify-content: flex-end;
+          flex-wrap: wrap;
+          flex-direction: column;
 
           img {
             display: inline-block;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1808 

#### What's this PR do?
certificate layout: line up signatures and their underline

#### How should this be manually tested?
Just add a certificate page and 5 signatories on it.

#### Screenshots (if appropriate)
**Before**

<img width="1203" alt="Screenshot 2020-08-21 at 11 55 12" src="https://user-images.githubusercontent.com/4043989/90861978-2733bd80-e3a6-11ea-8764-880b0d268c12.png">
<img width="926" alt="Screenshot 2020-08-21 at 11 56 17" src="https://user-images.githubusercontent.com/4043989/90861988-2bf87180-e3a6-11ea-9200-0e895df6f16f.png">

**Now**

<img width="930" alt="Screenshot 2020-08-24 at 13 15 51" src="https://user-images.githubusercontent.com/4043989/91020757-49c71000-e60c-11ea-9098-32302a196505.png">
<img width="1192" alt="Screenshot 2020-08-24 at 13 16 00" src="https://user-images.githubusercontent.com/4043989/91020771-4df32d80-e60c-11ea-9140-a83fd623ed8e.png">
<img width="1186" alt="Screenshot 2020-08-24 at 13 16 22" src="https://user-images.githubusercontent.com/4043989/91020773-4f245a80-e60c-11ea-8579-05a2fd5dbfd1.png">
<img width="1070" alt="Screenshot 2020-08-24 at 13 16 30" src="https://user-images.githubusercontent.com/4043989/91020777-4fbcf100-e60c-11ea-9a03-54b40afcd6ab.png">
<img width="798" alt="Screenshot 2020-08-24 at 13 16 40" src="https://user-images.githubusercontent.com/4043989/91020778-50558780-e60c-11ea-9d57-de9ba06dcff6.png">
<img width="457" alt="Screenshot 2020-08-24 at 13 16 50" src="https://user-images.githubusercontent.com/4043989/91020779-50ee1e00-e60c-11ea-9433-bed8db21ca70.png">
<img width="70" alt="Screenshot 2020-08-24 at 13 16 55" src="https://user-images.githubusercontent.com/4043989/91020780-5186b480-e60c-11ea-8dd1-f3b03976d4f6.png">
<img width="439" alt="Screenshot 2020-08-24 at 13 17 00" src="https://user-images.githubusercontent.com/4043989/91020782-521f4b00-e60c-11ea-95d5-294e5bae009c.png">
<img width="448" alt="Screenshot 2020-08-24 at 13 17 07" src="https://user-images.githubusercontent.com/4043989/91020784-521f4b00-e60c-11ea-9122-6c8cb49d7a1d.png">
