### PR TITLE
Added far-future cache control header to wagtail images

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% load static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags render_bundle %}
+{% load static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags render_bundle image_version_url %}
 
 
 {% block title %}{{ site_name }} | {{ page.title }}{% endblock %}
 
 {% block seohead %}
     {% meta_tags page %}
-    <meta property="og:image" content="{% image page.thumbnail_image fill-821x400 as thumbnail_image %}{{ page.get_site.root_url }}{{thumbnail_image.url}}" />
+    <meta property="og:image" content="{{ page.get_site.root_url }}{% image_version_url page.thumbnail_image "fill-821x400" %}" />
     <meta property="og:description" content="{{page.search_description}}">
     <meta property="product:brand" content="xPro">
     <meta property="product:availability" content="in stock">

--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -19,11 +19,13 @@ from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, re_path
+from django.views.decorators.cache import cache_control
 from oauth2_provider.urls import base_urlpatterns
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.images.views.serve import ServeView
+from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 from mitxpro.views import (
     index,
@@ -34,72 +36,84 @@ from mitxpro.views import (
     cms_signin_redirect_to_site_signin,
 )
 
+WAGTAIL_IMG_CACHE_AGE = 31_536_000  # 1 year
 
-urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("status/", include("server_status.urls")),
-    # NOTE: we only bring in base_urlpatterns so applications can only be created via django-admin
-    path(
-        "oauth2/",
-        include((base_urlpatterns, "oauth2_provider"), namespace="oauth2_provider"),
-    ),
-    path("hijack/", include("hijack.urls")),
-    path("", include("authentication.urls")),
-    path("", include("b2b_ecommerce.urls")),
-    path("", include("courses.urls")),
-    path("", include("courseware.urls")),
-    path("", include("ecommerce.urls")),
-    path("", include("users.urls")),
-    path("", include("sheets.urls")),
-    path("", include("mail.urls")),
-    path("boeing/", include(("voucher.urls", "voucher"))),
-    path("api/app_context", AppContextView.as_view(), name="api-app_context"),
-    # named routes mapped to the react app
-    path("signin/", index, name="login"),
-    path("signin/password/", index, name="login-password"),
-    re_path(r"^signin/forgot-password/$", index, name="password-reset"),
-    re_path(
-        r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
-        index,
-        name="password-reset-confirm",
-    ),
-    path("create-account/", index, name="signup"),
-    path("create-account/details/", index, name="signup-details"),
-    path("create-account/extra/", index, name="signup-extra"),
-    path("create-account/denied/", index, name="signup-denied"),
-    path("create-account/error/", index, name="signup-error"),
-    path("create-account/confirm/", index, name="register-confirm"),
-    path("account/inactive/", index, name="account-inactive"),
-    path("account/confirm-email/", index, name="account-confirm-email-change"),
-    path("checkout/", index, name="checkout-page"),
-    path("profile/", index, name="view-profile"),
-    path("profile/edit/", index, name="edit-profile"),
-    re_path(r"^ecommerce/admin/", restricted, name="ecommerce-admin"),
-    # social django needs to be here to preempt the login
-    path("", include("social_django.urls", namespace="social")),
-    re_path(r"^dashboard/", index, name="user-dashboard"),
-    re_path(r"^receipt/(?P<pk>\d+)/", index, name="order-receipt"),
-    re_path(r"^account-settings/", index, name="account-settings"),
-    # Wagtail
-    # NOTE: This route enables dynamic Wagtail image loading. It comes directly from the Wagtail docs:
-    #       https://docs.wagtail.io/en/v2.7/advanced_topics/images/image_serve_view.html#setup
-    re_path(
-        r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
-        ServeView.as_view(),
-        name="wagtailimages_serve",
-    ),
-    re_path(
-        r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"
-    ),
-    re_path(r"^cms/", include(wagtailadmin_urls)),
-    re_path(r"^documents/", include(wagtaildocs_urls)),
-    path("robots.txt", include("robots.urls")),
-    path("", include(wagtail_urls)),
-    # Add custom URL patterns that will also serve Wagtail pages
-    path("", include("cms.urls")),
-] + (
-    static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+urlpatterns = (
+    [
+        path("admin/", admin.site.urls),
+        path("status/", include("server_status.urls")),
+        # NOTE: we only bring in base_urlpatterns so applications can only be created via django-admin
+        path(
+            "oauth2/",
+            include((base_urlpatterns, "oauth2_provider"), namespace="oauth2_provider"),
+        ),
+        path("hijack/", include("hijack.urls")),
+        path("", include("authentication.urls")),
+        path("", include("b2b_ecommerce.urls")),
+        path("", include("courses.urls")),
+        path("", include("courseware.urls")),
+        path("", include("ecommerce.urls")),
+        path("", include("users.urls")),
+        path("", include("sheets.urls")),
+        path("", include("mail.urls")),
+        path("boeing/", include(("voucher.urls", "voucher"))),
+        path("api/app_context", AppContextView.as_view(), name="api-app_context"),
+        # named routes mapped to the react app
+        path("signin/", index, name="login"),
+        path("signin/password/", index, name="login-password"),
+        re_path(r"^signin/forgot-password/$", index, name="password-reset"),
+        re_path(
+            r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
+            index,
+            name="password-reset-confirm",
+        ),
+        path("create-account/", index, name="signup"),
+        path("create-account/details/", index, name="signup-details"),
+        path("create-account/extra/", index, name="signup-extra"),
+        path("create-account/denied/", index, name="signup-denied"),
+        path("create-account/error/", index, name="signup-error"),
+        path("create-account/confirm/", index, name="register-confirm"),
+        path("account/inactive/", index, name="account-inactive"),
+        path("account/confirm-email/", index, name="account-confirm-email-change"),
+        path("checkout/", index, name="checkout-page"),
+        path("profile/", index, name="view-profile"),
+        path("profile/edit/", index, name="edit-profile"),
+        re_path(r"^ecommerce/admin/", restricted, name="ecommerce-admin"),
+        # social django needs to be here to preempt the login
+        path("", include("social_django.urls", namespace="social")),
+        re_path(r"^dashboard/", index, name="user-dashboard"),
+        re_path(r"^receipt/(?P<pk>\d+)/", index, name="order-receipt"),
+        re_path(r"^account-settings/", index, name="account-settings"),
+        # Wagtail
+        re_path(
+            r"^cms/login", cms_signin_redirect_to_site_signin, name="wagtailadmin_login"
+        ),
+        re_path(r"^cms/", include(wagtailadmin_urls)),
+        re_path(r"^documents/", include(wagtaildocs_urls)),
+    ]
+    + decorate_urlpatterns(
+        # NOTE: This route enables dynamic Wagtail image loading. It comes directly from the Wagtail docs:
+        #       https://docs.wagtail.io/en/v2.7/advanced_topics/images/image_serve_view.html#setup
+        [
+            re_path(
+                r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
+                ServeView.as_view(),
+                name="wagtailimages_serve",
+            )
+        ],
+        cache_control(max_age=WAGTAIL_IMG_CACHE_AGE),
+    )
+    + [
+        path("", include(wagtail_urls)),
+        # Add custom URL patterns that will also serve Wagtail pages
+        path("", include("cms.urls")),
+        path("robots.txt", include("robots.urls")),
+    ]
+    + (
+        static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+        + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    )
 )
 
 handler404 = not_found_handler


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Partially addresses #2019 

#### What's this PR do?
Adds a Cache-Control header to wagtail image renditions so they are cached for a year on users' browsers. This should help alleviate some of the issues we've had with uncached Wagtail images.

#### How should this be manually tested?
Check various images across the site in your browser's Network tab and observe the Cache-Control header

#### Any background context you want to provide?
502s under high traffic will still be possible with this fix, but this is a good idea to implement whether or not it helps alleviate those failures. These wagtail images have version tags built into their URLs, so they can be cached indefinitely. These images shouldn't need to be pulled down from a Fastly cache if they have been loaded once

#### Screenshots (if appropriate)
![ss 2020-12-02 at 14 38 03 ](https://user-images.githubusercontent.com/14932219/100922908-6ba61d80-34ac-11eb-846d-63bf789ab736.png)


![ss 2020-12-02 at 14 36 56 ](https://user-images.githubusercontent.com/14932219/100922917-6d6fe100-34ac-11eb-9c7d-6b3940bea341.png)

