### PR TITLE
Added courses list ordering for B2B Bulk order page

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -99,6 +99,7 @@ class ProductViewSet(ReadOnlyModelViewSet):
                     & Q(content_type__model="courserun")
                 )
             )
+            .order_by("programs__title", "course_run__course__title")
             .select_related("content_type")
             .prefetch_related("content_object")
             .prefetch_generic_related(

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1227,6 +1227,27 @@ def test_products_viewset_list(user_drf_client, coupon_product_ids):
         )
 
 
+def test_products_viewset_list_ordering(user_drf_client):
+    """
+    Test that the ProductViewSet returns all products ordered alphabetically
+    by course/program title
+    """
+    response = user_drf_client.get(reverse("products_api-list"))
+    assert response.status_code == status.HTTP_200_OK
+    products = response.json()
+    serialized_products_list = ProductSerializer(data=products, many=True).initial_data
+    ordered_products_title = sorted(
+        serialized_products_list,
+        key=lambda k: k["content_object"]["course"]["title"]
+        if "course" in k["content_object"]
+        else k["content_object"]["title"],
+    )
+    ordered_products_type = sorted(
+        ordered_products_title, key=lambda k: k["product_type"], reverse=True
+    )
+    assert ordered_products_type == serialized_products_list
+
+
 def test_products_viewset_list_missing_unchecked_bulk_visibility(user_drf_client):
     """ Test that the ProductViewSet returns all products
         which are visible_in_bulk_form


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1928 

#### What's this PR do?
This PR adds the Course name alphabetical ordering on courses list populated on the B2B bulk order page. [Link](https://xpro.mit.edu/ecommerce/bulk/)

#### How should this be manually tested?
- Go to [B2b Bulk Order](https://xpro.mit.edu/ecommerce/bulk/) page and select course dropdown, Verify the courses list ordering.
- Use any Http client and hit `<XPRO_HOST>/api/products/` and verify the response

#### Screenshots
**Old behavior**

<img width="1407" alt="Screenshot 2020-09-24 at 5 59 04 PM" src="https://user-images.githubusercontent.com/34372316/94148176-b9405180-fe8f-11ea-8026-22a04544cdf1.png">
<img width="1398" alt="Screenshot 2020-09-24 at 5 59 14 PM" src="https://user-images.githubusercontent.com/34372316/94148190-bcd3d880-fe8f-11ea-899d-faa81da9ee86.png">

**New behavior**

<img width="1253" alt="Screenshot 2020-09-24 at 5 36 25 PM" src="https://user-images.githubusercontent.com/34372316/94148207-c4937d00-fe8f-11ea-8ba4-2d9818ad01ab.png">
<img width="1315" alt="Screenshot 2020-09-24 at 5 58 38 PM" src="https://user-images.githubusercontent.com/34372316/94148214-c65d4080-fe8f-11ea-863b-bd07013ef5e8.png">

