### PR TITLE
Added fields validation on user profile first & last name

### DIFF
--- a/static/js/components/forms/ProfileFormFields.js
+++ b/static/js/components/forms/ProfileFormFields.js
@@ -26,8 +26,7 @@ export const NAME_REGEX = /^(?![~!@&)(+:'.?/,`-]+)([^/^$#*=[\]`%_;<>{}"|]+)$/
 
 // Field Error messages
 export const NAME_REGEX_FAIL_MESSAGE =
-  "Name cannot start with a special character, and it cannot contain any character from {/^$#*=[]`%_;<>{}}"
-
+  "Name cannot start with a special character (~!@&)(+:'.?/,`-), and cannot contain any of (/^$#*=[]`%_;<>{}|\")"
 const ADDRESS_LINES_MAX = 4
 const seedYear = moment().year()
 

--- a/static/js/components/forms/ProfileFormFields.js
+++ b/static/js/components/forms/ProfileFormFields.js
@@ -22,6 +22,11 @@ const US_POSTAL_CODE_REGEX = /[0-9]{5}(-[0-9]{4}){0,1}/
 const CA_POSTAL_CODE_REGEX = /[A-Z][0-9][A-Z] [0-9][A-Z][0-9]/
 const COUNTRIES_REQUIRING_POSTAL_CODE = [US_ALPHA_2, CA_ALPHA_2]
 const COUNTRIES_REQUIRING_STATE = [US_ALPHA_2, CA_ALPHA_2]
+export const NAME_REGEX = /^(?![~!@&)(+:'.?/,`-]+)([^/^$#*=[\]`%_;<>{}"|]+)$/
+
+// Field Error messages
+export const NAME_REGEX_FAIL_MESSAGE =
+  "Name cannot start with a special character, and it cannot contain any character from {/^$#*=[]`%_;<>{}}"
 
 const ADDRESS_LINES_MAX = 4
 const seedYear = moment().year()
@@ -38,11 +43,13 @@ export const legalAddressValidation = yup.object().shape({
       .string()
       .label("First Name")
       .trim()
+      .matches(NAME_REGEX, NAME_REGEX_FAIL_MESSAGE)
       .required(),
     last_name: yup
       .string()
       .label("Last Name")
       .trim()
+      .matches(NAME_REGEX, NAME_REGEX_FAIL_MESSAGE)
       .required(),
     city: yup
       .string()

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -200,7 +200,7 @@ describe("RegisterDetailsForm", () => {
 
   // Tests name regex for first & last name
   const invalidNameMessage =
-    "Name cannot start with a special character, and it cannot contain any character from {/^$#*=[]`%_;<>{}}"
+    "Name cannot start with a special character (~!@&)(+:'.?/,`-), and cannot contain any of (/^$#*=[]`%_;<>{}|\")"
   ;["legal_address.first_name", "legal_address.last_name"].forEach(
     fieldName => {
       const wrapper = renderForm()
@@ -228,7 +228,7 @@ describe("RegisterDetailsForm", () => {
         )} and expects error=${JSON.stringify(
           invalidNameMessage
         )}`, async () => {
-          // Prepend the character to start if the name value
+          // Prepend the character to start of the name value
           const value = `${validCharacter}Name`
           field.simulate("change", {
             persist: () => {},

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -197,4 +197,93 @@ describe("RegisterDetailsForm", () => {
       )
     })
   })
+
+  // Tests name regex for first & last name
+  const invalidNameMessage =
+    "Name cannot start with a special character, and it cannot contain any character from {/^$#*=[]`%_;<>{}}"
+  ;["legal_address.first_name", "legal_address.last_name"].forEach(
+    fieldName => {
+      const wrapper = renderForm()
+      const field = wrapper.find(`input[name="${fieldName}"]`)
+
+      // List of valid character but they couldn't exist in the start of name
+      ;[
+        "~",
+        "!",
+        "@",
+        "&",
+        ")",
+        "(",
+        "+",
+        ":",
+        ".",
+        "?",
+        "/",
+        ",",
+        "`",
+        "-"
+      ].forEach(validCharacter => {
+        it(`validates the field name=${fieldName}, value=${JSON.stringify(
+          `${validCharacter}Name`
+        )} and expects error=${JSON.stringify(
+          invalidNameMessage
+        )}`, async () => {
+          // Prepend the character to start if the name value
+          const value = `${validCharacter}Name`
+          field.simulate("change", {
+            persist: () => {},
+            target:  { name: fieldName, value: value }
+          })
+          field.simulate("blur")
+          await wait()
+          wrapper.update()
+          assert.deepEqual(
+            findFormikErrorByName(wrapper, fieldName).text(),
+            invalidNameMessage
+          )
+        })
+      })
+      // List of invalid characters that cannot exist anywhere in name
+      ;[
+        "/",
+        "^",
+        "$",
+        "#",
+        "*",
+        "=",
+        "[",
+        "]",
+        "`",
+        "%",
+        "_",
+        ";",
+        "<",
+        ">",
+        "{",
+        "}",
+        '"',
+        "|"
+      ].forEach(invalidCharacter => {
+        it(`validates the field name=${fieldName}, value=${JSON.stringify(
+          `${invalidCharacter}Name${invalidCharacter}`
+        )} and expects error=${JSON.stringify(
+          invalidNameMessage
+        )}`, async () => {
+          // Prepend the character to start if the name value
+          const value = `${invalidCharacter}Name${invalidCharacter}`
+          field.simulate("change", {
+            persist: () => {},
+            target:  { name: fieldName, value: value }
+          })
+          field.simulate("blur")
+          await wait()
+          wrapper.update()
+          assert.deepEqual(
+            findFormikErrorByName(wrapper, fieldName).text(),
+            invalidNameMessage
+          )
+        })
+      })
+    }
+  )
 })

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -19,6 +19,15 @@ log = logging.getLogger()
 
 US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
 CA_POSTAL_RE = re.compile(r"[A-Z]\d[A-Z] \d[A-Z]\d$", flags=re.I)
+USER_NAME_RE = re.compile(
+    r"""
+    ^                               # Start of string
+    (?![~!@&)(+:'.?/,`-]+)          # String should not start from character(s) in this set - They can exist in elsewhere
+    ([^/^$#*=\[\]`%_;<>{}\"|]+)     # String should not contain characters(s) from this set - All invalid characters
+    $                               # End of string
+    """,
+    flags=re.I | re.VERBOSE | re.MULTILINE,
+)
 
 
 class LegalAddressSerializer(serializers.ModelSerializer):
@@ -36,6 +45,18 @@ class LegalAddressSerializer(serializers.ModelSerializer):
     # only required in the US/CA
     state_or_territory = serializers.CharField(max_length=255, allow_blank=True)
     postal_code = serializers.CharField(max_length=10, allow_blank=True)
+
+    def validate_first_name(self, value):
+        """Validates the first name of the user"""
+        if value and not USER_NAME_RE.match(value):
+            raise serializers.ValidationError("First name is not valid")
+        return value
+
+    def validate_last_name(self, value):
+        """Validates the last name of the user"""
+        if value and not USER_NAME_RE.match(value):
+            raise serializers.ValidationError("Last name is not valid")
+        return value
 
     def validate_street_address(self, value):
         """Validates an incoming street address list"""

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -276,7 +276,7 @@ def test_legal_address_serializer_invalid_name(sample_address):
 
     # Case 2: Make sure that name doesn't start with valid special character(s)
     # These characters are valid for a name but they shouldn't be at the start
-    for valid_character in '^/^$#*=[]`%_;<>{}"|':
+    for valid_character in '^/$#*=[]`%_;<>{}"|':
         sample_address["first_name"] = "{}First".format(valid_character)
         sample_address["last_name"] = "{}Last".format(valid_character)
         serializer = LegalAddressSerializer(data=sample_address)

--- a/users/serializers_test.py
+++ b/users/serializers_test.py
@@ -258,3 +258,27 @@ def test_update_user_email(
     else:
         mock_update_edx_user_email.assert_called_once_with(user)
     mock_change_edx_user_email_task.apply_async.assert_not_called()
+
+
+def test_legal_address_serializer_invalid_name(sample_address):
+    """Test that LegalAddressSerializer raises an exception if any if the first or last name is not valid"""
+
+    # To make sure that this test isn't flaky, Checking all the character and sequences that should match our name regex
+
+    # Case 1: Make sure that invalid character(s) doesn't exist within the name
+    for invalid_character in "~!@&)(+:'.?/,`-":
+        # Replace the invalid character on 3 different places within name for rigorous testing of this case
+        sample_address["first_name"] = "{0}First{0} Name{0}".format(invalid_character)
+        sample_address["last_name"] = "{0}Last{0} Name{0}".format(invalid_character)
+        serializer = LegalAddressSerializer(data=sample_address)
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    # Case 2: Make sure that name doesn't start with valid special character(s)
+    # These characters are valid for a name but they shouldn't be at the start
+    for valid_character in '^/^$#*=[]`%_;<>{}"|':
+        sample_address["first_name"] = "{}First".format(valid_character)
+        sample_address["last_name"] = "{}Last".format(valid_character)
+        serializer = LegalAddressSerializer(data=sample_address)
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2037 

#### What's this PR do?
It adds validation on the first and last name of the user in the registration form.

**Below details are taken from Bootcamp PR https://github.com/mitodl/bootcamp-ecommerce/pull/1096 and & confirmed in xPRO as well.**

1. Acceptable Special characters were ```~!@&)(+:'.?/,`-```

2. Non Acceptable special characters were: ```/^$#*=[\]`%_;<>{}"|```

**Cases**
1. Compliance API doesn't accept any character from the `Non-Acceptable` character set mentioned above.
2.  Compliance API accepts characters from the `Acceptable character set` mentioned above, But these characters cannot be at the start of the name

The `regex` used in the PR is created based on the above scenarios.

#### How should this be manually tested?
Follow the steps in the aforementioned issue and see check that field validation is working, based on the above four points.

#### Where should the reviewer start?
Register for a new account.

#### Screenshots (if appropriate)
<img width="792" alt="Screenshot 2021-01-06 at 6 37 41 PM" src="https://user-images.githubusercontent.com/34372316/103774407-504fa480-504e-11eb-8273-c58920c9047c.png">
