### PR TITLE
Added validation for enrollment deferrals to an unenrollable course run

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -307,6 +307,12 @@ def defer_enrollment(
         raise ValidationError(
             "Cannot defer to the same course run (run: {})".format(to_run.courseware_id)
         )
+    elif not to_run.is_not_beyond_enrollment:
+        raise ValidationError(
+            "Cannot defer to a course run that is outside of its enrollment period (run: {}).".format(
+                to_run.courseware_id
+            )
+        )
     elif not force and from_enrollment.run.course != to_run.course:
         raise ValidationError(
             "Cannot defer to a course run of a different course ('{}' -> '{}'). "

--- a/sheets/admin.py
+++ b/sheets/admin.py
@@ -78,6 +78,7 @@ class FileWatchRenewalAttemptAdmin(admin.ModelAdmin):
     )
     search_fields = ("sheet_file_id", "result")
     list_filter = ("sheet_type", "result_status_code")
+    readonly_fields = ("date_attempted",)
     ordering = ("-date_attempted",)
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1962 

#### What's this PR do?
Fixes a bug where we weren't properly validating attempts to defer a course run enrollment to a course run that was outside of its enrollment period (e.g.: the `enrollment_end` date is in the past)

#### How should this be manually tested?
Probably doesn't need manual testing since the test case tests the validation. If you want, you can set up a course enrollment, then run the `defer_enrollment` management command to try to defer the enrollment to another course run with an `enrollment_start` in the future or `enrollment_end` in the past

#### Any background context you want to provide?
The bug issue describes buggy behavior in our spreadsheets, but the bug exists in an API function that is used in a few different places, including the management command I mentioned above