### PR TITLE
Applying lazy-loading on div element backgrounds

### DIFF
--- a/cms/templates/partials/course-carousel.html
+++ b/cms/templates/partials/course-carousel.html
@@ -1,5 +1,5 @@
 {% load static wagtailcore_tags wagtailimages_tags %}
-<div id="courseLineup" class="course-in-program">
+<div id="courseLineup" class="course-in-program lazy-load-div" >
   <div class="container">
     <div class="head">
       <h1>{{ page.heading }}</h1>

--- a/cms/templates/partials/faculty-carousel.html
+++ b/cms/templates/partials/faculty-carousel.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags image_version_url %}
-<div id="faculty" class="faculty-block">
+<div id="faculty" class="faculty-block lazy-load-div">
   <div class="container">
     <div class="head">
       <h1>{{ page.heading }}</h1>

--- a/cms/templates/partials/for-teams.html
+++ b/cms/templates/partials/for-teams.html
@@ -1,5 +1,5 @@
 {% load static wagtailimages_tags image_version_url %}
-<div id="forTeams" class="for-teams-block {% if page.dark_theme %} dark-theme {% endif %}">
+<div id="forTeams" class="for-teams-block {% if page.dark_theme %} dark-theme {% endif %} lazy-load-div">
   <div class="container">
     <div class="row">
       <div class="col-lg-7 {% if page.switch_layout %}order-2{% endif %}">

--- a/cms/templates/partials/image-carousel.html
+++ b/cms/templates/partials/image-carousel.html
@@ -1,5 +1,5 @@
 {% load static image_version_url %}
-<div class="companies-trust-block">
+<div class="companies-trust-block lazy-load-div">
     <div class="container">
         <h1>{{ page.title }}</h1>
         <div class="logos-slider">

--- a/cms/templates/partials/testimonial-carousel.html
+++ b/cms/templates/partials/testimonial-carousel.html
@@ -1,5 +1,5 @@
 {% load image_version_url wagtailcore_tags %}
-<div id="testimonials" class="learners-block">
+<div id="testimonials" class="learners-block lazy-load-div">
   <div class="container">
     <div class="head">
       <h1>{{ page.heading }}</h1>

--- a/cms/templates/partials/text-section.html
+++ b/cms/templates/partials/text-section.html
@@ -1,5 +1,5 @@
 {% load static wagtailimages_tags wagtailcore_tags %}
-<div id="textSection" class="text-block {% if page.dark_theme %} dark-theme {% endif %}">
+<div id="textSection" class="text-block {% if page.dark_theme %} dark-theme {% endif %} lazy-load-div">
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-lg-10">

--- a/courses/templates/subscription.html
+++ b/courses/templates/subscription.html
@@ -1,4 +1,4 @@
-<div class="posted-block">
+<div class="posted-block lazy-load-div">
     <div class="container">
         <h1>WANT TO LEARN ABOUT NEW COURSES FROM {{ site_name }}?</h1>
         <!--[if lte IE 8]>

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -76,5 +76,28 @@
       });
     </script>
     {% endif %}
+    <script type="text/javascript">
+      /*
+          This script helps in loading the div backgrounds lazily since div element doesn't support "loading='lazy'" attr.
+          It adds intersection observer on all those div elements which specify "lazy-load-div" in their classes.
+          Upon entering the viewport, specified css class with name "lazy-background" having "background-image" attribute
+          is added into the ClassList of the div element which then loads the background.
+       */
+      document.addEventListener("DOMContentLoaded", function () {
+        const lazyBackgrounds = document.querySelectorAll(".lazy-load-div");
+        let lazyBackgroundObserver = new IntersectionObserver(function (entries, observer) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("lazy-background");
+              lazyBackgroundObserver.unobserve(entry.target);
+            }
+          });
+        });
+
+        lazyBackgrounds.forEach(function (lazyBackground) {
+          lazyBackgroundObserver.observe(lazyBackground);
+        });
+      });
+    </script>
   </body>
 </html>

--- a/static/scss/catalog/keep-me-posted.scss
+++ b/static/scss/catalog/keep-me-posted.scss
@@ -2,7 +2,7 @@
 .posted-block {
   width: 100%;
   padding: 75px 0;
-  background: url('#{$static-path}/images/bg-contact.jpg') repeat-x 50% 50%;
+  background: repeat-x 50% 50%;
   min-height: 200px;
   background-size: cover;
   position: relative;
@@ -138,6 +138,10 @@
       margin: 0;
     }
   }
+}
+
+.posted-block.lazy-background {
+  background-image: url('#{$static-path}/images/bg-contact.jpg');
 }
 
 .submitted-message {

--- a/static/scss/detail/companies-trust.scss
+++ b/static/scss/detail/companies-trust.scss
@@ -2,7 +2,7 @@
 
 .companies-trust-block {
   padding: 90px 0 80px;
-  background: white url('#{$static-path}/images/countries-trust-bg.png') repeat-x 0 0;
+  background: white repeat-x 0 0;
   position: relative;
   text-align: center;
 
@@ -15,6 +15,10 @@
     margin: 0 0 50px;
     text-align: center;
   }
+}
+
+.companies-trust-block.lazy-background {
+  background-image: url('#{$static-path}/images/countries-trust-bg.png');
 }
 
 .logos-slider {

--- a/static/scss/detail/courses-in-program.scss
+++ b/static/scss/detail/courses-in-program.scss
@@ -2,7 +2,7 @@
 .course-in-program {
   width: 100%;
   padding: 100px 0 50px;
-  background: white url("#{$static-path}/images/course-carousel-bg.jpg") no-repeat 50% 50%;
+  background: white no-repeat 50% 50%;
   min-height: 400px;
   overflow: hidden;
   position: relative;
@@ -47,6 +47,10 @@
     transform: translateX(-50%);
     left: 50%;
   }
+}
+
+.course-in-program.lazy-background {
+  background-image: url("#{$static-path}/images/course-carousel-bg.jpg");
 }
 
 .course-slider {

--- a/static/scss/detail/faculty.scss
+++ b/static/scss/detail/faculty.scss
@@ -2,7 +2,7 @@
 .faculty-block {
   width: 100%;
   padding: 100px 0 50px;
-  background: black url("#{$static-path}/images/faculty-bg.jpg") no-repeat 50% 0;
+  background: black no-repeat 50% 0;
   min-height: 400px;
   overflow: hidden;
   position: relative;
@@ -27,6 +27,10 @@
       margin: 0 0 25px;
     }
   }
+}
+
+.faculty-block.lazy-background {
+  background-image: url("#{$static-path}/images/faculty-bg.jpg");
 }
 
 .faculty-slider {

--- a/static/scss/detail/for-teams.scss
+++ b/static/scss/detail/for-teams.scss
@@ -2,7 +2,7 @@
 .for-teams-block {
   width: 100%;
   padding: 100px 0 50px;
-  background: white url("#{$static-path}/images/transparent-pixels-bg.png") repeat-x 0 100%;
+  background: white repeat-x 0 100%;
   min-height: 400px;
   overflow: hidden;
   position: relative;
@@ -81,6 +81,10 @@
       }
     }
   }
+}
+
+.for-teams-block.lazy-background {
+  background-image: url("#{$static-path}/images/transparent-pixels-bg.png");
 }
 
 // Dark theme

--- a/static/scss/detail/testimonial-carousel.scss
+++ b/static/scss/detail/testimonial-carousel.scss
@@ -1,7 +1,7 @@
 // sass-lint:disable mixins-before-declarations
 .learners-block {
   padding: 100px 0 50px;
-  background: white url("#{$static-path}/images/testimonial-carousel-bg.jpg") no-repeat 50% 0;
+  background: white no-repeat 50% 0;
   min-height: 400px;
   overflow: hidden;
   position: relative;
@@ -39,6 +39,10 @@
       margin: 0 0 25px;
     }
   }
+}
+
+.learners-block.lazy-background {
+  background-image: url("#{$static-path}/images/testimonial-carousel-bg.jpg");
 }
 
 .learners-slider {

--- a/static/scss/detail/text-section.scss
+++ b/static/scss/detail/text-section.scss
@@ -2,7 +2,7 @@
 .text-block {
   width: 100%;
   padding: 100px 0 50px;
-  background: white url("#{$static-path}/images/transparent-pixels-bg.png") repeat-x 0 100%;
+  background: white repeat-x 0 100%;
   min-height: 400px;
   overflow: hidden;
   position: relative;
@@ -29,6 +29,10 @@
   p {
     margin: 0 0 30px;
   }
+}
+
+.text-block.lazy-background {
+  background-image: url("#{$static-path}/images/transparent-pixels-bg.png");
 }
 
 // Dark theme


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#2065 

#### What's this PR do?
It adds `IntersectionObserve`r on our `div` elements to load their background lazily. Initially we used to load the backgrounds of our div elements such as `Faculty, Testimonials` right when they would render. After this PR the backgrounds will only load once that specific div element is coming into `Viewport`.

**Note:** This change give some performance improvement in the suggestion category of `Defer Off-Screen images` by `Lighthouse`. Although it adds a bit to the overall performance we should note that the backgrounds to div elements such as `Faculty, Testimonials` which are around `500kb` can take some time to load in worst cases.

#### How should this be manually tested?
Generate Lighthouse report, See the suggestions section `Defer off-screen resources/images`. This might need some A/B to test the differences properly.
