### PR TITLE
Added Viewset routing for wagtail hook

### DIFF
--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -1,4 +1,5 @@
 """Custom hooks to configure wagtail behavior"""
+from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.core import hooks
 
@@ -20,7 +21,8 @@ class OrderedPagesAPIEndpoint(PagesAPIViewSet):
 
 
 @hooks.register("construct_admin_api")
-def configure_admin_api_default_order(admin_api):
+def configure_admin_api_default_order(api_router):
     """Swap admin pages API for our own flavor that orders results by title"""
-    admin_api.register_endpoint("pages", OrderedPagesAPIEndpoint)
-    return admin_api
+    api_router = WagtailAPIRouter("wagtailapi")
+    api_router.register_endpoint("pages", OrderedPagesAPIEndpoint)
+    return api_router


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2047 

#### What's this PR do?
It adds registers admin API for wagtail in the Router

#### How should this be manually tested?
Go to `/cms` and check that `pages` list populates correctly and doesn't give `Server Error`

#### Where should the reviewer start?
xPRO CMS

#### Any background context you want to provide?
A wagtail upgrade was recently done, and looks like we might have missed registering the Newly added ViewSet in WagtailAPIRouter.
