### PR TITLE
adding max_redemption_per_user feature for promo coupons

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -273,6 +273,7 @@ class CouponPaymentVersionAdmin(admin.ModelAdmin):
         "amount",
         "num_coupon_codes",
         "activation_date",
+        "max_redemptions_per_user",
     )
     raw_id_fields = ("payment",)
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -1094,6 +1094,7 @@ def create_coupons(
     num_coupon_codes,
     coupon_type,
     max_redemptions=1,
+    max_redemptions_per_user=1,
     tag=None,
     company_id=None,
     automatic=False,
@@ -1151,7 +1152,7 @@ def create_coupons(
         num_coupon_codes=num_coupon_codes,
         coupon_type=coupon_type,
         max_redemptions=max_redemptions,
-        max_redemptions_per_user=1,
+        max_redemptions_per_user=max_redemptions_per_user,
         payment_type=payment_type,
         payment_transaction=payment_transaction,
     )

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -739,7 +739,11 @@ class BaseCouponSerializer(serializers.Serializer):
     expiration_date = serializers.DateTimeField()
     product_ids = serializers.ListField(child=serializers.IntegerField())
     max_redemptions = serializers.IntegerField(default=1)
-    max_redemptions_per_user = serializers.IntegerField(default=1)
+    max_redemptions_per_user = serializers.IntegerField(
+        default=1,
+        required=False,
+        validators=[MinValueValidator(1), MaxValueValidator(100)],
+    )
     coupon_type = serializers.ChoiceField(
         choices=set(
             zip(
@@ -795,6 +799,7 @@ class BaseCouponSerializer(serializers.Serializer):
             num_coupon_codes=validated_data.get("num_coupon_codes"),
             coupon_type=validated_data.get("coupon_type"),
             max_redemptions=validated_data.get("max_redemptions", 1),
+            max_redemptions_per_user=validated_data.get("max_redemptions_per_user", 1),
             payment_type=validated_data.get("payment_type"),
             payment_transaction=validated_data.get("payment_transaction"),
             coupon_code=validated_data.get("coupon_code"),

--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -71,6 +71,14 @@ const couponValidations = yup.object().shape({
       .min(1, "Must be at least ${min}")
       .required("Number required")
   }),
+  max_redemptions_per_user: yup.number().when("coupon_type", {
+    is:   COUPON_TYPE_PROMO,
+    then: yup
+      .number()
+      .required("Number required")
+      .min(1, "Must be at least ${min}")
+      .max(100, "Must be at most ${max}")
+  }),
   payment_transaction: yup.string().when("coupon_type", {
     is:   COUPON_TYPE_SINGLE_USE,
     then: yup.string().required("Payment transaction is required")
@@ -102,21 +110,22 @@ export const CouponForm = ({
     onSubmit={onSubmit}
     validationSchema={couponValidations}
     initialValues={{
-      coupon_type:         COUPON_TYPE_SINGLE_USE,
-      product_type:        PRODUCT_TYPE_COURSERUN,
-      products:            [],
-      num_coupon_codes:    1,
-      max_redemptions:     1000000,
-      discount:            "",
-      name:                "",
-      coupon_code:         "",
-      activation_date:     "",
-      expiration_date:     "",
-      company:             "",
-      payment_type:        "",
-      payment_transaction: "",
-      include_future_runs: false,
-      is_global:           false
+      coupon_type:              COUPON_TYPE_SINGLE_USE,
+      product_type:             PRODUCT_TYPE_COURSERUN,
+      products:                 [],
+      num_coupon_codes:         1,
+      max_redemptions:          1000000,
+      max_redemptions_per_user: 1,
+      discount:                 "",
+      name:                     "",
+      coupon_code:              "",
+      activation_date:          "",
+      expiration_date:          "",
+      company:                  "",
+      payment_type:             "",
+      payment_transaction:      "",
+      include_future_runs:      false,
+      is_global:                false
     }}
     render={({
       isSubmitting,
@@ -192,6 +201,18 @@ export const CouponForm = ({
             </label>
             <ErrorMessage name="name" component={FormError} />
           </div>
+          {isPromo(values.coupon_type) && (
+            <div className="block">
+              <label htmlFor="max_redemptions_per_user">
+                Max Redemptions Per User (1 to 100)*
+                <Field name="max_redemptions_per_user" />
+              </label>
+              <ErrorMessage
+                name="max_redemptions_per_user"
+                component={FormError}
+              />
+            </div>
+          )}
           <div className="block">
             <label htmlFor="tag">
               Tag (optional)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes https://github.com/mitodl/mitxpro/issues/1775

#### What's this PR do?
adding max_redemption_per_user feature for promo coupons

#### How should this be manually tested?
* Go to `/ecommerce/admin/coupons/` and create a Promo coupon with `max_redemptions_per_user` greater then 1.
* Make sure that `max_redemptions` is greater than or equal to `max_redemptions_per_user`.
* Now use that coupon code multiple times with the same user on different products.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42243411/100751086-b9694a00-3408-11eb-998a-6e25b60d0e7d.png)

