### PR TITLE
Performance Optimization: Defer youtube iframe's script loading

### DIFF
--- a/cms/embeds.py
+++ b/cms/embeds.py
@@ -32,9 +32,9 @@ class YouTubeEmbedFinder(OEmbedFinder):
 
     def find_embed(self, url, max_width=None):
         embed = super().find_embed(url, max_width)
-
         embed_tag = BeautifulSoup(embed["html"], "html.parser")
-        iframe_url = embed_tag.find("iframe").attrs["src"]
+        player_iframe = embed_tag.find("iframe")
+        iframe_url = player_iframe.attrs["src"]
         scheme, netloc, path, params, query, fragment = urlparse(iframe_url)
 
         querydict = parse_qs(query)
@@ -43,7 +43,9 @@ class YouTubeEmbedFinder(OEmbedFinder):
 
         query = urlencode(querydict, doseq=1)
         iframe_url = urlunparse((scheme, netloc, path, params, query, fragment))
-        embed_tag.find("iframe").attrs["src"] = iframe_url
+        player_iframe.attrs["loading"] = "lazy"
+        player_iframe.attrs["src"] = ""
+        player_iframe.attrs["data-src"] = iframe_url
         embed["html"] = str(embed_tag)
 
         return embed

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -59,6 +59,20 @@
     {% endblock %}
     {% render_bundle 'django' added_attrs='defer' %}
     {% block scripts %}
+      {# Script to defer youtube video rendering #}
+      <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', function () {
+          const iframes = Array.from(document.getElementsByTagName('iframe'));
+            iframes.forEach(function (iframe) {
+              const data_src = iframe.getAttribute('data-src')
+                /* Making sure that we only change attributes of those iframes that have youtube embed as a source url.
+                By replacing the src with data-src we let the iframe run the youtube scripts and load the video.*/
+              if (data_src && data_src.indexOf("youtube.com/embed") !== -1) {
+                iframe.setAttribute('src', data_src);
+              }
+          });
+        });
+        </script>
     {% endblock %}
     {% if zendesk_config.help_widget_enabled and not request.path|startswith:'/certificate/' %}
     <script type="text/javascript">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2154

#### What's this PR do?
- Adds a script to defer youtube video iframes to run scripts until the `DOMContentLoaded` event.

#### How should this be manually tested?
- Add a youtube video URL in a Course or Program page in CMS and visit that page in the app. Now visit any of the program or course pages and verify that the youtube script was loaded after that page load.
- Add a `Text-Video` section in CMS in HomePage. Visit the home page and verify the script deferring as I the above point.
- In the above process it would be good to notice google's `LightHouse` stats and some improvement in the performance result.

#### Any background context you want to provide?
We tried to improve the performance of xPRO and for that, we opted and discussed many solutions that can be found on https://github.com/mitodl/mitxpro/issues/2065. In this PR, we added one more step towards improvement and loading the youtube videos after the page is loaded. We expect that this will put some impact on performance optimization.

