### PR TITLE
asadiqbal08/Do not show user past dates option for course runs.

### DIFF
--- a/static/js/components/input/ProductSelector.js
+++ b/static/js/components/input/ProductSelector.js
@@ -162,17 +162,33 @@ export class ProductSelector extends React.Component<Props, State> {
     ) {
       return []
     }
-
+    //Get today's date
+    const todaysDate = new Date()
     if (productType === PRODUCT_TYPE_PROGRAM) {
-      return buildProgramDateOptions(programRuns)
+      return buildProgramDateOptions(
+        programRuns.filter(programRun => {
+          let startDate = null
+          if (programRun.start_date) {
+            startDate = new Date(programRun.start_date)
+          }
+          return startDate && startDate >= todaysDate
+        })
+      )
     } else {
       return buildCourseDateOptions(
-        products.filter(
-          product =>
+        products.filter(product => {
+          let startDate = null
+          if (product.content_object.start_date) {
+            startDate = new Date(product.content_object.start_date)
+          }
+          return (
             product.product_type === PRODUCT_TYPE_COURSERUN &&
             // $FlowFixMe: flow doesn't seem to understand selectedCoursewareObj will be valid here
-            product.content_object.course.id === selectedCoursewareObj.value
-        )
+            product.content_object.course.id === selectedCoursewareObj.value &&
+            startDate &&
+            startDate >= todaysDate
+          )
+        })
       )
     }
   }

--- a/static/js/components/input/ProductSelector_test.js
+++ b/static/js/components/input/ProductSelector_test.js
@@ -18,6 +18,7 @@ import ProductSelector, {
 import { makeCourse } from "../../factories/course"
 import {
   makeProgramRun,
+  makePastProgramRun,
   makeCourseRunProduct,
   makeProgramProduct
 } from "../../factories/ecommerce"
@@ -270,6 +271,23 @@ describe("ProductSelector", () => {
         value: programRun.id
       }))
     )
+  })
+
+  it("not renders a list of available program runs when a program start_date is in past", () => {
+    const programRuns = [
+      makePastProgramRun(programProduct.latest_version),
+      makePastProgramRun(programProduct.latest_version)
+    ]
+    const props = Object.assign(defaultProps, { programRuns })
+    const wrapper = shallow(<InnerProductSelector {...props} />)
+    wrapper.setState({
+      productType:           PRODUCT_TYPE_PROGRAM,
+      selectedCoursewareObj: {
+        label: programProduct.latest_version.content_title,
+        value: programProduct.id
+      }
+    })
+    assert.deepEqual(undefined)
   })
 
   it("sets the selected program run when one is selected", () => {

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -143,8 +143,8 @@ export const makeCourseRunContentObject = (
     id:          genProductContentObjectId.next().value,
     title:       casual.word,
     readable_id: readableId,
-    start_date:  casual.moment.format(),
-    end_date:    casual.moment.format(),
+    start_date:  casual.moment.format("2050-01-01"),
+    end_date:    casual.moment.format("2050-12-12"),
     course:      { id: course.id, title: course.title }
   }
 }
@@ -204,8 +204,21 @@ export const makeProgramRun = (
     // $FlowFixMe: flow doesn't understand generators well
     genProgramRunId.next().value
   }`,
-  start_date: casual.moment.format(),
-  end_date:   casual.moment.format()
+  start_date: casual.moment.format("2050-01-01"),
+  end_date:   casual.moment.format("2050-12-12")
+})
+
+export const makePastProgramRun = (
+  program: BaseProductVersion
+): ProgramRunDetail => ({
+  // $FlowFixMe: flow doesn't understand generators well
+  id:      genProductId.next().value,
+  run_tag: `${program.readable_id}${ENROLLABLE_ITEM_ID_SEPARATOR}R${
+    // $FlowFixMe: flow doesn't understand generators well
+    genProgramRunId.next().value
+  }`,
+  start_date: casual.moment.format("2019-01-01"),
+  end_date:   casual.moment.format("2050-12-12")
 })
 
 const genCompanyId = incrementer()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1866 

#### What's this PR do?
Do not show user past dates in selection.

#### How should this be manually tested?

- Steps to Reproduce
    Got to B2B/Bulk CC checkout page ecommerce/bulk/
    Select Course. Select Architecture and Systems Engineering: Models and Methods to Manage Complex Systems
    Note: Past dates are shown. It should only show dates for future runs.
- Expected Behavior
    Only show dates for future runs