### PR TITLE
Remove pytest-pylint

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov . --pylint --cov-report term --cov-report html --cov-report xml --ds=mitxpro.settings --reuse-db
+addopts = --cov . --cov-report term --cov-report html --cov-report xml --ds=mitxpro.settings --reuse-db
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
 filterwarnings =
     error

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -19,7 +19,6 @@ pytest-cov>=2.6.1
 pytest-django
 pytest-env
 pytest-mock
-pytest-pylint==0.14.1
 pytest-lazy-fixture==0.5.1
 responses
 safety


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
`pylint` is now being run separately from pytest so we don't need `pytest-pylint` anymore

#### How should this be manually tested?
Tests should pass