### PR TITLE
HotFix: PayPal Information Rendering

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -889,9 +889,7 @@ class OrderReceiptSerializer(serializers.ModelSerializer):
     def get_receipt(self, instance):
         """Get receipt information if it exists"""
         receipt = instance.receipt_set.order_by("-created_on").first()
-        if receipt and (
-            "req_card_number" in receipt.data or "req_card_type" in receipt.data
-        ):
+        if receipt:
             data = {
                 "card_number": None,
                 "card_type": None,

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -196,26 +196,28 @@ export class ReceiptPage extends React.Component<Props> {
                       </dd>
                     </dl>
                   </div>
+                  <h3>Payment Information</h3>
                   {orderReceipt.receipt ? (
                     <div className="receipt-col">
-                      <h3>Payment Information</h3>
-                      <dl>
-                        <dt>Name:</dt>
-                        <dd>{orderReceipt.receipt.name}</dd>
-                      </dl>
                       {orderReceipt.receipt &&
                       orderReceipt.receipt.payment_method === "card" ? (
-                          <dl>
-                            <dt>Payment Method:</dt>
-                            <dd id="paymentMethod">
-                              {orderReceipt.receipt.card_type
-                                ? `${orderReceipt.receipt.card_type} | `
-                                : null}
-                              {orderReceipt.receipt.card_number
-                                ? orderReceipt.receipt.card_number
-                                : null}
-                            </dd>
-                          </dl>
+                          <div>
+                            <dl>
+                              <dt>Name:</dt>
+                              <dd>{orderReceipt.receipt.name}</dd>
+                            </dl>
+                            <dl>
+                              <dt>Payment Method:</dt>
+                              <dd id="paymentMethod">
+                                {orderReceipt.receipt.card_type
+                                  ? `${orderReceipt.receipt.card_type} | `
+                                  : null}
+                                {orderReceipt.receipt.card_number
+                                  ? orderReceipt.receipt.card_number
+                                  : null}
+                              </dd>
+                            </dl>
+                          </div>
                         ) : orderReceipt.receipt.payment_method === "paypal" ? (
                           <div>
                             <dl>
@@ -232,12 +234,14 @@ export class ReceiptPage extends React.Component<Props> {
                             </dl>
                           </div>
                         ) : null}
-                      {orderReceipt.coupon ? (
-                        <dl>
-                          <dt>Discount Code:</dt>
-                          <dd id="discountCode">{orderReceipt.coupon}</dd>
-                        </dl>
-                      ) : null}
+                    </div>
+                  ) : null}
+                  {orderReceipt.coupon ? (
+                    <div className="receipt-col">
+                      <dl>
+                        <dt>Discount Code:</dt>
+                        <dd id="discountCode">{orderReceipt.coupon}</dd>
+                      </dl>
                     </div>
                   ) : null}
                 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #2139

![screenshot-localhost_8053-2021 03 02-16_21_56](https://user-images.githubusercontent.com/7334669/109641418-805d8480-7b73-11eb-865f-3c80f91b7d2e.png)


`card_type` and `card_number` are not the part of PayPal checkout. 