### PR TITLE
fix: filtering user on the basis of username because of non-masters courses

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -475,9 +475,9 @@ def get_edx_grades_with_users(course_run, user=None):
         all_grades = list(edx_course_grades.all_current_grades)
         for edx_grade in all_grades:
             try:
-                user = User.objects.get(email=edx_grade.email)
+                user = User.objects.get(username=edx_grade.username)
             except User.DoesNotExist:
-                log.warning("User with email %s not found", edx_grade.email)
+                log.warning("User with username %s not found", edx_grade.username)
             else:
                 yield edx_grade, user
 


### PR DESCRIPTION

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2115

#### What's this PR do?
edX's grades APIs send user-email only if the course's enrollment mode is `masters` (https://github.com/edx/edx-platform/commit/68ec2e184d1b4ed7824954e34c97bef39647ebe2)
So this PR replaces the usage of user-email to user's username for our grade processing.

#### How should this be manually tested?
We can go to xPRO's shell and run the `sync_grades_and_certificates` command for `non-masters` enrollment. If the issue is fixed then you won't see any error in syncing. 

