### PR TITLE
fix: validation for duplicate contract_number in order creation

### DIFF
--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -60,7 +60,17 @@ class B2BCheckoutView(APIView):
         try:
             num_seats = int(num_seats)
         except ValueError:
-            raise ValidationError("num_seats must be a number")
+            raise ValidationError({"num_seats": "num_seats must be a number"})
+
+        if (
+            contract_number
+            and B2BOrder.objects.filter(
+                contract_number__iexact=contract_number, status=B2BOrder.FULFILLED
+            ).exists()
+        ):
+            raise ValidationError(
+                {"contract_number": "This contract number has already been used"}
+            )
 
         with transaction.atomic():
             product_version = get_object_or_404(ProductVersion, id=product_version_id)

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -192,6 +192,10 @@ class B2BPurchaseForm extends React.Component<Props> {
                   readOnly={true}
                   value={contractNumber}
                 />
+                <ErrorMessage
+                  name="contract_number"
+                  render={errorMessageRenderer}
+                />
               </label>
             )}
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2258 

#### What's this PR do?
- Stops order creation is a duplicate reference number is provided
- Adds an error message about the duplicate reference number

#### How should this be manually tested?
Testing steps can be seen on the issue description itself

#### Where should the reviewer start?
- B2b bulk orders with reference number `ecommerce/bulk/?contract_number=<contract_number>`

#### Screenshots (if appropriate)

**The error that shows when we try to create an order with a reference number that has already been associated with a _Fulfilled Order_**
<img width="1228" alt="Screenshot 2021-06-16 at 5 15 27 PM" src="https://user-images.githubusercontent.com/34372316/122217018-72373800-cec6-11eb-852e-289cd2a0c057.png">
