### PR TITLE
Merge 3rd-party & django js files, Move HTML scripts to js files

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -30,60 +30,6 @@
   {% render_bundle 'header' %}
 {% endblock %}
 
-{% block scripts %}
-  {{ block.super }}
-  <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
-      // FAQs
-      $("body").on("click", ".readmore", function(e) {
-        const $readmoreText = $(this).find(".readmore-text");
-        e.preventDefault();
-        $("li.extra-faq").toggleClass("d-none");
-        $readmoreText.text($readmoreText.text() === "Hide" ? "Read" : "Hide");
-      });
-
-      // More Dates
-      $(".dates-tooltip").popover({
-        template:
-          '<div class="popover" role="tooltip">' +
-          '<div class="arrow"></div>' +
-          '<div class="popover-header py-2 px-0 mx-5"></div>' +
-          '<div class="popover-body"></div>' +
-          '</div>'
-      });
-
-      var navbar = $("#subNavBarContainer");
-
-      // Navigation Bar
-      $("body").scrollspy({
-        target: "#subNavBar",
-        offset: navbar.outerHeight() + 5.0
-      });
-
-      $(window).on("activate.bs.scrollspy", function(e, obj) {
-        $("#subNavBarSelector").text(
-          $(`.navbar-nav>li>a[href='${obj.relatedTarget}']`).text()
-        );
-      });
-
-      $(".navbar-nav>li>a").on("click", function(event) {
-        event.preventDefault();
-
-        const target = $($(this).attr("href"));
-
-        window.scrollTo(0, target.offset().top - navbar.outerHeight());
-
-        $(".navbar-collapse.show").removeClass("show");
-        $(".navbar-toggler").addClass("collapsed");
-      });
-      
-      if (SETTINGS.zendesk_config.help_widget_enabled) {
-        zE('webWidget', 'helpCenter:setSuggestions', { search: '{{page.product.title}}'});
-      }
-    });
-  </script>
-{% endblock %}
-
 {% block content %}
 <div>
   {% include "partials/hero.html" %}

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -59,7 +59,6 @@
     {% block footer %}
         {% include "footer.html" %}
     {% endblock %}
-    {% render_bundle 'third_party' added_attrs='defer' %}
     {% render_bundle 'django' added_attrs='defer' %}
     {% block scripts %}
     {% endblock %}

--- a/mitxpro/views_test.py
+++ b/mitxpro/views_test.py
@@ -61,7 +61,7 @@ def test_webpack_url(mocker, settings, client):
     response = client.get(reverse("login"))
 
     bundles = {bundle[0][1] for bundle in get_bundle.call_args_list}
-    assert bundles == {"third_party", "django", "root", "style"}
+    assert bundles == {"django", "root", "style"}
     js_settings = json.loads(response.context["js_settings_json"])
     assert js_settings == {
         "gaTrackingID": "fake",

--- a/static/js/entry/django.js
+++ b/static/js/entry/django.js
@@ -1,3 +1,12 @@
+// Third-party imports
+import "jquery"
+import "bootstrap"
+import "popper.js"
+import "slick-carousel"
+import "hls.js"
+import "@fancyapps/fancybox"
+
+// Custom native imports
 import notifications from "../notifications.js"
 import tooltip from "../tooltip.js"
 import hero from "../hero.js"
@@ -6,6 +15,7 @@ import coursewareCarousel from "../courseware_carousel.js"
 import textVideoSection from "../text_video_section.js"
 import imageCarousel from "../image_carousel.js"
 import facultyCarousel from "../faculty_carousel.js"
+import productDetails from "../product_detail.js"
 
 document.addEventListener("DOMContentLoaded", function() {
   notifications()
@@ -16,4 +26,5 @@ document.addEventListener("DOMContentLoaded", function() {
   textVideoSection()
   imageCarousel()
   facultyCarousel()
+  productDetails()
 })

--- a/static/js/entry/third-party.js
+++ b/static/js/entry/third-party.js
@@ -1,6 +1,0 @@
-import "jquery"
-import "bootstrap"
-import "popper.js"
-import "slick-carousel"
-import "hls.js"
-import "@fancyapps/fancybox"

--- a/static/js/product_detail.js
+++ b/static/js/product_detail.js
@@ -1,0 +1,55 @@
+/*eslint-env jquery*/
+/*eslint semi: ["error", "always"]*/
+
+export default function productDetails() {
+  // FAQs
+  $("body").on("click", ".readmore", function(e) {
+    const $readmoreText = $(this).find(".readmore-text");
+    e.preventDefault();
+    $("li.extra-faq").toggleClass("d-none");
+    $readmoreText.text($readmoreText.text() === "Hide" ? "Read" : "Hide");
+  });
+
+  // More Dates
+  $(".dates-tooltip").popover({
+    template:
+      '<div class="popover" role="tooltip">' +
+      '<div class="arrow"></div>' +
+      '<div class="popover-header py-2 px-0 mx-5"></div>' +
+      '<div class="popover-body"></div>' +
+      "</div>"
+  });
+
+  const navbar = $("#subNavBarContainer");
+
+  // Navigation Bar
+  $("body").scrollspy({
+    target: "#subNavBar",
+    offset: navbar.outerHeight() + 5.0
+  });
+
+  $(window).on("activate.bs.scrollspy", function(e, obj) {
+    $("#subNavBarSelector").text(
+      $(`.navbar-nav>li>a[href='${obj.relatedTarget}']`).text()
+    );
+  });
+
+  $(".navbar-nav>li>a").on("click", function(event) {
+    event.preventDefault();
+
+    const target = $($(this).attr("href"));
+
+    window.scrollTo(0, target.offset().top - navbar.outerHeight());
+
+    $(".navbar-collapse.show").removeClass("show");
+    $(".navbar-toggler").addClass("collapsed");
+  });
+
+  // eslint-disable-next-line no-undef
+  if (SETTINGS.zendesk_config.help_widget_enabled) {
+    // eslint-disable-next-line no-undef
+    zE("webWidget", "helpCenter:setSuggestions", {
+      search: "{{page.product.title}}"
+    });
+  }
+}

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -7,8 +7,7 @@ module.exports = {
       root:         ["@babel/polyfill", "./static/js/entry/root"],
       header:       ["@babel/polyfill", "./static/js/entry/header"],
       style:        "./static/js/entry/style",
-      third_party:  ["@babel/polyfill", "./static/js/entry/third-party"],
-      django:       "./static/js/entry/django"
+      django:       ["@babel/polyfill", "./static/js/entry/django"],
     },
     module: {
       rules: [


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2065 

#### What's this PR do?
- Merges `django.js` & `third-party.js` files since the usage of both files is only in one place `base.html`.
- Moves inline scripts from product_page.html to js files which in turn is now served through webpack.

#### How should this be manually tested?
- Make sure that `django.js` & `third-party.js` related scripts/functionality works fine & is now converted into one js file request which is `base.js`.
- Make sure that moved script changes in `product_page.html` works fine in this PR.
 
#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
We had two had two separate files before for loading third-party plugins and out custom plugins. But both of these had only 
 one place of usage e.g. in `base.html`
