### PR TITLE
Ignore B2B line sync errors in hubspot

### DIFF
--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -10,6 +10,7 @@ from urllib.parse import urljoin, urlencode
 import requests
 from django.conf import settings
 
+from b2b_ecommerce.models import B2B_INTEGRATION_PREFIX
 from mitxpro.utils import now_in_utc
 
 HUBSPOT_API_BASE_URL = "https://api.hubapi.com"
@@ -51,8 +52,10 @@ def parse_hubspot_id(hubspot_id):
     Returns:
         int: The object ID or None
     """
-    match = re.compile(fr"{settings.HUBSPOT_ID_PREFIX}-(\d+)").match(hubspot_id)
-    return int(match.group(1)) if match else None
+    match = re.compile(
+        fr"{settings.HUBSPOT_ID_PREFIX}-({B2B_INTEGRATION_PREFIX})?(\d+)"
+    ).match(hubspot_id)
+    return int(match.group(2)) if match else None
 
 
 def send_hubspot_request(

--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -83,21 +83,11 @@ line_error_response_json = [
     {
         "portalId": 5_890_463,
         "objectType": "LINE_ITEM",
-        "integratorObjectId": f"{settings.HUBSPOT_ID_PREFIX}{B2B_INTEGRATION_PREFIX}-{FAKE_OBJECT_ID}",
+        "integratorObjectId": f"{settings.HUBSPOT_ID_PREFIX}-{B2B_INTEGRATION_PREFIX}{FAKE_OBJECT_ID + 1}",
         "changeOccurredTimestamp": hubspot_timestamp(TIMESTAMPS[0]),
         "errorTimestamp": hubspot_timestamp(TIMESTAMPS[2]),
         "type": "INVALID_ASSOCIATION_PROPERTY",
-        "details": f"Invalid associations [hs_assoc__deal_id: {settings.HUBSPOT_ID_PREFIX}{B2B_INTEGRATION_PREFIX}-{FAKE_OBJECT_ID}]. Do those objects exist?",
-        "status": "OPEN",
-    },
-    {
-        "portalId": 5_890_463,
-        "objectType": "LINE_ITEM",
-        "integratorObjectId": f"{settings.HUBSPOT_ID_PREFIX}-{FAKE_OBJECT_ID + 1}",
-        "changeOccurredTimestamp": hubspot_timestamp(TIMESTAMPS[0]),
-        "errorTimestamp": hubspot_timestamp(TIMESTAMPS[2]),
-        "type": "INVALID_ASSOCIATION_PROPERTY",
-        "details": f"Invalid associations [hs_assoc__deal_id: {settings.HUBSPOT_ID_PREFIX}-{FAKE_OBJECT_ID}]. Do those objects exist?",
+        "details": f"Invalid associations [hs_assoc__deal_id: {settings.HUBSPOT_ID_PREFIX}-{B2B_INTEGRATION_PREFIX}{FAKE_OBJECT_ID}]. Do those objects exist?",
         "status": "OPEN",
     },
     {
@@ -142,7 +132,7 @@ def mock_hubspot_line_errors(mocker):
 def mock_hubspot_b2b_line_error(mocker):
     """Mock the get_sync_errors API call and return a b2b line sync error with invalid association properties"""
     yield mocker.patch(
-        "hubspot.api.paged_sync_errors", side_effect=[line_error_response_json[1:1], []]
+        "hubspot.api.paged_sync_errors", side_effect=[[line_error_response_json[1]], []]
     )
 
 

--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -8,6 +8,7 @@ import pytz
 from django.conf import settings
 import pytest
 from b2b_ecommerce import factories as b2b_factories
+from b2b_ecommerce.models import B2B_INTEGRATION_PREFIX
 from ecommerce import factories
 from hubspot.api import hubspot_timestamp
 
@@ -82,6 +83,16 @@ line_error_response_json = [
     {
         "portalId": 5_890_463,
         "objectType": "LINE_ITEM",
+        "integratorObjectId": f"{settings.HUBSPOT_ID_PREFIX}{B2B_INTEGRATION_PREFIX}-{FAKE_OBJECT_ID}",
+        "changeOccurredTimestamp": hubspot_timestamp(TIMESTAMPS[0]),
+        "errorTimestamp": hubspot_timestamp(TIMESTAMPS[2]),
+        "type": "INVALID_ASSOCIATION_PROPERTY",
+        "details": f"Invalid associations [hs_assoc__deal_id: {settings.HUBSPOT_ID_PREFIX}{B2B_INTEGRATION_PREFIX}-{FAKE_OBJECT_ID}]. Do those objects exist?",
+        "status": "OPEN",
+    },
+    {
+        "portalId": 5_890_463,
+        "objectType": "LINE_ITEM",
         "integratorObjectId": f"{settings.HUBSPOT_ID_PREFIX}-{FAKE_OBJECT_ID + 1}",
         "changeOccurredTimestamp": hubspot_timestamp(TIMESTAMPS[0]),
         "errorTimestamp": hubspot_timestamp(TIMESTAMPS[2]),
@@ -124,6 +135,14 @@ def mock_hubspot_line_errors(mocker):
     """Mock the get_sync_errors API call and return multiple line sync error with invalid association properties"""
     yield mocker.patch(
         "hubspot.api.paged_sync_errors", side_effect=[line_error_response_json]
+    )
+
+
+@pytest.fixture
+def mock_hubspot_b2b_line_error(mocker):
+    """Mock the get_sync_errors API call and return a b2b line sync error with invalid association properties"""
+    yield mocker.patch(
+        "hubspot.api.paged_sync_errors", side_effect=[line_error_response_json[1:1], []]
     )
 
 

--- a/hubspot/tasks_test.py
+++ b/hubspot/tasks_test.py
@@ -192,6 +192,18 @@ def test_create_hubspot_line_resync(
     assert HubspotLineResync.objects.first().line == line
 
 
+def test_ignore_hubspot_b2b_line_error(
+    settings, mock_hubspot_b2b_line_error, mock_logger
+):
+    """Test that a b2b line error is ignored"""
+    HubspotErrorCheckFactory.create(checked_on=TIMESTAMPS[0])
+    settings.HUBSPOT_API_KEY = "dkfjKJ2jfd"
+    check_hubspot_api_errors()
+    assert mock_hubspot_b2b_line_error.call_count == 1
+    assert HubspotLineResync.objects.count() == 0
+    assert mock_logger.call_count == 0
+
+
 def test_skip_error_checks(settings, mock_hubspot_errors):
     """Test that no requests to Hubspot are made if the HUBSPOT_API_KEY is not set """
     settings.HUBSPOT_API_KEY = None

--- a/hubspot/tasks_test.py
+++ b/hubspot/tasks_test.py
@@ -199,9 +199,9 @@ def test_ignore_hubspot_b2b_line_error(
     HubspotErrorCheckFactory.create(checked_on=TIMESTAMPS[0])
     settings.HUBSPOT_API_KEY = "dkfjKJ2jfd"
     check_hubspot_api_errors()
-    assert mock_hubspot_b2b_line_error.call_count == 1
+    assert mock_hubspot_b2b_line_error.call_count == 2
     assert HubspotLineResync.objects.count() == 0
-    assert mock_logger.call_count == 0
+    mock_logger.assert_not_called()
 
 
 def test_skip_error_checks(settings, mock_hubspot_errors):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/mitxpro/issues/2074

#### What's this PR do?
Ignores B2B line sync errors in hubspot

#### How should this be manually tested?
Tests should pass

To test manually:
Make sure the following .env values are populated:
HUBSPOT_API_KEY=<obtain from hubspot website or me>
HUBSPOT_ID_PREFIX=<something like 'xpro-localdev-2021'>

Manually create a new B2BOrder in django admin (to avoid triggering a sync task).  Fill out the bare minimum (product version, email, num seats, per item price, total price).  Note the id of the order.

In a shell, run:
 ```
from hubspot.tasks import *
sync_b2b_product_with_hubspot(<order_id>)`
```

After a minute or so, run:
```
for error in get_sync_errors():
    if ("B2B-<order_id>" in error.get("integratorObjectId", "")):
        print(error)
```

You should get a line printed that looks something like this:
```
{'portalId': 5890463, 'objectType': 'LINE_ITEM', 'integratorObjectId': 'xpro-localdev-2021-B2B-<order_id>', 'changeOccurredTimestamp': 1611322300833, 'errorTimestamp': 1611322324417, 'type': 'INVALID_ASSOCIATION_PROPERTY', 'details': 'Invalid associations [hs_assoc__deal_id: xpro-localdev-2021-B2B-<order_id>]. Do those objects exist?', 'status': 'OPEN'}
```

Now run `check_hubspot_api_errors()`.  You might or might not get an error logged, but if so it should not be the one above.


#### Any background context you want to provide?
After some discussion with Peter and Brian, decided to make a quick fix to ignore these errors since B2B orders are typically synced to hubspot twice.  If this error occurs on the 1st sync, the second sync will fix it.

Longer term, if some B2B orders prove to not sync properly in the future, it might make sense to schedule resync tasks, as is currently done with regular Order line errors.
