### PR TITLE
Course card url redirection fix to use url instead of full_url

### DIFF
--- a/cms/templates/partials/courseware-carousel-base.html
+++ b/cms/templates/partials/courseware-carousel-base.html
@@ -1,6 +1,6 @@
 {% load static wagtailcore_tags  image_version_url %}
 {% for courseware_page in pages %}
-  <div class="slide" data-url="{{ courseware_page.full_url }}">
+  <div class="slide" data-url="{{ courseware_page.url }}">
     <div class="slide-holder">
       {% if courseware_page.thumbnail_image %}
         <img src="{% image_version_url courseware_page.thumbnail_image "fill-480x275" %}" alt="{{ courseware_page.title }}" />


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
It fixes the course redirection when clicked from a course carousel inside a Product Detail page. Before it would use full_url that would take the user to the base URL which was either `localhost` or `BASE:Port` hence not loading the page.

#### How should this be manually tested?
Open a program with a `Course Carousel`, Click on any card's(Area except `Card/course title` & `View Details`), and the course detail page should load without any errors.

#### Where should the reviewer start?
Product page for a Program with carousel.

