### PR TITLE
Fixed error handling to save enrollments on edX HTTP errors

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -6,6 +6,7 @@ import logging
 from traceback import format_exc
 
 from django.core.exceptions import ValidationError
+from requests.exceptions import HTTPError, ConnectionError as RequestsConnectionError
 
 from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
 from courses.models import CourseRunEnrollment, ProgramEnrollment, CourseRun
@@ -105,13 +106,14 @@ def create_run_enrollments(
             for all of the given course runs
     """
     successful_enrollments = []
-
     try:
         enroll_in_edx_course_runs(user, runs)
     except (
         EdxApiEnrollErrorException,
         UnknownEdxApiEnrollException,
         NoEdxApiAuthError,
+        HTTPError,
+        RequestsConnectionError,
     ):
         log.exception(
             "edX enrollment failure for user: %s, runs: %s (order: %s)",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #2042

#### What's this PR do?
Adds exception handling to order completion so that local enrollment records will still be created if a request to edX results in an unexpected error (e.g.: the service is down or there's a bug on the server)

#### How should this be manually tested?
1. Run xPro without edX running
1. Complete checkout for some course run

Checkout You should see an exception logged, and a `CourseRunEnrollment` record should be created for the given user and run. Before this fix, this would have resulted in an unhandled exception and no local enrollment record would have been created
