### PR TITLE
Reduce Layout shifts, Inline Styling - Set fixed height/width where possible

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -259,13 +259,9 @@ class CatalogPage(Page):
             .select_related("thumbnail_image")
         )
 
-        featured_product = ProgramPage.objects.filter(
-            featured=True, program__live=True
-        ).select_related("program", "thumbnail_image").prefetch_related(
-            "program__courses__courseruns"
-        ) or CoursePage.objects.filter(
-            featured=True, course__live=True
-        )
+        featured_product = program_page_qset.filter(
+            featured=True
+        ) or course_page_qset.filter(featured=True)
         all_pages, program_pages, course_pages = filter_and_sort_catalog_pages(
             program_page_qset,
             course_page_qset,

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -11,7 +11,7 @@
       {% for member in page.members %}
         <div class="slide">
           <div class="slide-holder">
-            <img src="{% image_version_url member.value.image "fill-300x300" %}" alt="{{ member.value.name }}">
+            <img src="{% image_version_url member.value.image "fill-300x300" %}" alt="{{ member.value.name }}" loading="lazy">
             <h2>{{ member.value.name }}</h2>
             <div class="text-holder">
               {{ member.value.description|richtext }}

--- a/cms/templates/partials/learning-techniques.html
+++ b/cms/templates/partials/learning-techniques.html
@@ -5,7 +5,7 @@
     {% for technique in page.technique_items %}
       <li>
         <div class="img-holder">
-          <img src="{% image_version_url technique.value.image "height-110|format-png" %}" alt="Learning technique" />
+          <img src="{% image_version_url technique.value.image "height-110|format-png" %}" alt="Learning technique" loading="lazy"/>
         </div>
         <h3>{{ technique.value.heading }}</h3>
         <h4>{{ technique.value.sub_heading }}</h4>

--- a/cms/templates/partials/testimonial-carousel.html
+++ b/cms/templates/partials/testimonial-carousel.html
@@ -12,7 +12,7 @@
       <div class="slide">
         <div class="slide-holder">
           {% if testimonial.value.image %}
-            <img src="{% image_version_url testimonial.value.image "fill-75x75" %}" alt="{{ testimonial.value.name }}" />
+            <img src="{% image_version_url testimonial.value.image "fill-75x75" %}" alt="{{ testimonial.value.name }}" width="75" height="75" loading="lazy"/>
           {% endif %}
           <h2>{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>
           <p>{{ testimonial.value.quote|truncatechars:150 }}</p>
@@ -36,7 +36,7 @@
             </div>
             <div class="container px-4">
               <div class="row py-2">
-                <img src="{% image_version_url testimonial.value.image "fill-100x100" %}" class="border rounded-circle headshot-image" alt="Testimonial image" />
+                <img src="{% image_version_url testimonial.value.image "fill-100x100" %}" class="border rounded-circle headshot-image" alt="Testimonial image" width="100" height="100" loading="lazy"/>
               </div>
               <div class="row mb-4">
                 <h2 class="modal-title text-uppercase">{{ testimonial.value.name }}, {{ testimonial.value.title }}</h2>

--- a/mitxpro/templates/footer.html
+++ b/mitxpro/templates/footer.html
@@ -6,7 +6,7 @@
       <div class="content-holder">
         <div class="row">
           <div class="col-sm-6 clearfix">
-            <img src={% static 'images/help.png' %} alt="Help">
+            <img src={% static 'images/help.png' %} width="70" height="70" alt="Help" loading="lazy">
             <div class="info">
               <a href="https://xpro.zendesk.com/hc/">
                 <h2>Help & FAQ</h2>
@@ -15,7 +15,7 @@
             </div>
           </div>
           <div class="col-sm-6 clearfix">
-            <img src={% static 'images/contact.png' %} alt="Contact Us">
+            <img src={% static 'images/contact.png' %} width="70" height="70" alt="Contact Us" loading="lazy">
             <div class="info">
               <a href="https://xpro.zendesk.com/hc/en-us/requests/new">
                 <h2>Contact Us</h2>
@@ -30,7 +30,7 @@
   <div class="container">
     <div class="footer-bottom">
       <div class="mit-info">
-        <img src="{% static 'images/mit.png' %}" alt="MIT" />
+        <img src="{% static 'images/mit.png' %}" width="78" height="41" alt="MIT" loading="lazy"/>
         <address>
           Massachusetts Institute of Technology <br />77 Massachusetts Avenue
           <br />Cambridge, MA 02139

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -41,6 +41,8 @@ const TopAppBar = ({ currentUser, location }: Props) => (
             src="/static/images/mitx-pro-logo.png"
             className="site-logo"
             alt={SETTINGS.site_name}
+            width={154}
+            height={47.5}
           />
         </div>
         {currentUser.is_authenticated ? null : (

--- a/static/js/components/UserMenu.js
+++ b/static/js/components/UserMenu.js
@@ -27,6 +27,8 @@ const UserMenu = ({ currentUser }: Props) => {
           src="/static/images/avatar_default.png"
           alt={`Profile image for ${currentUser.name}`}
           className={`profile-image`}
+          width={34}
+          height={34}
         />
       </div>
       <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -109,6 +109,8 @@ export class ReceiptPage extends React.Component<Props> {
                     <img
                       src="/static/images/mitx-pro-logo.png"
                       alt="MIT xPro"
+                      width={154}
+                      height={47.5}
                     />
                   </div>
                   <h1>Receipt</h1>

--- a/static/scss/footer.scss
+++ b/static/scss/footer.scss
@@ -105,6 +105,7 @@
 
     img {
       width: 78px;
+      height: 41px;
       margin: 0 auto 15px;
 
       @include media-breakpoint-up(md) {

--- a/static/scss/top-app-bar.scss
+++ b/static/scss/top-app-bar.scss
@@ -77,7 +77,7 @@
 
 .site-logo {
   width: 154px;
-  height: auto;
+  height: 47.5px;
 }
 
 .navbar-brand {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #2065

#### What's this PR do?
Attempts to optimize the Catalog & Product Pages through suggestions provided by Lighthouse
- Sets fixed styling(height/width) for the elements where possible to avoid layout shifts.
- Adds lazy loading to the images where possible.
- Defers a Zendesk script

#### How should this be manually tested?
Open any of the Catalog/Product and check the statistics on `LightHouse`, Make sure that the page loads in a better amount of time than before. Make sure that we caught maximum possible suggestions through Lighthouse regarding images layout shifts, setting height/width of images.
