### PR TITLE
remove prop types from prod bundles

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,7 +10,8 @@ const prodBabelConfig = Object.assign({}, babelSharedLoader)
 
 prodBabelConfig.query.plugins.push(
   "@babel/plugin-transform-react-constant-elements",
-  "@babel/plugin-transform-react-inline-elements"
+  "@babel/plugin-transform-react-inline-elements",
+  "@babel/plugin-transform-react-remove-prop-types"
 )
 
 const prodConfig = Object.assign({}, config)


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2065

#### What's this PR do?
Uses babel's plugin to ignore/remove prop-types in the js bundle for production
