### PR TITLE
adding logout redirection

### DIFF
--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,5 +1,4 @@
 """URL configurations for authentication"""
-from django.contrib.auth import views as auth_views
 from django.urls import path
 
 from authentication.views import (
@@ -10,6 +9,7 @@ from authentication.views import (
     RegisterDetailsView,
     RegisterExtraDetailsView,
     get_social_auth_types,
+    CustomLogoutView,
     CustomPasswordResetView,
     CustomPasswordResetConfirmView,
     CustomSetPasswordView,
@@ -47,5 +47,5 @@ urlpatterns = [
     ),
     path("api/set_password/", CustomSetPasswordView.as_view(), name="set-password-api"),
     path("api/auths/", get_social_auth_types, name="get-auth-types-api"),
-    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("logout/", CustomLogoutView.as_view(), name="logout"),
 ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/1931

#### What's this PR do?
In `xpro's logout flow`, after the user is logged out from `xpro` it redirects User to its `edx` counterpart's logout URL using `LOGOUT_REDIRECT_URL` environment variable. This PR enhances the functionality and adds a `redirect_url` to `edx's logout URL` which helps User to get back to `xpro`.

#### How should this be manually tested?
Use the following flow to see the error or can watch the video https://www.dropbox.com/s/b7c1eimwj4yowt3/JuniperLoginStuckInEdx.mov?dl=0:

* Sign in to xpro devstack
* Sign out
* Sign right back in
* Sign out

After this PR, the bug shouldn't appear again.

#### Note
This PR is dependent on https://github.com/mitodl/edx-platform/pull/238 as we have to add `xpro's URL` in `LOGIN_REDIRECT_WHITELIST`
