### PR TITLE
Fixed bug where coupon assignment sheets didn't have local DB record

### DIFF
--- a/sheets/coupon_request_api.py
+++ b/sheets/coupon_request_api.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.utils.functional import cached_property
 
 import ecommerce.api
-from ecommerce.models import Company, Coupon, CouponPaymentVersion
+from ecommerce.models import Company, Coupon, CouponPaymentVersion, BulkCouponAssignment
 from mitxpro.utils import now_in_utc, item_at_index_or_none, item_at_index_or_blank
 from sheets.api import (
     get_authorized_pygsheets_client,
@@ -292,6 +292,9 @@ class CouponRequestHandler(SheetHandler):
             worksheet_id=worksheet.id,
             num_data_rows=len(coupon_codes),
         )
+        # If it doesn't exist, create bulk coupon assignment for tracking purposes
+        BulkCouponAssignment.objects.create(assignment_sheet_id=bulk_coupon_sheet.id)
+
         # Share
         if settings.SHEETS_ADMIN_EMAILS:
             share_drive_file_with_emails(

--- a/sheets/coupon_request_api_test.py
+++ b/sheets/coupon_request_api_test.py
@@ -47,13 +47,16 @@ def pygsheets_fixtures(mocker, db, request_csv_rows):
         "sheets.sheet_handler_api.get_data_rows", return_value=request_csv_rows
     )
     mocked_worksheet = MagicMock(spec=Worksheet, get_all_values=Mock(return_value=[]))
-    mocked_spreadsheet = MagicMock(spec=Spreadsheet, sheet1=mocked_worksheet)
+    mocked_spreadsheet = MagicMock(
+        spec=Spreadsheet, sheet1=mocked_worksheet, id="abc123"
+    )
     mocked_pygsheets_client = MagicMock(
         spec=PygsheetsClient,
         oauth=Mock(),
         open_by_key=Mock(return_value=mocked_spreadsheet),
         drive=MagicMock(spec=DriveAPIWrapper),
         sheet=MagicMock(spec=SheetAPIWrapper),
+        create=Mock(return_value=mocked_spreadsheet),
     )
     mocker.patch(
         "sheets.coupon_request_api.get_authorized_pygsheets_client",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1925 

#### What's this PR do?
Makes it so that enrollment code assignment sheets have a local DB record as soon as the sheet is created

#### How should this be manually tested?
N/A. Code review only

#### Any background context you want to provide?
In the past, we've been able to rely on a file watch (webhook) being set up as soon as an assignment sheet is created. When we got the first request after the assignment sheet was edited, our code would create a new `BulkCouponAssignment` record for that sheet. Since the file watch API is more volatile lately, we've had a few of those initial file watch requests fail, leaving those assignment sheets in an un-processable state
