### PR TITLE
Sorting pages in CMS admin by title - #171

### DIFF
--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -1,0 +1,24 @@
+"""Custom hooks to configure wagtail behavior"""
+from wagtail.admin.api.endpoints import PagesAdminAPIEndpoint
+from wagtail.core import hooks
+
+
+@hooks.register("construct_explorer_page_queryset")
+def sort_pages_alphabetically(parent_page, pages, request):
+    """Sort all pages by title alphabetically"""
+    return pages.order_by("title")
+
+
+class OrderedPagesAPIEndpoint(PagesAdminAPIEndpoint):
+    """A clone of the default Wagtail admin API that additionally orders all responses by page title alphabetically"""
+
+    def filter_queryset(self, queryset):
+        """Sort all pages by title alphabetically"""
+        return super().filter_queryset(queryset).order_by("title")
+
+
+@hooks.register("construct_admin_api")
+def configure_admin_api_default_order(admin_api):
+    """Swap admin pages API for our own flavor that orders results by title"""
+    admin_api.register_endpoint("pages", OrderedPagesAPIEndpoint)
+    return admin_api


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes [#17](https://github.mit.edu/xpro/xpro-issues/issues/171)

#### What's this PR do?
Modifies wagtail admin to display all page lists sorted alphabetically.

#### How should this be manually tested?
Browse the CMS and make sure all page lists are sorted alphabetically.