### PR TITLE
upgrade trim-newlines to v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "js-yaml": "^3.13.1",
     "kind-of": "6.0.3",
     "minimist": "1.2.5",
-    "merge": "^2.1.1"
+    "merge": "^2.1.1",
+    "node-sass/**/trim-newlines": "^3.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10197,10 +10197,10 @@ tr46@^2.0.0:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
   integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2269

#### What's this PR do?
Upgrades trim-lines to v3.0.1

#### How should this be manually tested?
webpack should be able to compile sass files
