### PR TITLE
Blocklist: Check for blocked emails when registering users

### DIFF
--- a/authentication/exceptions.py
+++ b/authentication/exceptions.py
@@ -55,7 +55,7 @@ class EmailBlockedException(PartialException):
     """Raised if a user's email is marked blocked"""
 
     def __str__(self):
-        return "Email is marked blocked"
+        return "Email address is marked blocked"
 
 
 class RequirePasswordAndPersonalInfoException(PartialException):

--- a/authentication/exceptions.py
+++ b/authentication/exceptions.py
@@ -51,6 +51,13 @@ class RequirePasswordException(PartialException):
         return "Password is required to login"
 
 
+class EmailBlockedException(PartialException):
+    """Raised if a user's email is marked blocked"""
+
+    def __str__(self):
+        return "Email is marked blocked"
+
+
 class RequirePasswordAndPersonalInfoException(PartialException):
     """Authentication requires a password and address"""
 

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -186,6 +186,7 @@ def validate_email(
             raise EmailBlockedException(backend, current_partial)
     return {}
 
+
 @partial
 def validate_password(
     strategy, backend, user=None, flow=None, current_partial=None, *args, **kwargs

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -19,7 +19,7 @@ from authentication.exceptions import (
     UserCreationFailedException,
     EmailBlockedException,
 )
-from authentication.utils import SocialAuthState, user_email_blocked
+from authentication.utils import SocialAuthState, is_user_email_blocked
 from authentication.api import create_user_with_generated_username
 
 from compliance import api as compliance_api
@@ -182,7 +182,7 @@ def validate_email(
     """
     data = strategy.request_data()
     if flow == SocialAuthState.FLOW_REGISTER and "email" in data:
-        if user_email_blocked(data["email"]):
+        if is_user_email_blocked(data["email"]):
             raise EmailBlockedException(backend, current_partial)
     return {}
 

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -615,7 +615,7 @@ def test_create_user_when_email_blocked(mocker):
     mock_strategy = mocker.Mock()
     mock_email_backend = mocker.Mock()
     mock_strategy.request_data.return_value = {"email": "test@example.com"}
-    mocker.patch("authentication.pipeline.user.user_email_blocked", return_value=True)
+    mocker.patch("authentication.pipeline.user.is_user_email_blocked", return_value=True)
     with pytest.raises(EmailBlockedException):
         user_actions.validate_email(
             mock_strategy,

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -615,7 +615,9 @@ def test_create_user_when_email_blocked(mocker):
     mock_strategy = mocker.Mock()
     mock_email_backend = mocker.Mock()
     mock_strategy.request_data.return_value = {"email": "test@example.com"}
-    mocker.patch("authentication.pipeline.user.is_user_email_blocked", return_value=True)
+    mocker.patch(
+        "authentication.pipeline.user.is_user_email_blocked", return_value=True
+    )
     with pytest.raises(EmailBlockedException):
         user_actions.validate_email(
             mock_strategy,

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -17,11 +17,12 @@ from authentication.exceptions import (
     UnexpectedExistingUserException,
     RequireProfileException,
     UserCreationFailedException,
-    EmailBlockedException
+    EmailBlockedException,
 )
 from authentication.utils import SocialAuthState
 from compliance.constants import RESULT_SUCCESS, RESULT_DENIED, RESULT_UNKNOWN
 from compliance.factories import ExportsInquiryLogFactory
+
 
 @pytest.fixture
 def backend_settings(settings):
@@ -224,6 +225,7 @@ def test_user_password_not_exists(rf):
             user=None,
             flow=SocialAuthState.FLOW_LOGIN,
         )
+
 
 @pytest.mark.parametrize(
     "backend_name,flow",
@@ -583,11 +585,12 @@ def test_create_courseware_user(
         mock_create_user_api.assert_not_called()
         mock_create_user_task.apply_async.assert_not_called()
 
+
 @pytest.mark.parametrize(
     "backend_name,flow,data",
     [
         ("notemail", SocialAuthState.FLOW_REGISTER, {}),
-        ("notemail", SocialAuthState.FLOW_LOGIN, dict(email='test@example.com')),
+        ("notemail", SocialAuthState.FLOW_LOGIN, dict(email="test@example.com")),
     ],
 )
 def test_validate_email_backend(mocker, backend_name, flow, data):
@@ -605,13 +608,14 @@ def test_validate_email_backend(mocker, backend_name, flow, data):
 
     mock_strategy.request_data.assert_called_once()
 
+
 @pytest.mark.django_db
 def test_create_user_when_email_blocked(mocker):
-    """Tests that validate_email raises an error if user email is blocked""" 
+    """Tests that validate_email raises an error if user email is blocked"""
     mock_strategy = mocker.Mock()
     mock_email_backend = mocker.Mock()
-    mock_strategy.request_data.return_value = {'email': 'test@example.com'}
-    mocker.patch('authentication.pipeline.user.user_email_blocked', return_value=True)
+    mock_strategy.request_data.return_value = {"email": "test@example.com"}
+    mocker.patch("authentication.pipeline.user.user_email_blocked", return_value=True)
     with pytest.raises(EmailBlockedException):
         user_actions.validate_email(
             mock_strategy,

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -23,6 +23,7 @@ from authentication.exceptions import (
     RequireProfileException,
     UserExportBlockedException,
     UserTryAgainLaterException,
+    EmailBlockedException,
 )
 from authentication.utils import SocialAuthState
 
@@ -286,6 +287,12 @@ class RegisterEmailSerializer(SocialAuthSerializer):
         except RequirePasswordException as exc:
             result = SocialAuthState(
                 SocialAuthState.STATE_LOGIN_PASSWORD,
+                partial=exc.partial,
+                errors=[str(exc)],
+            )
+        except EmailBlockedException as exc:
+            result = SocialAuthState(
+                SocialAuthState.STATE_REGISTER_EMAIL,
                 partial=exc.partial,
                 errors=[str(exc)],
             )

--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -67,7 +67,7 @@ def load_drf_strategy(request=None):
     )
 
 
-def user_email_blocked(email):
+def is_user_email_blocked(email):
     """Returns the user's email blocked status"""
     hash_object = hashlib.md5(email.lower().encode("utf-8"))
     return BlockList.objects.filter(hashed_email=hash_object.hexdigest()).exists()

--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -1,6 +1,8 @@
 """Authentication utils"""
+import hashlib
 from social_core.utils import get_strategy
 from social_django.utils import STORAGE
+from users.models import BlockList
 
 
 class SocialAuthState:  # pylint: disable=too-many-instance-attributes
@@ -63,3 +65,9 @@ def load_drf_strategy(request=None):
     return get_strategy(
         "authentication.strategy.DjangoRestFrameworkStrategy", STORAGE, request
     )
+
+
+def user_email_blocked(email):
+    """Returns the user's email blocked status"""
+    hash_object = hashlib.md5(email.lower().encode("utf-8"))
+    return BlockList.objects.filter(hashed_email=hash_object.hexdigest()).exists()

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -392,6 +392,8 @@ SOCIAL_AUTH_PIPELINE = (
     # validate an incoming email auth request
     "authentication.pipeline.user.validate_email_auth_request",
     # require a password and profile if they're not set
+    "authentication.pipeline.user.validate_email",
+    # require a password and profile if they're not set
     "authentication.pipeline.user.validate_password",
     # Send a validation email to the user to verify its email address.
     # Disabled by default.

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -391,7 +391,7 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.associate_by_email",
     # validate an incoming email auth request
     "authentication.pipeline.user.validate_email_auth_request",
-    # require a password and profile if they're not set
+    # validate the user's email either it is blocked or not.
     "authentication.pipeline.user.validate_email",
     # require a password and profile if they're not set
     "authentication.pipeline.user.validate_password",

--- a/static/js/containers/pages/register/RegisterEmailPage.js
+++ b/static/js/containers/pages/register/RegisterEmailPage.js
@@ -10,11 +10,13 @@ import { mutateAsync } from "redux-query"
 import { createStructuredSelector } from "reselect"
 
 import { addUserNotification } from "../../../actions"
+
 import queries from "../../../lib/queries"
 import {
   STATE_ERROR,
   STATE_REGISTER_CONFIRM_SENT,
   STATE_LOGIN_PASSWORD,
+  STATE_REGISTER_EMAIL,
   handleAuthResponse
 } from "../../../lib/auth"
 import { qsNextSelector } from "../../../lib/selectors"
@@ -66,6 +68,29 @@ export class RegisterEmailPage extends React.Component<Props> {
           history.push(`${routes.register.confirmSent}?${params}`)
         },
 
+        [STATE_REGISTER_EMAIL]: () => {
+          addUserNotification({
+            "account-blocked": {
+              type:  ALERT_TYPE_TEXT,
+              color: "danger",
+              props: {
+                text: [
+                  <div key="1">
+                    Please contact{" "}
+                    <a
+                      style={{ color: "white" }}
+                      href={"https://xpro.zendesk.com/hc/en-us/requests/new"}
+                    >
+                      {" "}
+                      customer support
+                    </a>{" "}
+                    to complete your registration.
+                  </div>
+                ]
+              }
+            }
+          })
+        },
         [STATE_LOGIN_PASSWORD]: () => {
           addUserNotification({
             "account-exists": {

--- a/static/js/containers/pages/register/RegisterEmailPage_test.js
+++ b/static/js/containers/pages/register/RegisterEmailPage_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
-import React from 'react'
+import React from "react"
 
 import RegisterEmailPage, {
   RegisterEmailPage as InnerRegisterEmailPage


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #2226 

#### What's this PR do?
As an xPRO administrator, I want the ability to add a user to a blocklist that will prevent that user from registering. The user will need to speak to customer service to complete their registration.

#### How should this be manually tested?
- Blocked a user email first running the `retire_users` management command
   - `./manage.py retire_users --user=foo@email.com --block`
- Visit the xPro create account page for registration process.
- Enter the blocked email in the text field.
- It show a message to user `Please contact customer support to complete your registration.`

#### Screenshots (if appropriate)
<img width="1436" alt="Screen Shot 2021-06-03 at 4 53 33 PM" src="https://user-images.githubusercontent.com/7334669/120640725-4068af00-c48c-11eb-85a4-30bf431352e4.png">
