### PR TITLE
B2B/Bulk: Add Instructions to downloadable enrollment sheet and remove enrollment code column

### DIFF
--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -177,20 +177,26 @@ class B2BEnrollmentCodesView(APIView):
 
         rows = (
             {
-                "code": code,
                 "url": make_checkout_url(
                     code=code,
                     product_id=order.product_version.text_id,
                     run_tag=order.program_run.run_tag if order.program_run else None,
-                ),
+                )
             }
             for code in Coupon.objects.filter(
                 versions__payment_version__b2border=order
             ).values_list("coupon_code", flat=True)
         )
 
+        instructions = [
+            "Distribute the links below to each of your learners. Additional instructions are available at:",
+            '=HYPERLINK("https://xpro.zendesk.com/hc/en-us/articles/360048166292-How-to-I-distribute-my-enrollment-codes-that-I-purchased-in-a-bulk-order-")',
+        ]
+
         return make_csv_http_response(
-            csv_rows=rows, filename=f"enrollmentcodes-{order_hash}.csv"
+            csv_rows=rows,
+            filename=f"enrollmentcodes-{order_hash}.csv",
+            instructions=instructions,
         )
 
 

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -302,15 +302,16 @@ def test_enrollment_codes(client):
         resp.get("Content-Disposition")
         == f'attachment; filename="enrollmentcodes-{order.unique_id}.csv"'
     )
-    rows = [line.split(",") for line in resp.content.decode().split()]
-    assert rows[0] == ["code", "url"]
-    assert sorted(rows[1:]) == sorted(
+    rows = [line.split(",") for line in resp.content.decode().split("\r\n")]
+    assert rows[0] == [
+        "Distribute the links below to each of your learners. Additional instructions are available at:"
+    ]
+    assert sorted(rows[3 : len(rows) - 1]) == sorted(
         [
             [
-                coupon.coupon_code,
                 make_checkout_url(
                     code=coupon.coupon_code, product_id=order.product_version.text_id
-                ),
+                )
             ]
             for coupon in coupons
         ]
@@ -332,16 +333,15 @@ def test_program_run_enrollment_codes(client):
     )
 
     resp = client.get(reverse("b2b-enrollment-codes", kwargs={"hash": order.unique_id}))
-    rows = [line.split(",") for line in resp.content.decode().split()]
-    assert sorted(rows[1:]) == sorted(
+    rows = [line.split(",") for line in resp.content.decode().split("\r\n")]
+    assert sorted(rows[3 : len(rows) - 1]) == sorted(
         [
             [
-                coupon.coupon_code,
                 make_checkout_url(
                     code=coupon.coupon_code,
                     product_id=order.product_version.text_id,
                     run_tag=program_run.run_tag,
-                ),
+                )
             ]
             for coupon in coupons
         ]

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -456,19 +456,25 @@ def format_price(amount):
     return f"${amount:0,.2f}"
 
 
-def make_csv_http_response(*, csv_rows, filename):
+def make_csv_http_response(*, csv_rows, filename, instructions=None):
     """
-    Create a HttpResponse for a CSV file.
+    Create a HttpResponse for a CSV file with instructions at the start of the file.
 
     Args:
         csv_rows (iterable of dict): An iterable of dict, to be written to the CSV file
         filename (str): The filename to suggest for download
+        instructions (iterable of str): An iterable of str instructions to be written to the CSV file, one per row
 
     Returns:
         django.http.response.HttpResponse: A HTTP response
     """
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+    if instructions:
+        writer = csv.writer(response)
+        for instruction in instructions:
+            writer.writerow([instruction])
 
     csv_rows = iter(csv_rows)
     try:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1876

#### What's this PR do?
B2B/Bulk: Add Instructions to downloadable enrollment sheet and remove enrollment code column 

#### How should this be manually tested?
Just create b2b order and download the enrollment codes

#### Screenshots (if appropriate)
<img width="1390" alt="Screenshot 2020-08-26 at 17 31 00" src="https://user-images.githubusercontent.com/4043989/91303833-03b3ad00-e7c2-11ea-9d7c-0d36eeb67a7f.png">
