### PR TITLE
change b2b order coupon name

### DIFF
--- a/b2b_ecommerce/api.py
+++ b/b2b_ecommerce/api.py
@@ -26,10 +26,20 @@ def complete_b2b_order(order):
     Args:
         order (B2BOrder): A fulfilled order for enrollment codes
     """
+
+    if order.coupon and order.contract_number:
+        name = f"{order.contract_number} {order.coupon.coupon_code}"
+    elif order.contract_number:
+        name = order.contract_number
+    elif order.coupon:
+        name = order.coupon.coupon_code
+    else:
+        name = f"CouponPayment for order #{order.id}"
+
     with transaction.atomic():
         product_id = order.product_version.product.id
         payment_version = create_coupons(
-            name=f"CouponPayment for order #{order.id}",
+            name=name,
             product_ids=[product_id],
             amount=Decimal("1"),
             num_coupon_codes=order.num_seats,


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/mitxpro/issues/1895

#### What's this PR do?
The pr updates the payment name for coupons created for B2B orders to include the conract number and b2b coupon code

#### How should this be manually tested?
Create a b2b coupon through the admin

Go to http://localhost:8053/ecommerce/bulk/?contract_number=test_contract, fill out the form with the coupon code and place an order

From the shell run
```
from b2b_ecommerce.models import *
from b2b_ecommerce.api import *
complete_b2b_order(B2BOrder.objects.last())
```

The generated coupons should have coupon payment name `test_contract <b2b coupon code>`