### PR TITLE
Digital credentials for configuration based specified runs

### DIFF
--- a/app.json
+++ b/app.json
@@ -151,6 +151,10 @@
       "description": "Verification method for digital credentials",
       "required": false
     },
+    "DIGITAL_CREDENTIALS_SUPPORTED_RUNS": {
+      "description": "Comma separated string of course/program runs/Ids that support digital credentials",
+      "required": false
+    },
     "DJANGO_LOG_LEVEL": {
       "description": "The log level for django",
       "required": false

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1430,3 +1430,11 @@ DIGITAL_CREDENTIALS_VERIFICATION_METHOD = get_string(
     default=None,
     description="Verification method for digital credentials",
 )
+# pylint:disable=fixme
+# FIXME: This setting is meant to be temporary and it should be removed once we decide to support digital credentials
+#  for all courses/programs.
+DIGITAL_CREDENTIALS_SUPPORTED_RUNS = get_delimited_list(
+    name="DIGITAL_CREDENTIALS_SUPPORTED_RUNS",
+    default=[],
+    description="Comma separated string of course/program runs/Ids that support digital credentials",
+)

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -592,4 +592,5 @@ def get_js_settings(request: HttpRequest):
             "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),
         },
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
+        "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
     }

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -464,6 +464,7 @@ def test_get_js_settings(settings, rf):
         "HELP_WIDGET_KEY": "fake_key",
     }
     settings.FEATURES["DIGITAL_CREDENTIALS"] = True
+    settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
 
     request = rf.get("/")
 
@@ -479,4 +480,5 @@ def test_get_js_settings(settings, rf):
         "site_name": settings.SITE_NAME,
         "zendesk_config": {"help_widget_enabled": False, "help_widget_key": "fake_key"},
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
+        "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
     }

--- a/static/js/containers/pages/DashboardPage.js
+++ b/static/js/containers/pages/DashboardPage.js
@@ -269,23 +269,26 @@ export class DashboardPage extends React.Component<Props, State> {
                     >
                       View Certificate
                     </a>
-                    {SETTINGS.digital_credentials ? (
-                      <div className="digital-credential-link">
-                        <a
-                          data-toggle="modal"
-                          href={`#${courseDialogIdentifier}`}
-                          className="read-more"
-                        >
-                          {" "}
+                    {this.isDigitalCredentialSupported(
+                      courseRunEnrollment.run.courseware_id
+                    ) ? (
+                        <div className="digital-credential-link">
+                          <a
+                            data-toggle="modal"
+                            href={`#${courseDialogIdentifier}`}
+                            className="read-more"
+                          >
+                            {" "}
                           Digital Credential
-                        </a>
-                        {this.renderDigitalCredentialDialog(
-                          courseRunEnrollment.certificate.uuid,
-                          courseDialogIdentifier,
-                          true
-                        )}
-                      </div>
-                    ) : null}
+                          </a>
+                          {this.renderDigitalCredentialDialog(
+                          // $FlowFixMe: Flow thinks certificate can be null or undefined but it can't be
+                            courseRunEnrollment.certificate.uuid,
+                            courseDialogIdentifier,
+                            true
+                          )}
+                        </div>
+                      ) : null}
                   </div>
                 ) : null}
               </div>
@@ -411,23 +414,26 @@ export class DashboardPage extends React.Component<Props, State> {
                   >
                     View Certificate
                   </a>
-                  {SETTINGS.digital_credentials ? (
-                    <div className="digital-credential-link">
-                      <a
-                        data-toggle="modal"
-                        href={`#${programDialogIdentifier}`}
-                        className="read-more"
-                      >
-                        {" "}
+                  {this.isDigitalCredentialSupported(
+                    programEnrollment.program.readable_id
+                  ) ? (
+                      <div className="digital-credential-link">
+                        <a
+                          data-toggle="modal"
+                          href={`#${programDialogIdentifier}`}
+                          className="read-more"
+                        >
+                          {" "}
                         Digital Credential
-                      </a>
-                      {this.renderDigitalCredentialDialog(
-                        programEnrollment.certificate.uuid,
-                        programDialogIdentifier,
-                        false
-                      )}
-                    </div>
-                  ) : null}
+                        </a>
+                        {this.renderDigitalCredentialDialog(
+                        // $FlowFixMe: Flow thinks certificate can be null or undefined but it can't be
+                          programEnrollment.certificate.uuid,
+                          programDialogIdentifier,
+                          false
+                        )}
+                      </div>
+                    ) : null}
                 </div>
               ) : null}
             </div>
@@ -477,6 +483,17 @@ export class DashboardPage extends React.Component<Props, State> {
       return "To retrieve your credential, install the CredWallet app and then click Download Digital Credential.\n"
     }
     return "To retrieve your credential, please open the xPRO dashboard on an iOS or Android device and follow the instructions.\n"
+  }
+
+  isDigitalCredentialSupported = (runId: string): boolean => {
+    // Returns true if digital credentials feature is on and the passed run id exists in supported list of runs
+    {
+      /*FIXME: Check for digital credentials supported runs is meant to be temporary, It needs to be removed once we decide to support digital credentials for all courses/programs.*/
+    }
+    return (
+      SETTINGS.digital_credentials &&
+      SETTINGS.digital_credentials_supported_runs.includes(runId)
+    )
   }
 
   renderDigitalCredentialDialog = (

--- a/static/js/containers/pages/DashboardPage_test.js
+++ b/static/js/containers/pages/DashboardPage_test.js
@@ -450,13 +450,18 @@ describe("DashboardPage", () => {
 
     it("shows a digital credential link", async () => {
       SETTINGS.digital_credentials = true
+      const programEnrollments = userEnrollments.program_enrollments
+      const courseRunEnrollments = userEnrollments.program_enrollments[0].course_run_enrollments.concat(
+        userEnrollments.past_program_enrollments[0].course_run_enrollments
+      )
+      SETTINGS.digital_credentials_supported_runs = [
+        programEnrollments[0].program.readable_id
+      ]
       const { inner } = await renderPage({
         entities: {
           enrollments: {
-            program_enrollments:    userEnrollments.program_enrollments,
-            course_run_enrollments: userEnrollments.program_enrollments[0].course_run_enrollments.concat(
-              userEnrollments.past_program_enrollments[0].course_run_enrollments
-            )
+            program_enrollments:    programEnrollments,
+            course_run_enrollments: courseRunEnrollments
           },
           currentUser: {
             is_authenticated: false

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -16,7 +16,8 @@ declare type Settings = {
     help_widget_enabled: boolean,
     help_widget_key: ?string
   },
-  digital_credentials: boolean
+  digital_credentials: boolean,
+  digital_credentials_supported_runs: Array<string>
 }
 declare var SETTINGS: Settings
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2181

#### What's this PR do?
Adds a configuration-based list of courses and programs run Ids that would support digital credentials if the feature is turned on.

#### How should this be manually tested?
- Create course/program certificate(s)
- Enable `FEATURE_DIGITAL_CREDENTIALS` feature flag
- Setup newly added configuration key `DIGITAL_CREDENTIALS_SUPPORTED_RUNS`, the value of this key should contain a comma-separated list of run Ids that we want to support digital credentials.
- Visit the dashboard and notice that the `Digital Credential` link is only available for courses/programs for whom we have added run Ids in `DIGITAL_CREDENTIALS_SUPPORTED_RUNS`.

#### Any background context you want to provide?
We recently added changes for Digital Credentials on the dashboard, You can visit https://github.com/mitodl/mitxpro/pull/2168 and https://github.com/mitodl/mitxpro/pull/2171 if you'd like to have prior context.

#### Screenshots (if appropriate)
<img width="1235" alt="Screenshot 2021-04-07 at 5 38 04 PM" src="https://user-images.githubusercontent.com/34372316/113868068-b7553480-97c8-11eb-92b4-0e892088f407.png">
<img width="1299" alt="Screenshot 2021-04-07 at 5 41 07 PM" src="https://user-images.githubusercontent.com/34372316/113868094-bcb27f00-97c8-11eb-81a0-c412e593e1ac.png">
