### PR TITLE
asadiqbal08/Update block_users on email address that wasn't already registered.

### DIFF
--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -67,14 +67,14 @@ def load_drf_strategy(request=None):
     )
 
 
-def get_hash_object(value):
-    """Returns the hash object for the given value"""
+def get_md5_hash(value):
+    """Returns the md5 hash object for the given value"""
     return hashlib.md5(value.lower().encode("utf-8"))
 
 
 def is_user_email_blocked(email):
     """Returns the user's email blocked status"""
-    hash_object = get_hash_object(email)
+    hash_object = get_md5_hash(email)
     return BlockList.objects.filter(hashed_email=hash_object.hexdigest()).exists()
 
 
@@ -82,7 +82,7 @@ def block_user_email(email):
     """Blocks the user's email if provided"""
     msg = None
     if email:
-        hash_object = get_hash_object(email)
+        hash_object = get_md5_hash(email)
         _, created = BlockList.objects.get_or_create(
             hashed_email=hash_object.hexdigest()
         )

--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -67,9 +67,14 @@ def load_drf_strategy(request=None):
     )
 
 
+def get_hash_object(value):
+    """Returns the hash object for the given value"""
+    return hashlib.md5(value.lower().encode("utf-8"))
+
+
 def is_user_email_blocked(email):
     """Returns the user's email blocked status"""
-    hash_object = hashlib.md5(email.lower().encode("utf-8"))
+    hash_object = get_hash_object(email)
     return BlockList.objects.filter(hashed_email=hash_object.hexdigest()).exists()
 
 
@@ -77,7 +82,7 @@ def block_user_email(email):
     """Blocks the user's email if provided"""
     msg = None
     if email:
-        hash_object = hashlib.md5(email.lower().encode("utf-8"))
+        hash_object = get_hash_object(email)
         _, created = BlockList.objects.get_or_create(
             hashed_email=hash_object.hexdigest()
         )

--- a/users/management/commands/unblock_users.py
+++ b/users/management/commands/unblock_users.py
@@ -1,22 +1,17 @@
 """
 Unblock user(s) from MIT xPRO
 """
-import hashlib
 from argparse import RawTextHelpFormatter
-from urllib.parse import urlparse
 import sys
 
 from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 
-from social_django.models import UserSocialAuth
-
+from authentication.utils import get_hash_object
 from mail.api import validate_email_addresses
 from mail.exceptions import MultiEmailValidationError
-from users.api import fetch_users
 from users.models import BlockList
 
-from mitxpro import settings
 
 User = get_user_model()
 
@@ -79,7 +74,7 @@ class Command(BaseCommand):
             sys.exit(2)
 
         for user_email in users:
-            hash_object = hashlib.md5(user_email.lower().encode("utf-8"))
+            hash_object = get_hash_object(user_email)
             blocked_user = BlockList.objects.filter(
                 hashed_email=hash_object.hexdigest()
             )

--- a/users/management/commands/unblock_users.py
+++ b/users/management/commands/unblock_users.py
@@ -7,7 +7,7 @@ import sys
 from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 
-from authentication.utils import get_hash_object
+from authentication.utils import get_md5_hash
 from mail.api import validate_email_addresses
 from mail.exceptions import MultiEmailValidationError
 from users.models import BlockList
@@ -74,7 +74,7 @@ class Command(BaseCommand):
             sys.exit(2)
 
         for user_email in users:
-            hash_object = get_hash_object(user_email)
+            hash_object = get_md5_hash(user_email)
             blocked_user = BlockList.objects.filter(
                 hashed_email=hash_object.hexdigest()
             )

--- a/users/management/tests/block_users_test.py
+++ b/users/management/tests/block_users_test.py
@@ -40,7 +40,7 @@ class TestblockUsers(TestCase):
     @pytest.mark.django_db
     def test_multiple_success_blocking_user(self):
         """test block_users command blocking emails success with more than one user"""
-        test_usernames = ["foo", "bar", "baz"]
+        test_usernames = ["foo@test.com", "bar@test.com", "baz@test.com"]
 
         for username in test_usernames:
             user = UserFactory.create(username=username, is_active=True)
@@ -55,3 +55,10 @@ class TestblockUsers(TestCase):
         assert BlockList.objects.all().count() == 0
         with self.assertRaises(SystemExit):
             COMMAND.handle("block_users", users=[])
+
+    @pytest.mark.django_db
+    def test_user_blocking_with_invalid_email(self):
+        """test block_users command system exit if not provided a valid email address"""
+        test_email = "test.com"
+        with self.assertRaises(SystemExit):
+            COMMAND.handle("block_users", users=[test_email])


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #2261 

#### What's this PR do?
@briangrossman  found an issue, tried to run block_users on an email address that wasn't already registered with xPRO and got an error because the email didn't exists (below):
We actually need to account for this use case. There may be a time when we want to add a user to the blocklist before they register for the site. 

#### How should this be manually tested?
- Run the command with user email that is not exist in xPro.
- It should be added in block list.

