### PR TITLE
Added task decorator to file watch renewal task and fixed exception handling

### DIFF
--- a/sheets/api.py
+++ b/sheets/api.py
@@ -483,7 +483,7 @@ def create_or_renew_sheet_file_watch(sheet_metadata, force=False, sheet_file_id=
             URL. If the spreadsheet being watched is a singleton, this isn't necessary.
 
     Returns:
-        (GoogleFileWatch, bool, bool): The GoogleFileWatch object, a flag indicating
+        (Optional[GoogleFileWatch], bool, bool): The GoogleFileWatch object (or None), a flag indicating
             whether or not it was newly created during execution, and a flag indicating
             whether or not it was updated during execution.
     """
@@ -535,6 +535,7 @@ def create_or_renew_sheet_file_watch(sheet_metadata, force=False, sheet_file_id=
             _track_file_watch_renewal(
                 sheet_metadata.sheet_type, sheet_file_id, exception=exc
             )
+            return None, False, False
         else:
             _track_file_watch_renewal(sheet_metadata.sheet_type, sheet_file_id)
         log.info(

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -234,12 +234,13 @@ def renew_file_watch(*, sheet_type, file_id):
     )
     return {
         "type": sheet_metadata.sheet_type,
-        "file_watch_channel_id": file_watch.channel_id,
-        "file_watch_file_id": file_watch.file_id,
+        "file_watch_channel_id": getattr(file_watch, "channel_id"),
+        "file_watch_file_id": getattr(file_watch, "file_id"),
         "created": created,
     }
 
 
+@app.task()
 def renew_all_file_watches():
     """
     Renews push notifications for changes to all relevant spreadsheets via the Google API.


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes an issue with #1952

#### What's this PR do?
- Properly defines the file watch renewal task (😬 )
- Fixes exception handling so file watch renewal errors are properly saved to the database

#### How should this be manually tested?
No manual testing needed. Test should pass and we should stop seeing [this sentry error](https://sentry.io/organizations/mit-office-of-digital-learning/issues/1990515434/?environment=rc&project=1413655&query=is%3Aunresolved)
