### PR TITLE
Showing receipt Link in case of individual courses run purchases of a program

### DIFF
--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -238,15 +238,6 @@ export class DashboardPage extends React.Component<Props, State> {
               </div>
               <div className="date-summary-text col-12">{dateSummary.text}</div>
             </div>
-            {courseRunEnrollment.receipt ? (
-              <div className="row mt-2">
-                <div className="col">
-                  <Link to={`/receipt/${courseRunEnrollment.receipt}`}>
-                    View Receipt
-                  </Link>
-                </div>
-              </div>
-            ) : null}
             <div className="row mt-2">
               <div className="archived-course-link col-lg-7 col-md-8">
                 {dateSummary.archived &&
@@ -261,7 +252,7 @@ export class DashboardPage extends React.Component<Props, State> {
                   ) : null}
               </div>
               <div className="d-sm-flex justify-content-sm-between col-12 mt-3 mb-2">
-                {courseRunEnrollment.receipt && !isProgramCourse ? (
+                {courseRunEnrollment.receipt ? (
                   <div className="view-receipt">
                     <Link to={`/receipt/${courseRunEnrollment.receipt}`}>
                       View Receipt

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -238,6 +238,15 @@ export class DashboardPage extends React.Component<Props, State> {
               </div>
               <div className="date-summary-text col-12">{dateSummary.text}</div>
             </div>
+            {courseRunEnrollment.receipt ? (
+              <div className="row mt-2">
+                <div className="col">
+                  <Link to={`/receipt/${courseRunEnrollment.receipt}`}>
+                    View Receipt
+                  </Link>
+                </div>
+              </div>
+            ) : null}
             <div className="row mt-2">
               <div className="archived-course-link col-lg-7 col-md-8">
                 {dateSummary.archived &&


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #2162

#### What's this PR do?
Showing receipt Link in case of individual courses run purchases of a program over the dashboard.

#### How should this be manually tested?
Three Scenario: 
1-  The case where the learner purchases the entire program. (Receipt link be appeared on program and for individual courses)

![Screen Shot 2021-04-02 at 2 01 55 PM](https://user-images.githubusercontent.com/7334669/113402210-17f60300-93be-11eb-89f5-a25f34e181bf.jpg)

2- The case where the learner hasn't enrolled in all courses in the program yet. (Receipt Link should appear on individual courses over the dashboard)

<img width="1187" alt="Screen Shot 2021-04-01 at 2 58 14 PM" src="https://user-images.githubusercontent.com/7334669/113277920-b1f47780-92fa-11eb-826e-a2410278c0b6.png">


3- The case where the learner purchased the courses individually and was enrolled in the program when they were awarded the certificates. ((Receipt Link should appear on individual courses over the dashboard for all course runs order) 

![Screen Shot 2021-04-01 at 3 25 01 PM](https://user-images.githubusercontent.com/7334669/113402224-1d534d80-93be-11eb-8e28-a776360143bb.jpg)




