### PR TITLE
using module level lodash imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,14 @@
 {
   "extends": "eslint-config-mitodl",
   rules: {
-      "no-unused-vars": 0
+    "no-unused-vars": 0,
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          "lodash"
+        ]
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,10 @@
   "extends": "eslint-config-mitodl",
   rules: {
     "no-unused-vars": 0,
+    // module importing pattern have huge impact over performance, especially when it comes to lodash
+    // the below rule will restrict developers to do lodash global imports
+    // (i.e: "import { map } from 'lodash'" will be insisted to get replaced with "import map from 'lodash/map'")
+    // (refs: https://eslint.org/docs/2.0.0/rules/no-restricted-imports and https://www.blazemeter.com/blog/the-correct-way-to-import-lodash-libraries-a-benchmark)
     "no-restricted-imports": [
       "error",
       {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -13,7 +13,7 @@ import {
   trim,
   view
 } from "ramda"
-import { truncate as _truncate } from "lodash"
+import _truncate from "lodash/truncate"
 import qs from "query-string"
 import { assert } from "chai"
 import * as R from "ramda"


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2065

#### What's this PR do?
It insists on importing `lodash methods` instead of the `whole lodash` plugin to reduce package size.

It reduces `header.js` size from `954 KB`  to `888 KB` and `root.js` size from `1.71 MB` to `1.64 MB` on my local machine.