### PR TITLE
Use user name update api from edx-api-client

### DIFF
--- a/courseware/constants.py
+++ b/courseware/constants.py
@@ -15,4 +15,3 @@ PRO_ENROLL_MODE_ERROR_TEXTS = (
 )
 # The amount of minutes after creation that a courseware model record should be eligible for repair
 COURSEWARE_REPAIR_GRACE_PERIOD_MINS = 5
-OPENEDX_UPDATE_USER_ACCOUNT_PATH = "/api/user/v1/accounts/{username}"

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-oauth-toolkit==1.2.0
 django-user-agents==0.4.0
 djangorestframework==3.9.4
 djoser
-edx-api-client==0.9.0
+edx-api-client==0.10.0
 django-storages==1.7.1
 drf-flex-fields==0.8.5
 google-api-python-client==1.7.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ djoser==1.7.0             # via -r requirements.in
 docutils==0.14            # via botocore
 draftjs-exporter==2.1.6   # via wagtail
 drf-flex-fields==0.8.5    # via -r requirements.in
-edx-api-client==0.9.0     # via -r requirements.in
+edx-api-client==0.10.0    # via -r requirements.in
 elasticsearch==7.0.2      # via django-server-status
 google-api-python-client==1.7.11  # via -r requirements.in, pygsheets
 google-auth-httplib2==0.0.3  # via google-api-python-client


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1964 

#### What's this PR do?
Removes the API implementation for updating the user's name from xPRO and uses the API from `edx-api-client`.

**Note:** This PR will need an update to use the latest `edx-api-client` once we merge [Update User name API PR](https://github.com/mitodl/edx-api-client/pull/70).
**UPDATE ON NOTE:** [edx-api-client 0.10.0](https://pypi.org/project/edx-api-client/0.10.0/) contains this change now.

#### How should this be manually tested?
- Login to your xPRO
- Go to profile/update
- Change the full name
- Open edX instance (e.g open any course from xPRO and you will be redirected to edX) and verify the changed name on edX profile

#### Any background context you want to provide?
This functionality was implemented some time ago and at that point we decided to enhance it and use API from `edx-api-client` and remove native API Implementation. https://github.com/mitodl/mitxpro/pull/1958#discussion_r508200871
