### PR TITLE
Get latest release of ZAP actions, rename ZAP workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
         with:
           ref: refs/heads/master
       - name: OWASP ZAP Baseline Scan of CI
-        uses: zaproxy/action-baseline@v0.4.0
+        uses: zaproxy/action-baseline
         with:
           target: ${{ secrets.ZAP_CI_TARGET }}
           rules_file_name: '.zap/rules.tsv'
       - name: OWASP ZAP Full Scan of RC
-        uses: zaproxy/action-full-scan@v0.2.0
+        uses: zaproxy/action-full-scan
         with:
           target: ${{ secrets.ZAP_RC_TARGET }}
           rules_file_name: '.zap/rules.tsv'
       - name: OWASP ZAP Full Scan of Production
-        uses: zaproxy/action-full-scan@v0.2.0
+        uses: zaproxy/action-full-scan
         with:
           target: ${{ secrets.ZAP_PROD_TARGET }}
           rules_file_name: '.zap/rules.tsv'

--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Scanning
 on:
   schedule:
     - cron: '0 5 * * *'


### PR DESCRIPTION
* Remove ZAP Github action's release tag so that we can always pull down the very latest release
* Rename the ZAP-related workflow, because it's not really CI-related.
