### PR TITLE
B2B/Bulk: Update coupon payment name to fix name collisions

### DIFF
--- a/b2b_ecommerce/api.py
+++ b/b2b_ecommerce/api.py
@@ -28,7 +28,7 @@ def complete_b2b_order(order):
     """
 
     if order.coupon and order.contract_number:
-        name = f"{order.contract_number} {order.coupon.coupon_code}"
+        name = f"order_{order.id} {order.contract_number} {order.coupon.coupon_code}"
     elif order.contract_number:
         name = order.contract_number
     elif order.coupon:

--- a/b2b_ecommerce/api_test.py
+++ b/b2b_ecommerce/api_test.py
@@ -130,7 +130,7 @@ def test_complete_b2b_order(mocker, contract_number, b2b_coupon_code):
     )
 
     if b2b_coupon and contract_number:
-        expected_name = f"{contract_number} {b2b_coupon.coupon_code}"
+        expected_name = f"order_{order.id} {contract_number} {b2b_coupon.coupon_code}"
     elif contract_number:
         expected_name = contract_number
     elif b2b_coupon:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes #1922 

#### What's this PR do?
B2B/Bulk: Update coupon payment name to fix name collisions

#### How should this be manually tested?
Just create a reusable coupon and try to create bulk enrollment with that coupon. It should create the coupon payment with a different name as the top two records in the screenshot.

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-09-18 at 16 36 45" src="https://user-images.githubusercontent.com/4043989/93593244-2efa7800-f9cd-11ea-92df-7f585cd55ecd.png">
