### PR TITLE
Fixed copyright year text and made it dynamic

### DIFF
--- a/mail/templates/b2b_receipt/body.html
+++ b/mail/templates/b2b_receipt/body.html
@@ -170,7 +170,7 @@
           <tr>
             <td style="padding: 20px; text-align: center; font-size: 11px; line-height: 12px;">
               <p style="margin: 0">MIT Open Learning, 600 Technology Square, 2nd Floor, Cambridge, MA 02139</p>
-              <p style="margin: 0;">&copy; 2019 {{ site_name }}, All Rights Reserved. <a href="{{ base_url }}/enterprise-terms-and-conditions" style="color: #03152d; text-decoration: underline;">Terms of Service</a> and <a href="{{ base_url }}/privacy-policy" style="color: #03152d; text-decoration: underline;">Privacy Policy</a></p>
+              <p style="margin: 0;">&copy; {% now "Y" %} {{ site_name }}, All Rights Reserved. <a href="{{ base_url }}/enterprise-terms-and-conditions" style="color: #03152d; text-decoration: underline;">Terms of Service</a> and <a href="{{ base_url }}/privacy-policy" style="color: #03152d; text-decoration: underline;">Privacy Policy</a></p>
             </td>
           </tr>
       </table>

--- a/mitxpro/templates/footer.html
+++ b/mitxpro/templates/footer.html
@@ -74,7 +74,7 @@
       </li>
     </ul>
     <span class="copyright"
-      >© 2019 All rights reserved. <a href="#">{{ site_name }}</a>.</span
+      >&copy; {% now "Y" %} All rights reserved. <a href="#">{{ site_name }}</a>.</span
     >
   </div>
 </footer>

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -389,7 +389,8 @@ export class ReceiptPage extends React.Component<Props> {
                       </div>
                     </div>
                     <span className="rec-copyright">
-                      © 2019 All rights reserved. MIT xPRO.
+                      &copy; {new Date().getFullYear()} All rights reserved. MIT
+                      xPRO.
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #1945 

#### What's this PR do?
This PR changes the copyright year to 2020, in an attempt it makes the year calculation dynamic depending upon current date.

#### How should this be manually tested?
This can be tested on multiple pages e.g. :
1. Go to the home page and have a look at the footer part.
2. Go to the receipt's detail page and have a look at the receipt bottom & page footer
3. Check overall in the app where ever there is a copyright text and its not updated to 2020 as of now.

#### Screenshots (if appropriate)
Footer/Coomon throughout the app:
<img width="717" alt="Screenshot 2020-10-07 at 4 00 16 PM" src="https://user-images.githubusercontent.com/34372316/95322694-5353c100-08b6-11eb-9bb4-e080ed99eb49.png">

Receipt detail page:
<img width="1403" alt="Screenshot 2020-10-07 at 3 55 31 PM" src="https://user-images.githubusercontent.com/34372316/95322706-55b61b00-08b6-11eb-8dea-778f0706784d.png">

