### PR TITLE
prioritize contract_number to be used as payment_transaction

### DIFF
--- a/b2b_ecommerce/api.py
+++ b/b2b_ecommerce/api.py
@@ -45,7 +45,7 @@ def complete_b2b_order(order):
             num_coupon_codes=order.num_seats,
             coupon_type=CouponPaymentVersion.SINGLE_USE,
             payment_type=CouponPaymentVersion.PAYMENT_SALE,
-            payment_transaction=order.reference_number,
+            payment_transaction=order.contract_number or order.reference_number,
         )
         order.coupon_payment_version = payment_version
         order.save()

--- a/b2b_ecommerce/api_test.py
+++ b/b2b_ecommerce/api_test.py
@@ -148,7 +148,7 @@ def test_complete_b2b_order(mocker, contract_number, b2b_coupon_code):
         num_coupon_codes=order.num_seats,
         coupon_type=CouponPaymentVersion.SINGLE_USE,
         payment_type=CouponPaymentVersion.PAYMENT_SALE,
-        payment_transaction=order.reference_number,
+        payment_transaction=order.contract_number or order.reference_number,
     )
     send_email_mock.assert_called_once_with(order)
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [x] Code is tested

#### What are the relevant tickets?
fixes: [B2B/Bulk Credit Card Purchases is not descriptive in Combined Revenue Recognition report](https://github.com/mitodl/mitxpro/issues/1946)

#### What's this PR do?
It prioritizes `contract_number` over `reference_number` (i.e: xpro-bulk-production-##) when assigning to `ecommerce_couponpaymentversion.payment_transaction` 

#### How should this be manually tested?
* Create a bulk order from `/ecommerce/bulk` using a b2bcoupon or payment via cybersource.
* Through admin panel got to `/admin/ecommerce/couponpaymentversion` and check `payment_transaction` in the coupon, it should be B2Border.contract_number or B2Border.reference_number depending upon the fact that if contract_number was given while placing the order or not. 

Note: Contract_number is not shown in `/ecommerce/bulk` in the default interface so we need to add query_param to it like `/ecommerce/bulk/?contract_number=contract_number`