### PR TITLE
Combined and reduced font imports, async loading non-essential fonts

### DIFF
--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -11,11 +11,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     {% include "partials/gtm_head.html" %}
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=swap" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Rajdhani:300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css" rel="stylesheet"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700|Rajdhani:300,400,500,600,700&display=swap"
+          media="all" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
+          media="none" onload="if(media!='all') media='all'">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css"
+          media="none" onload="if(media!='all') media='all'"/>
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
     {% if CSOURCE_PAYLOAD %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2065 

#### What's this PR do?
- Combines google font imports into a single `<link>`
- Removes a font import for a font that we didn't appear to be using
- Sets non-essential font/icon imports to load asynchronously

#### How should this be manually tested?
Load the homepage, ensure that everything looks correct. Also try slowing down the connection to see if this PR introduces any UI weirdness while the page is loading

#### Any background context you want to provide?
If the async loading is applied to the google font API `<link>` tag, there is a noticeable "blink" when the font on the home page changes over as the page is loading. That's why I decided not to use that async technique for that link tag

