### PR TITLE
fix course order in carousel w.r.t position_in_program

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -748,8 +748,10 @@ class ProgramPage(ProductPage):
         Gets a list of pages (CoursePage) of all the courses associated with this program
         """
         courses = self.program.courses.all()
-        return CoursePage.objects.filter(course_id__in=courses).select_related(
-            "course", "thumbnail_image"
+        return (
+            CoursePage.objects.filter(course_id__in=courses)
+            .select_related("course", "thumbnail_image")
+            .order_by("course__position_in_program")
         )
 
     @property
@@ -839,7 +841,11 @@ class CoursePage(ProductPage):
         Gets a list of pages (CoursePage) of all the courses from the associated program
         """
         return (
-            CoursePage.objects.filter(course__program=self.course.program)
+            (
+                CoursePage.objects.filter(course__program=self.course.program)
+                .select_related("course", "thumbnail_image")
+                .order_by("course__position_in_program")
+            )
             if self.course.program
             else []
         )

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1237,3 +1237,24 @@ def test_certificate_for_program_page():
         assert signatory.value.title_2 == "Title_2"
         assert signatory.value.organization == "Organization"
         assert signatory.value.signature_image.title == "Image"
+
+
+def test_program_course_order():
+    """
+    The course pages in program page should be ordered on the basis of position_in_program
+    """
+    program_page = ProgramPageFactory.create()
+    course_pages = CoursePageFactory.create_batch(
+        3,
+        course__position_in_program=factory.Iterator([2, 3, 1]),
+        course__program=program_page.program,
+    )
+    single_course_page = course_pages[0]
+    assert [
+        course_page.course.position_in_program
+        for course_page in single_course_page.course_pages
+    ] == [1, 2, 3]
+    assert [
+        course_page.course.position_in_program
+        for course_page in program_page.course_pages
+    ] == [1, 2, 3]


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2133

#### What's this PR do?
Fixes `Course order in carousel` under Program-page w.r.t `position_in_program` variable present in course model.

#### How should this be manually tested?
Create a `Program` and its `ProgramPage`.
Create `Courses` and their `CoursePage`s under that Program.
Change the order of Courses by changing `position_in_program` through Admin Panel.
Now go to the live version of ProgramPage, you will notice that the course carousel has reordered according to `position_in_program` variable
