### PR TITLE
Allowed username update in admin with warning

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -46,12 +46,23 @@ class UserProfileInline(admin.StackedInline):
         return True
 
 
+_username_warning = """
+<div style="background-color: #dc3545; color: #fff; padding: 10px; font-size: 16px; border-radius: 5px;">
+   <strong>WARNING:</strong> 
+   Changing this username will require you to apply the same change in edX immediately after.<br /><br>
+   Do not make this change unless you can perform the same change to the edX username, or you have someone
+   else lined up to do it.
+</div>
+"""
+
+
 class UserAdmin(ContribUserAdmin, HijackUserAdminMixin, TimestampedModelAdmin):
     """Admin views for user"""
 
     include_created_on_in_list = True
     fieldsets = (
-        (None, {"fields": ("username", "password", "last_login", "created_on")}),
+        (None, {"fields": ("password", "last_login", "created_on")}),
+        (_("Username"), {"fields": ("username",), "description": _username_warning}),
         (_("Personal Info"), {"fields": ("name", "email")}),
         (
             _("Permissions"),
@@ -78,7 +89,7 @@ class UserAdmin(ContribUserAdmin, HijackUserAdminMixin, TimestampedModelAdmin):
     list_filter = ("is_staff", "is_superuser", "is_active", "groups")
     search_fields = ("username", "name", "email")
     ordering = ("email",)
-    readonly_fields = ("username", "last_login")
+    readonly_fields = ("last_login",)
     inlines = [UserLegalAddressInline, UserProfileInline]
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Enables username update in Django admin with a conspicuous warning about requiring an edX username update immediately afterward

#### How should this be manually tested?
Change the username for some user via Django admin, then change it back. No errors = good

#### Any background context you want to provide?
We've had a lot of username change requests lately and this is one step toward making it easier

#### Screenshots (if appropriate)
**BEFORE**
![ss 2021-01-29 at 14 06 19 ](https://user-images.githubusercontent.com/14932219/106316873-6ca0c480-623b-11eb-95fe-511fab9ee705.png)

**AFTER**
![ss 2021-01-29 at 14 02 09 ](https://user-images.githubusercontent.com/14932219/106316904-75919600-623b-11eb-8959-bdf278092fdd.png)
