### PR TITLE
Added country name in compliance admin

### DIFF
--- a/compliance/admin.py
+++ b/compliance/admin.py
@@ -2,6 +2,7 @@
 Admin site bindings for compliance
 """
 
+import pycountry
 from django.conf import settings
 from django.contrib import admin
 
@@ -17,10 +18,21 @@ class ExportsInquiryLogAdmin(admin.ModelAdmin):
 
     model = ExportsInquiryLog
     search_fields = ["user__email", "computed_result", "info_code", "reason_code"]
-    list_filter = ["computed_result", "info_code", "reason_code"]
-    list_display = ["user", "computed_result", "info_code", "reason_code"]
+    list_filter = [
+        "computed_result",
+        "info_code",
+        "reason_code",
+        "user__legal_address__country",
+    ]
+    list_display = ["user", "computed_result", "info_code", "reason_code", "country"]
+    list_select_related = ["user__legal_address"]
     readonly_fields = [] if settings.DEBUG else get_field_names(ExportsInquiryLog)
     actions = ["manually_approve_inquiry"]
+
+    def country(self, instance):
+        """Get country name from ISO Alpha-2 country code"""
+        country = pycountry.countries.get(alpha_2=instance.user.legal_address.country)
+        return country.name if country else "N/A"
 
     def manually_approve_inquiry(self, request, queryset):
         """Admin action to manually approve export compliance inquiry records"""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2130 

#### What's this PR do?
Adds country name in Admin display of `ExportsInquiryLogAdmin`.

#### How should this be manually tested?
Have a look at the `ExportsInquiryLogAdmin` page and verify that you can see the user's country for each record, Additionally, you should also be able to filter data on the basis of the country.

#### Where should the reviewer start?
Django admin

#### Any background context you want to provide?
The associated ticket has the details as to why we need to add this value in the admin.

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-02-23 at 3 29 50 PM" src="https://user-images.githubusercontent.com/34372316/108831508-0b76d180-75ec-11eb-984a-4a221f817349.png">

