### PR TITLE
clarify management command

### DIFF
--- a/courses/management/commands/sync_grades_and_certificates.py
+++ b/courses/management/commands/sync_grades_and_certificates.py
@@ -33,8 +33,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--grade",
             type=float,
-            help="Override a grade. Setting grade: 0 blacklists a user. Setting a passing grade \
-                (>0.0) whitelists a user. range: 0.0 - 1.0",
+            help="Override a grade. Setting grade to 0.0 blocks certificate creation. Setting a passing grade \
+                (>0.0) allows certificate creation. Range: 0.0 - 1.0",
             required=False,
         )
         parser.add_argument(

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -91,9 +91,9 @@ def test_course_run_certificate_idempotent(user, course):
     assert not deleted
 
 
-def test_course_run_certificate_blacklist(user, course):
+def test_course_run_certificate_not_passing(user, course):
     """
-    Test that the certificate is not generated if grade isn't passing
+    Test that the certificate is not generated if the grade is set to 0.0
     """
     grade = CourseRunGradeFactory.create(
         course_run__course=course, user=user, grade=1.0, passed=True


### PR DESCRIPTION
#### Pre-Flight checklist

none

#### What are the relevant tickets?

none

#### What's this PR do?

makes it clear that the `sync_grades_and_certificates` can be used to block the creation of certificates, instead of using the phrase "blacklist" 

#### How should this be manually tested?

run `python manage.py sync_grades_and_certificates --help`

