### PR TITLE
fix: don't fail CI on coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true
 
   javascript-tests:
     runs-on: ubuntu-latest
@@ -182,4 +181,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: coverage/lcov.info
-          fail_ci_if_error: true


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Updates github action ci.yml to allow codecov to fail softly.

#### How should this be manually tested?
Github actions should succeed, especially if the codecov upload fails.