### PR TITLE
Added flag to run python tests only without pylint/cov/warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,36 @@ from fixtures.cybersource import *
 TEST_MEDIA_ROOT = "/var/media/test_media_root"
 
 
-def pytest_configure():
+def pytest_addoption(parser):
+    """Pytest hook that adds command line parameters"""
+    parser.addoption(
+        "--simple",
+        action="store_true",
+        help="Run tests only (no cov, no pylint, warning output silenced)",
+    )
+
+
+def pytest_cmdline_main(config):
+    """Pytest hook that runs after command line options are parsed"""
+    if getattr(config.option, "simple") is True:
+        config.option.pylint = False
+        config.option.no_pylint = True
+
+
+def pytest_configure(config):
     """Pytest hook to perform some initial configuration"""
     settings.MEDIA_ROOT = TEST_MEDIA_ROOT
+    if getattr(config.option, "simple") is True:
+        # NOTE: These plugins are already configured by the time the pytest_cmdline_main hook is run, so we can't
+        #       simply add/alter the command line options in that hook. This hook is being used to
+        #       reconfigure/unregister plugins that we can't change via the pytest_cmdline_main hook.
+        # Switch off coverage plugin
+        cov = config.pluginmanager.get_plugin("_cov")
+        cov.options.no_cov = True
+        # Remove warnings plugin to suppress warnings
+        if config.pluginmanager.has_plugin("warnings"):
+            warnings_plugin = config.pluginmanager.get_plugin("warnings")
+            config.pluginmanager.unregister(warnings_plugin)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket

#### What's this PR do?
Adds a pytest flag that allows us to run Python tests only without pylint and coverage, and with warnings suppressed

#### How should this be manually tested?
Run bash in a web container, then run `pytest --simple`. You should see the test suite run without pylint, without a coverage report, and with no warnings output

#### Any background context you want to provide?
This flag will be particularly helpful while hacking on tests in a local branch. Most of the time you just need the tests to run and to have the console output limited to which tests passed and failed.

<img width="1135" alt="ss 2020-11-10 at 13 37 24 " src="https://user-images.githubusercontent.com/14932219/98716632-e7072a00-2359-11eb-9309-95713fcd8221.png">
