### PR TITLE
Fixed 404/500 error with missing course thumbnails

### DIFF
--- a/cms/template_tags_test.py
+++ b/cms/template_tags_test.py
@@ -1,22 +1,32 @@
 """Tests for custom CMS templatetags"""
+from urllib.parse import urljoin
+
 import pytest
 from wagtail.images.views.serve import generate_signature
 from wagtail_factories import ImageFactory
 
 from cms.templatetags.image_version_url import image_version_url
 
+BASE_URL = "http://localhost"
 
-@pytest.mark.django_db
-def test_image_version_url():
+
+@pytest.mark.parametrize("full_url", [True, False])
+def test_image_version_url(settings, full_url):
     """image_version_url should produce an image URL with the file hash set as the file version in the querystring"""
+    settings.SITE_BASE_URL = BASE_URL
     view_name = "wagtailimages_serve"
     image_id = 1
     file_hash = "abcdefg"
     image_filter = "fill-75x75"
     image = ImageFactory.build(id=image_id, file_hash=file_hash)
     expected_signature = generate_signature(image_id, image_filter, key=None)
-    result_url = image_version_url(image, image_filter, viewname=view_name)
-    assert (
-        result_url
-        == f"/images/{expected_signature}/{image_id}/{image_filter}/?v={file_hash}"
+    result_url = image_version_url(
+        image, image_filter, full_url=full_url, viewname=view_name
     )
+    relative_url = (
+        f"/images/{expected_signature}/{image_id}/{image_filter}/?v={file_hash}"
+    )
+    expected_result_url = (
+        relative_url if full_url is False else urljoin(BASE_URL, relative_url)
+    )
+    assert result_url == expected_result_url

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -6,7 +6,9 @@
 
 {% block seohead %}
     {% meta_tags page %}
-    <meta property="og:image" content="{{ page.get_site.root_url }}{% image_version_url page.thumbnail_image "fill-821x400" %}" />
+    {% if page.thumbnail_image %}
+      <meta property="og:image" content="{% image_version_url page.thumbnail_image "fill-821x400" True %}" />
+    {% endif %}
     <meta property="og:description" content="{{page.search_description}}">
     <meta property="product:brand" content="xPro">
     <meta property="product:availability" content="in stock">

--- a/cms/templatetags/image_version_url.py
+++ b/cms/templatetags/image_version_url.py
@@ -1,18 +1,34 @@
 """CMS templatetags"""
 
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urljoin
 from django import template
+from django.conf import settings
 from wagtail.images.templatetags.wagtailimages_tags import image_url
 
 register = template.Library()
 
 
 @register.simple_tag()
-def image_version_url(image, filter_spec, viewname="wagtailimages_serve"):
-    """Generates an image URL using Wagtails library and appends a version to the path to enable effective caching"""
+def image_version_url(
+    image, filter_spec, full_url=False, viewname="wagtailimages_serve"
+):
+    """
+    Generates an image URL using Wagtail's library and appends a version to the path to enable effective caching
+
+    Args:
+        image (wagtail.images.models.Image): The image the a URL will be generated for
+        filter_spec (str): A filter specification for the image (see Wagtail docs)
+        full_url (bool): If True, generates the image URL with the full base URL instead of just a relative URL
+        viewname (str): The view name to use for generating the URL
+
+    Returns:
+        str or None: The image URL, or None if the image doesn't exist
+    """
+    if not image:
+        return ""
     generated_image_url = image_url(image, filter_spec, viewname=viewname)
-    return (
-        f"{generated_image_url}?v={quote_plus(image.file_hash)}"
-        if generated_image_url
-        else ""
-    )
+    if not generated_image_url:
+        return ""
+    if full_url:
+        generated_image_url = urljoin(settings.SITE_BASE_URL, generated_image_url)
+    return f"{generated_image_url}?v={quote_plus(image.file_hash)}"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2025

#### What's this PR do?
Gracefully handles cases where course pages have no thumbnail image configured in the CMS, and improves the templatetag we use for Wagtail images so that it can generate full URLs instead of just relative ones

#### How should this be manually tested?
Configure a course page in the CMS such that it has a thumbnail image, then load the product page for it (e.g.: `http://xpro.odl.local:8053/courses/course-v1:SEED+SysEngBx3/`). It should load properly, and the `<meta og:image>` tag should have the correct URL as its value. Try again after setting that thumbnail image to nothing. The page should load and the `<meta>` tag should disappear

#### Screenshots (if appropriate)
![ss 2020-12-08 at 11 54 46 ](https://user-images.githubusercontent.com/14932219/101516089-0f7c4700-394d-11eb-9ea9-e460cabd27ab.png)

_Without a thumbnail image..._
![ss 2020-12-08 at 11 55 39 ](https://user-images.githubusercontent.com/14932219/101516084-0e4b1a00-394d-11eb-847e-2c8dd0517954.png)

