### PR TITLE
change button text from 'apply now' to 'learn more' for external course pages

### DIFF
--- a/cms/templates/partials/enroll_button.html
+++ b/cms/templates/partials/enroll_button.html
@@ -2,7 +2,7 @@
 <a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="{{ action_url }}">{{ action_title }}</a>
 {% elif page.is_external_course_page %}
 <a class="enroll-button enroll-now" href="{{ page.external_url }}">
-  Apply Now
+  Learn More
 </a>
 {% elif page.product %}
   {% if not user.is_anonymous %}


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxpro/issues/1986

#### What's this PR do?
Changes button text for external course pages from "Apply Now" to "Learn More".

#### How should this be manually tested?
Open any external course page, you will observe the "Learn More" button instead of the "Apply Now".

#### Acceptance Criteria:
- [x] Confirm that the buttons say `Learn More` for external courses
- [x] Confirm that the buttons don't change for non-external courses

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42243411/99041632-1e214980-25ad-11eb-868a-e34dc1add893.png)

