### PR TITLE
Add OWASP ZAP scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   push:
     branches:
+      - release
+      - release-candidate
       - master
 jobs:
   zap_scan:
@@ -10,9 +12,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: master
-      - name: OWASP ZAP Full Scan of Heroku CI
-        uses: zaproxy/action-baseline@0.4.0
+          ref: ${{ github.ref }}
+      - name: OWASP ZAP Baseline Scan of Heroku CI
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: zaproxy/action-baseline@v0.4.0
         with:
-          target: ${{ secrets.ZAP_TARGET }}
+          target: ${{ secrets.ZAP_CI_TARGET }}
+          rules_file_name: '.zap/rules.tsv'
+      - name: OWASP ZAP Full Scan of Heroku RC
+        if: ${{ github.ref == 'refs/heads/release-candidate' }}
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: ${{ secrets.ZAP_RC_TARGET }}
+          rules_file_name: '.zap/rules.tsv'
+      - name: OWASP ZAP Full Scan of Heroku Production
+        if: ${{ github.ref == 'refs/heads/release' }}
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: ${{ secrets.ZAP_PROD_TARGET }}
           rules_file_name: '.zap/rules.tsv'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
-      - name: OWASP ZAP Baseline Scan of Heroku CI
+      - name: OWASP ZAP Baseline Scan of CI
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: zaproxy/action-baseline@v0.4.0
         with:
           target: ${{ secrets.ZAP_CI_TARGET }}
           rules_file_name: '.zap/rules.tsv'
-      - name: OWASP ZAP Full Scan of Heroku RC
+      - name: OWASP ZAP Full Scan of RC
         if: ${{ github.ref == 'refs/heads/release-candidate' }}
         uses: zaproxy/action-full-scan@v0.2.0
         with:
           target: ${{ secrets.ZAP_RC_TARGET }}
           rules_file_name: '.zap/rules.tsv'
-      - name: OWASP ZAP Full Scan of Heroku Production
+      - name: OWASP ZAP Full Scan of Production
         if: ${{ github.ref == 'refs/heads/release' }}
         uses: zaproxy/action-full-scan@v0.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+jobs:
+  zap_scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: OWASP ZAP Full Scan of Heroku CI
+        uses: zaproxy/action-baseline@0.4.0
+        with:
+          target: ${{ secrets.ZAP_TARGET }}
+          rules_file_name: '.zap/rules.tsv'

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,2 @@
+10027	IGNORE	(Suspicious comments)
+10096	IGNORE	(Timestamp disclosure)


### PR DESCRIPTION
Add OWASP Zed Attack Proxy (ZAP) security scanning via Github Actions.

See https://www.zaproxy.org/

There are different types of scans for commits to `master`, `release`, and `release-candidate` branches; the latter two get a "full" scan.

The repo is checked out in order to get access to the `.zap/rules.tsv` file, which governs which tests are run or ignored. We're ignoring the "Suspicious comments" and "Unix timestamps" scans because I've only seen false positives coming from them; and they're labeled "informational," anyway.
