### PR TITLE
Added optional auth code column to refund spreadsheet

### DIFF
--- a/app.json
+++ b/app.json
@@ -478,8 +478,24 @@
       "description": "The frequency that the Drive folder should be checked for bulk coupon Sheets that need processing",
       "required": false
     },
+    "SHEETS_REFUND_COMPLETED_DATE_COL": {
+      "description": "The zero-based index of the enrollment change sheet column that contains the row completion date",
+      "required": false
+    },
+    "SHEETS_REFUND_ERROR_COL": {
+      "description": "The zero-based index of the enrollment change sheet column that contains row processing error messages",
+      "required": false
+    },
     "SHEETS_REFUND_FIRST_ROW": {
       "description": "The first row (as it appears in the spreadsheet) of data that our scripts should consider processing in the refund request spreadsheet",
+      "required": false
+    },
+    "SHEETS_REFUND_PROCESSOR_COL": {
+      "description": "The zero-based index of the enrollment change sheet column that contains the user that processed the row",
+      "required": false
+    },
+    "SHEETS_REFUND_SKIP_ROW_COL": {
+      "description": "The zero-based index of the enrollment change sheet column that indicates whether the row should be skipped",
       "required": false
     },
     "SHEETS_TASK_OFFSET": {

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1340,3 +1340,32 @@ SHEETS_REQ_CALCULATED_COLUMNS = {
 _uppercase_a_ord = ord("A")
 SHEETS_REQ_PROCESSED_COL_LETTER = chr(SHEETS_REQ_PROCESSED_COL + _uppercase_a_ord)
 SHEETS_REQ_ERROR_COL_LETTER = chr(SHEETS_REQ_ERROR_COL + _uppercase_a_ord)
+
+SHEETS_REFUND_PROCESSOR_COL = get_int(
+    name="SHEETS_REFUND_PROCESSOR_COL",
+    default=11,
+    description=(
+        "The zero-based index of the enrollment change sheet column that contains the user that processed the row"
+    ),
+)
+SHEETS_REFUND_COMPLETED_DATE_COL = get_int(
+    name="SHEETS_REFUND_COMPLETED_DATE_COL",
+    default=12,
+    description=(
+        "The zero-based index of the enrollment change sheet column that contains the row completion date"
+    ),
+)
+SHEETS_REFUND_ERROR_COL = get_int(
+    name="SHEETS_REFUND_ERROR_COL",
+    default=13,
+    description=(
+        "The zero-based index of the enrollment change sheet column that contains row processing error messages"
+    ),
+)
+SHEETS_REFUND_SKIP_ROW_COL = get_int(
+    name="SHEETS_REFUND_SKIP_ROW_COL",
+    default=14,
+    description=(
+        "The zero-based index of the enrollment change sheet column that indicates whether the row should be skipped"
+    ),
+)

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -151,10 +151,11 @@ class RefundRequestSheetMetadata(
     """Metadata for the refund request spreadsheet"""
 
     FORM_RESPONSE_ID_COL = 0
-    PROCESSOR_COL = 11
-    COMPLETED_DATE_COL = 12
-    ERROR_COL = 13
-    SKIP_ROW_COL = 14
+
+    PROCESSOR_COL = settings.SHEETS_REFUND_PROCESSOR_COL
+    COMPLETED_DATE_COL = settings.SHEETS_REFUND_COMPLETED_DATE_COL
+    ERROR_COL = settings.SHEETS_REFUND_ERROR_COL
+    SKIP_ROW_COL = settings.SHEETS_REFUND_SKIP_ROW_COL
 
     def __init__(self):
         self.sheet_type = SHEET_TYPE_ENROLL_CHANGE


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #2023 

#### What's this PR do?
Adds settings that allow for an optional admin-only auth code column in a refund spreadsheet

#### How should this be manually tested?
Code review only. This will be tested in RC
