### PR TITLE
Links in site notification with same color

### DIFF
--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -49,6 +49,13 @@
     background: $primary;
     text-align: center;
     color: white;
+
+    a {
+      color: white;
+      text-decoration: underline;
+      background-color: transparent;
+    }
+
   }
 
   .close-notification {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots

#### What are the relevant tickets?
fixes: #1879 

#### What's this PR do?
Fix the bug as described in the issue.

#### How should this be manually tested?
Add a notification via CMS along with some links in it and link should appear with same color of text, white and underlined.

#### Screenshots (if appropriate)

<img width="1440" alt="Screen Shot 2020-08-24 at 4 34 06 PM" src="https://user-images.githubusercontent.com/7334669/91040402-a2f06d00-e627-11ea-95a7-2d9736ba5553.png">
