### PR TITLE
Upgrade jQuery to 3.5.1 - #1863

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "history": "^4.6.3",
     "hls.js": "^0.13.1",
     "isomorphic-fetch": "^2.2.1",
-    "jquery": "^3.5.0",
+    "jquery": "^3.5.1",
     "jsdom": "^16.2.2",
     "lodash": "^4.17.19",
     "mini-css-extract-plugin": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5593,10 +5593,10 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1863 

#### What's this PR do?
Upgrades jQuery to version `3.5.1` from `3.5.0`, the latter has compatibility issues with bootstrap `4.4.1` that we are using.

#### How should this be manually tested?
Force dependency install from `watch` service. Go to catalog page and click on the "+ Detail" link. The link should behave as expected (opening/closing the accordion) and there should be no errors in the console.
