### PR TITLE
Fixed wagtail admin pages list ordering

### DIFF
--- a/cms/factories.py
+++ b/cms/factories.py
@@ -401,6 +401,24 @@ class HomePageFactory(wagtail_factories.PageFactory):
         model = HomePage
 
 
+class CourseIndexPageFactory(wagtail_factories.PageFactory):
+    """CourseIndexPage factory class"""
+
+    title = factory.fuzzy.FuzzyText(prefix="Course Index ")
+
+    class Meta:
+        model = CourseIndexPage
+
+
+class ProgramIndexPageFactory(wagtail_factories.PageFactory):
+    """ProgramIndexPage factory class"""
+
+    title = factory.fuzzy.FuzzyText(prefix="Program Index ")
+
+    class Meta:
+        model = ProgramIndexPage
+
+
 class SignatoryPageFactory(wagtail_factories.PageFactory):
     """SignatoryPage factory class"""
 

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -1,6 +1,5 @@
 """Custom hooks to configure wagtail behavior"""
-from wagtail.api.v2.router import WagtailAPIRouter
-from wagtail.api.v2.views import PagesAPIViewSet
+from wagtail.admin.api.views import PagesAdminAPIViewSet
 from wagtail.core import hooks
 
 
@@ -12,7 +11,7 @@ def sort_pages_alphabetically(
     return pages.order_by("title")
 
 
-class OrderedPagesAPIEndpoint(PagesAPIViewSet):
+class OrderedPagesAPIEndpoint(PagesAdminAPIViewSet):
     """A clone of the default Wagtail admin API that additionally orders all responses by page title alphabetically"""
 
     def filter_queryset(self, queryset):
@@ -21,8 +20,6 @@ class OrderedPagesAPIEndpoint(PagesAPIViewSet):
 
 
 @hooks.register("construct_admin_api")
-def configure_admin_api_default_order(api_router):
+def configure_admin_api_default_order(router):
     """Swap admin pages API for our own flavor that orders results by title"""
-    api_router = WagtailAPIRouter("wagtailapi")
-    api_router.register_endpoint("pages", OrderedPagesAPIEndpoint)
-    return api_router
+    router.register_endpoint("pages", OrderedPagesAPIEndpoint)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2134 

#### What's this PR do?
- Fixes the wagtail hook for sorting items on CMS

#### How should this be manually tested?
Add different cms pages and then open the pages tab from the CMS side menu, the list of items in this should be alphabetically sorted.

#### Where should the reviewer start?
- CMS

#### Any background context you want to provide?
We did some upgrades to the wagtail recently and during that process, our hooks for wagtail broke. Which indeed broke the sorting of the pages on Wagtail Admin's side menu.

#### Screenshots (if appropriate)
**(HomePage)**

<img width="686" alt="Screenshot 2021-03-01 at 5 26 17 PM" src="https://user-images.githubusercontent.com/34372316/109497324-b5a29d80-7ab3-11eb-8a06-55db13ecd785.png">

**(Courses Sub Pages)**

<img width="684" alt="Screenshot 2021-03-01 at 5 27 59 PM" src="https://user-images.githubusercontent.com/34372316/109497334-b9cebb00-7ab3-11eb-8bdf-0795a9d5ef85.png">


