### PR TITLE
Show appropriate messages on Registration Confirmation link failure

### DIFF
--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -29,6 +29,8 @@ class SocialAuthState:  # pylint: disable=too-many-instance-attributes
     STATE_INACTIVE = "inactive"
     STATE_INVALID_EMAIL = "invalid-email"
     STATE_USER_BLOCKED = "user-blocked"
+    STATE_INVALID_LINK = "invalid-link"
+    STATE_EXISTING_ACCOUNT = "existing-account"
 
     def __init__(
         self,

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -517,7 +517,7 @@ class AuthStateMachine(RuleBasedStateMachine):
 
     @rule(auth_state=consumes(ConfirmationRedeemedAuthStates))
     def redeem_confirmation_code_twice_existing_user(self, auth_state):
-        """Redeeming a code twice should fail"""
+        """Redeeming a code twice with an existing user should fail with existing account state"""
         _, _, code, partial_token = self.mock_email_send.call_args[0]
         self.create_existing_user()
         assert_api_call(

--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ PyNaCl==1.3.0
 redis==3.2.1
 requests
 sentry-sdk
-social-auth-app-django==3.1.0
+social-auth-app-django==3.4.0
 ulid-py
 ua-parser==0.8.0
 user-agents==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,10 @@ chardet==3.0.4
     # via requests
 click==7.0
     # via user-util
-cryptography==3.3.2
-    # via pyopenssl
+cryptography==3.4.4
+    # via
+    #   pyopenssl
+    #   social-auth-core
 decorator==4.4.0
     # via
     #   ipython
@@ -216,7 +218,7 @@ pygments==2.4.2
     # via ipython
 pygsheets==2.0.2
     # via -r requirements.in
-pyjwt==1.7.1
+pyjwt==2.0.1
     # via social-auth-core
 pynacl==1.3.0
     # via -r requirements.in
@@ -270,7 +272,6 @@ sentry-sdk==0.10.1
     # via -r requirements.in
 six==1.12.0
     # via
-    #   cryptography
     #   django-anymail
     #   django-compat
     #   django-server-status
@@ -285,13 +286,12 @@ six==1.12.0
     #   pyopenssl
     #   python-dateutil
     #   social-auth-app-django
-    #   social-auth-core
     #   tenacity
     #   traitlets
     #   zeep
-social-auth-app-django==3.1.0
+social-auth-app-django==3.4.0
     # via -r requirements.in
-social-auth-core==3.2.0
+social-auth-core==4.0.3
     # via social-auth-app-django
 soupsieve==2.0.1
     # via beautifulsoup4

--- a/static/js/containers/pages/register/RegisterConfirmPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage.js
@@ -17,7 +17,10 @@ import { routes } from "../../../lib/urls"
 import {
   STATE_REGISTER_DETAILS,
   STATE_INVALID_EMAIL,
-  handleAuthResponse
+  handleAuthResponse,
+  INFORMATIVE_STATES,
+  STATE_INVALID_LINK,
+  STATE_EXISTING_ACCOUNT
 } from "../../../lib/auth"
 
 import { authSelector } from "../../../lib/queries/auth"
@@ -69,12 +72,8 @@ export class RegisterConfirmPage extends React.Component<Props> {
         <div className="container auth-page">
           <div className="row">
             <div className="col">
-              {auth && auth.state === STATE_INVALID_EMAIL ? (
-                <React.Fragment>
-                  <p>No confirmation code was provided or it has expired.</p>
-                  <Link to={routes.register.begin}>Click here</Link> to register
-                  again.
-                </React.Fragment>
+              {auth && INFORMATIVE_STATES.indexOf(auth.state) > -1 ? (
+                this.getAppropriateInformationFragment(auth.state)
               ) : (
                 <p>Confirming...</p>
               )}
@@ -82,6 +81,36 @@ export class RegisterConfirmPage extends React.Component<Props> {
           </div>
         </div>
       </DocumentTitle>
+    )
+  }
+
+  getAppropriateInformationFragment(state: string) {
+    let preLinkText = ""
+    let postLinkText = ""
+    let linkRoute = null
+    if (state === STATE_INVALID_LINK) {
+      preLinkText = "This invitation is invalid or has expired. Please"
+      postLinkText = "to register again."
+      linkRoute = routes.register.begin
+    } else if (state === STATE_EXISTING_ACCOUNT) {
+      preLinkText = "You already have an xPRO account. Please"
+      postLinkText = "to sign in."
+      linkRoute = routes.login.begin
+    } else if (state === STATE_INVALID_EMAIL) {
+      preLinkText = "No confirmation code was provided or it has expired."
+      postLinkText = "to register again."
+      linkRoute = routes.register.begin
+    }
+    return (
+      <React.Fragment>
+        <span className={"confirmation-message"}>
+          {preLinkText}{" "}
+          <Link class={"action-link"} to={linkRoute}>
+            Click here
+          </Link>{" "}
+          {postLinkText}
+        </span>
+      </React.Fragment>
     )
   }
 }

--- a/static/js/containers/pages/register/RegisterConfirmPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage.js
@@ -90,15 +90,15 @@ export class RegisterConfirmPage extends React.Component<Props> {
     let linkRoute = null
     if (state === STATE_INVALID_LINK) {
       preLinkText = "This invitation is invalid or has expired. Please"
-      postLinkText = "to register again."
+      postLinkText = "to register again"
       linkRoute = routes.register.begin
     } else if (state === STATE_EXISTING_ACCOUNT) {
       preLinkText = "You already have an xPRO account. Please"
-      postLinkText = "to sign in."
+      postLinkText = "to sign in"
       linkRoute = routes.login.begin
     } else if (state === STATE_INVALID_EMAIL) {
       preLinkText = "No confirmation code was provided or it has expired."
-      postLinkText = "to register again."
+      postLinkText = "to register again"
       linkRoute = routes.register.begin
     }
     return (
@@ -106,9 +106,9 @@ export class RegisterConfirmPage extends React.Component<Props> {
         <span className={"confirmation-message"}>
           {preLinkText}{" "}
           <Link class={"action-link"} to={linkRoute}>
-            Click here
-          </Link>{" "}
-          {postLinkText}
+            click here {postLinkText}
+          </Link>
+          .
         </span>
       </React.Fragment>
     )

--- a/static/js/containers/pages/register/RegisterConfirmPage_test.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage_test.js
@@ -78,8 +78,8 @@ describe("RegisterConfirmPage", () => {
     const confirmationErrorText = inner.find(".confirmation-message")
     assert.isNotNull(confirmationErrorText)
     assert.equal(
-      confirmationErrorText.text().replace("<Link /> ", ""),
-      "This invitation is invalid or has expired. Please to register again."
+      confirmationErrorText.text().replace("<Link />", ""),
+      "This invitation is invalid or has expired. Please ."
     )
   })
 
@@ -98,8 +98,8 @@ describe("RegisterConfirmPage", () => {
     const confirmationErrorText = inner.find(".confirmation-message")
     assert.isNotNull(confirmationErrorText)
     assert.equal(
-      confirmationErrorText.text().replace("<Link /> ", ""),
-      "You already have an xPRO account. Please to sign in."
+      confirmationErrorText.text().replace("<Link />", ""),
+      "You already have an xPRO account. Please ."
     )
   })
 
@@ -117,8 +117,8 @@ describe("RegisterConfirmPage", () => {
     })
     const confirmationErrorText = inner.find(".confirmation-message")
     assert.equal(
-      confirmationErrorText.text().replace("<Link /> ", ""),
-      "No confirmation code was provided or it has expired. to register again."
+      confirmationErrorText.text().replace("<Link />", ""),
+      "No confirmation code was provided or it has expired. ."
     )
   })
 })

--- a/static/js/containers/pages/register/RegisterConfirmPage_test.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage_test.js
@@ -5,7 +5,13 @@ import IntegrationTestHelper from "../../../util/integration_test_helper"
 import RegisterConfirmPage, {
   RegisterConfirmPage as InnerRegisterConfirmPage
 } from "./RegisterConfirmPage"
-import { STATE_REGISTER_DETAILS } from "../../../lib/auth"
+import {
+  STATE_REGISTER_DETAILS,
+  STATE_INVALID_LINK,
+  STATE_EXISTING_ACCOUNT,
+  STATE_INVALID_EMAIL
+} from "../../../lib/auth"
+import { routes } from "../../../lib/urls"
 
 describe("RegisterConfirmPage", () => {
   let helper, renderPage
@@ -55,5 +61,64 @@ describe("RegisterConfirmPage", () => {
     })
     assert.equal(helper.currentLocation.pathname, "/create-account/details/")
     assert.equal(helper.currentLocation.search, `?partial_token=${token}`)
+  })
+
+  it("Shows a register link with invalid/expired confirmation code", async () => {
+    helper.handleRequestStub.returns({})
+    const token = "asdf"
+    const { inner, store } = await renderPage({
+      entities: {
+        auth: {
+          state:         STATE_INVALID_LINK,
+          partial_token: token,
+          extra_data:    {}
+        }
+      }
+    })
+    const confirmationErrorText = inner.find(".confirmation-message")
+    assert.isNotNull(confirmationErrorText)
+    assert.equal(
+      confirmationErrorText.text().replace("<Link /> ", ""),
+      "This invitation is invalid or has expired. Please to register again."
+    )
+  })
+
+  it("Shows a login link with existing account message", async () => {
+    helper.handleRequestStub.returns({})
+    const token = "asdf"
+    const { inner, store } = await renderPage({
+      entities: {
+        auth: {
+          state:         STATE_EXISTING_ACCOUNT,
+          partial_token: token,
+          extra_data:    {}
+        }
+      }
+    })
+    const confirmationErrorText = inner.find(".confirmation-message")
+    assert.isNotNull(confirmationErrorText)
+    assert.equal(
+      confirmationErrorText.text().replace("<Link /> ", ""),
+      "You already have an xPRO account. Please to sign in."
+    )
+  })
+
+  it("Shows a register link with invalid or no confirmation code", async () => {
+    helper.handleRequestStub.returns({})
+    const token = "asdf"
+    const { inner, store } = await renderPage({
+      entities: {
+        auth: {
+          state:         STATE_INVALID_EMAIL,
+          partial_token: token,
+          extra_data:    {}
+        }
+      }
+    })
+    const confirmationErrorText = inner.find(".confirmation-message")
+    assert.equal(
+      confirmationErrorText.text().replace("<Link /> ", ""),
+      "No confirmation code was provided or it has expired. to register again."
+    )
   })
 })

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -17,6 +17,8 @@ export const STATE_SUCCESS = "success"
 export const STATE_INACTIVE = "inactive"
 export const STATE_INVALID_EMAIL = "invalid-email"
 export const STATE_USER_BLOCKED = "user-blocked"
+export const STATE_INVALID_LINK = "invalid-link"
+export const STATE_EXISTING_ACCOUNT = "existing-account"
 
 export const STATE_LOGIN_EMAIL = "login/email"
 export const STATE_LOGIN_PASSWORD = "login/password"
@@ -28,6 +30,12 @@ export const STATE_REGISTER_CONFIRM = "register/confirm"
 export const STATE_REGISTER_DETAILS = "register/details"
 export const STATE_REGISTER_EXTRA_DETAILS = "register/extra"
 export const STATE_REGISTER_REQUIRED = "register/required"
+
+export const INFORMATIVE_STATES = [
+  STATE_INVALID_EMAIL,
+  STATE_INVALID_LINK,
+  STATE_EXISTING_ACCOUNT
+]
 
 export const ALL_STATES = [
   STATE_ERROR,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1885 

#### What's this PR do?
It add proper messages for more user readability on validation fail. Adds two more states to support the error messages:

1. If the user already has an account/partial account created and he clicks the confirmation link again he will be shown a message to login again. (`You already have an xPRO account. Please [click here] to sign in.`)
2. If a user doesn't have an account and he clicks on the confirmation link again he shown invalid/expired link message. (`This invitation is invalid or has expired. Please [click here] to register again.`)

#### How should this be manually tested?
Testing instruction are added in the associated ticket.

#### Where should the reviewer start?
Account Registration

#### Screenshots (if appropriate)
**Screenshot when User has partial/full profile created with us -- 'Click Here' Link will take him to login page**
<img width="1440" alt="Screenshot 2021-02-11 at 12 28 15 PM" src="https://user-images.githubusercontent.com/34372316/107615155-7c71cd00-6c6d-11eb-9c20-f41fb112dca2.png">

**Screenshot when User doesn't have a profile created with us -- 'Click Here' Link will take him to register page**

<img width="1439" alt="Screenshot 2021-02-11 at 12 26 48 PM" src="https://user-images.githubusercontent.com/34372316/107615128-70860b00-6c6d-11eb-8d79-8b58182984ef.png">
