### PR TITLE
asadiqbal08/News and Events carousel to product pages

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -849,7 +849,7 @@ class CoursePage(ProductPage):
         """
         Gets the news and events section subpage
         """
-        if self.program_page:
+        if self.program_page and self.program_page.news_and_events:
             return self.program_page.news_and_events
         return self._get_child_page_of_type(NewsAndEventsPage)
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -718,6 +718,13 @@ class ProductPage(MetadataPageMixin, Page):
         """Checks whether the page in question is for an external course/program page or not."""
         return self.is_external_program_page or self.is_external_course_page
 
+    @property
+    def news_and_events(self):
+        """
+        Gets the news and events section subpage
+        """
+        return self._get_child_page_of_type(NewsAndEventsPage)
+
 
 class ProgramPage(ProductPage):
     """
@@ -760,13 +767,6 @@ class ProgramPage(ProductPage):
     def course_lineup(self):
         """Gets the course carousel page"""
         return self._get_child_page_of_type(CoursesInProgramPage)
-
-    @property
-    def news_and_events(self):
-        """
-        Gets the news and events section subpage
-        """
-        return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def product(self):

--- a/cms/models.py
+++ b/cms/models.py
@@ -587,7 +587,6 @@ class ProductPage(MetadataPageMixin, Page):
         "TextSection",
         "CertificatePage",
         "NewsAndEventsPage",
-        
     ]
 
     # Matches the standard page path that Wagtail returns for this page type.

--- a/cms/models.py
+++ b/cms/models.py
@@ -586,6 +586,8 @@ class ProductPage(MetadataPageMixin, Page):
         "FacultyMembersPage",
         "TextSection",
         "CertificatePage",
+        "NewsAndEventsPage",
+        
     ]
 
     # Matches the standard page path that Wagtail returns for this page type.
@@ -626,6 +628,7 @@ class ProductPage(MetadataPageMixin, Page):
             "who_should_enroll": self.who_should_enroll,
             "techniques": self.techniques,
             "propel_career": self.propel_career,
+            "news_and_events": self.news_and_events
         }
 
     def _get_child_page_of_type(self, cls):
@@ -654,6 +657,13 @@ class ProductPage(MetadataPageMixin, Page):
     def who_should_enroll(self):
         """Gets the who should enroll child page"""
         return self._get_child_page_of_type(WhoShouldEnrollPage)
+
+    @property
+    def news_and_events(self):
+        """
+        Gets the news and events section subpage
+        """
+        return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def techniques(self):
@@ -1177,7 +1187,14 @@ class NewsAndEventsPage(Page):
     Page that holds news and events updates
     """
 
-    parent_page_types = ["HomePage"]
+    parent_page_types = [
+        "ExternalCoursePage",
+        "CoursePage",
+        "ProgramPage",
+        "HomePage",
+        "ExternalProgramPage",
+    ]
+
     promote_panels = []
     subpage_types = []
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -627,7 +627,7 @@ class ProductPage(MetadataPageMixin, Page):
             "who_should_enroll": self.who_should_enroll,
             "techniques": self.techniques,
             "propel_career": self.propel_career,
-            "news_and_events": self.news_and_events
+            "news_and_events": self.news_and_events,
         }
 
     def _get_child_page_of_type(self, cls):

--- a/cms/models.py
+++ b/cms/models.py
@@ -658,13 +658,6 @@ class ProductPage(MetadataPageMixin, Page):
         return self._get_child_page_of_type(WhoShouldEnrollPage)
 
     @property
-    def news_and_events(self):
-        """
-        Gets the news and events section subpage
-        """
-        return self._get_child_page_of_type(NewsAndEventsPage)
-
-    @property
     def techniques(self):
         """Gets the learning techniques child page"""
         return self._get_child_page_of_type(LearningTechniquesPage)
@@ -769,6 +762,13 @@ class ProgramPage(ProductPage):
         return self._get_child_page_of_type(CoursesInProgramPage)
 
     @property
+    def news_and_events(self):
+        """
+        Gets the news and events section subpage
+        """
+        return self._get_child_page_of_type(NewsAndEventsPage)
+
+    @property
     def product(self):
         """Gets the product associated with this page"""
         return self.program
@@ -843,6 +843,15 @@ class CoursePage(ProductPage):
     def course_lineup(self):
         """Gets the course carousel page"""
         return self.program_page.course_lineup if self.program_page else None
+
+    @property
+    def news_and_events(self):
+        """
+        Gets the news and events section subpage
+        """
+        if self.program_page:
+            return self.program_page.news_and_events
+        return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def course_pages(self):

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1266,31 +1266,10 @@ def test_product_program_page_news_and_events():
     """
     program_page = ProgramPageFactory.create()
     assert not program_page.news_and_events
-    news_and_events_page = NewsAndEventsPageFactory.create(
-        parent=program_page,
-        heading="heading",
-        items__0__news_and_events__content_type="content_type-0",
-        items__0__news_and_events__title="title-0",
-        items__0__news_and_events__image__title="image-0",
-        items__0__news_and_events__content="content-0",
-        items__0__news_and_events__call_to_action="call_to_action-0",
-        items__0__news_and_events__action_url="action_url-0",
-        items__1__news_and_events__content_type="content_type-1",
-        items__1__news_and_events__title="title-1",
-        items__1__news_and_events__image__title="image-1",
-        items__1__news_and_events__content="content-1",
-        items__1__news_and_events__call_to_action="call_to_action-1",
-        items__1__news_and_events__action_url="action_url-1",
-    )
+    news_and_events_page = create_news_and_events(parent=program_page)    
     assert program_page.news_and_events == news_and_events_page
     assert news_and_events_page.heading == "heading"
-    for count, news_and_events in enumerate(news_and_events_page.items):
-        assert news_and_events.value.get("content_type") == f"content_type-{count}"
-        assert news_and_events.value.get("title") == f"title-{count}"
-        assert news_and_events.value.get("image").title == f"image-{count}"
-        assert news_and_events.value.get("content") == f"content-{count}"
-        assert news_and_events.value.get("call_to_action") == f"call_to_action-{count}"
-        assert news_and_events.value.get("action_url") == f"action_url-{count}"
+    _assert_news_and_events_values(news_and_events_page)
 
 
 def test_product_course_page_news_and_events_without_program():

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1266,7 +1266,7 @@ def test_product_program_page_news_and_events():
     """
     program_page = ProgramPageFactory.create()
     assert not program_page.news_and_events
-    news_and_events_page = create_news_and_events(parent=program_page)    
+    news_and_events_page = create_news_and_events(parent=program_page)
     assert program_page.news_and_events == news_and_events_page
     assert news_and_events_page.heading == "heading"
     _assert_news_and_events_values(news_and_events_page)

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1258,3 +1258,123 @@ def test_program_course_order():
         course_page.course.position_in_program
         for course_page in program_page.course_pages
     ] == [1, 2, 3]
+
+
+def test_product_program_page_news_and_events():
+    """
+    NewsAndEvents subpage should provide expected values if comes under ProgramPage.
+    """
+    program_page = ProgramPageFactory.create()
+    assert not program_page.news_and_events
+    news_and_events_page = NewsAndEventsPageFactory.create(
+        parent=program_page,
+        heading="heading",
+        items__0__news_and_events__content_type="content_type-0",
+        items__0__news_and_events__title="title-0",
+        items__0__news_and_events__image__title="image-0",
+        items__0__news_and_events__content="content-0",
+        items__0__news_and_events__call_to_action="call_to_action-0",
+        items__0__news_and_events__action_url="action_url-0",
+        items__1__news_and_events__content_type="content_type-1",
+        items__1__news_and_events__title="title-1",
+        items__1__news_and_events__image__title="image-1",
+        items__1__news_and_events__content="content-1",
+        items__1__news_and_events__call_to_action="call_to_action-1",
+        items__1__news_and_events__action_url="action_url-1",
+    )
+    assert program_page.news_and_events == news_and_events_page
+    assert news_and_events_page.heading == "heading"
+    for count, news_and_events in enumerate(news_and_events_page.items):
+        assert news_and_events.value.get("content_type") == f"content_type-{count}"
+        assert news_and_events.value.get("title") == f"title-{count}"
+        assert news_and_events.value.get("image").title == f"image-{count}"
+        assert news_and_events.value.get("content") == f"content-{count}"
+        assert news_and_events.value.get("call_to_action") == f"call_to_action-{count}"
+        assert news_and_events.value.get("action_url") == f"action_url-{count}"
+
+
+def test_product_course_page_news_and_events():
+    """
+    NewsAndEvents subpage should provide expected values if comes under CoursePage
+    and CoursePage is not associated with any program.
+    """
+    course_page = CoursePageFactory.create(course__program=None)
+    assert not course_page.news_and_events
+    news_and_events_page = NewsAndEventsPageFactory.create(
+        parent=course_page,
+        heading="heading",
+        items__0__news_and_events__content_type="content_type-0",
+        items__0__news_and_events__title="title-0",
+        items__0__news_and_events__image__title="image-0",
+        items__0__news_and_events__content="content-0",
+        items__0__news_and_events__call_to_action="call_to_action-0",
+        items__0__news_and_events__action_url="action_url-0",
+        items__1__news_and_events__content_type="content_type-1",
+        items__1__news_and_events__title="title-1",
+        items__1__news_and_events__image__title="image-1",
+        items__1__news_and_events__content="content-1",
+        items__1__news_and_events__call_to_action="call_to_action-1",
+        items__1__news_and_events__action_url="action_url-1",
+    )
+    assert course_page.news_and_events == news_and_events_page
+    assert news_and_events_page.heading == "heading"
+    for count, news_and_events in enumerate(news_and_events_page.items):
+        assert news_and_events.value.get("content_type") == f"content_type-{count}"
+        assert news_and_events.value.get("title") == f"title-{count}"
+        assert news_and_events.value.get("image").title == f"image-{count}"
+        assert news_and_events.value.get("content") == f"content-{count}"
+        assert news_and_events.value.get("call_to_action") == f"call_to_action-{count}"
+        assert news_and_events.value.get("action_url") == f"action_url-{count}"
+
+
+def test_product_course_page_news_and_events():
+    """
+    NewsAndEvents subpage should provide expected values of program 'news and events' if comes under CoursePage
+    and CoursePage is associated with a program.
+    """
+    program_page = ProgramPageFactory.create()
+    course_page = CoursePageFactory.create(course__program=program_page.program)
+    assert not course_page.news_and_events
+    program_news_and_events_page = NewsAndEventsPageFactory.create(
+        parent=program_page,
+        heading="heading program",
+        items__0__news_and_events__content_type="content_type-0",
+        items__0__news_and_events__title="title-0",
+        items__0__news_and_events__image__title="image-0",
+        items__0__news_and_events__content="content-0",
+        items__0__news_and_events__call_to_action="call_to_action-0",
+        items__0__news_and_events__action_url="action_url-0",
+        items__1__news_and_events__content_type="content_type-1",
+        items__1__news_and_events__title="title-1",
+        items__1__news_and_events__image__title="image-1",
+        items__1__news_and_events__content="content-1",
+        items__1__news_and_events__call_to_action="call_to_action-1",
+        items__1__news_and_events__action_url="action_url-1",
+    )
+
+    course_news_and_events_page = NewsAndEventsPageFactory.create(
+        parent=course_page,
+        heading="heading course",
+        items__0__news_and_events__content_type="content_type-0",
+        items__0__news_and_events__title="title-0",
+        items__0__news_and_events__image__title="image-0",
+        items__0__news_and_events__content="content-0",
+        items__0__news_and_events__call_to_action="call_to_action-0",
+        items__0__news_and_events__action_url="action_url-0",
+        items__1__news_and_events__content_type="content_type-1",
+        items__1__news_and_events__title="title-1",
+        items__1__news_and_events__image__title="image-1",
+        items__1__news_and_events__content="content-1",
+        items__1__news_and_events__call_to_action="call_to_action-1",
+        items__1__news_and_events__action_url="action_url-1",
+    )
+    assert course_page.news_and_events == program_news_and_events_page
+    assert course_page.news_and_events != course_news_and_events_page
+    assert program_news_and_events_page.heading == "heading program"
+    for count, news_and_events in enumerate(program_news_and_events_page.items):
+        assert news_and_events.value.get("content_type") == f"content_type-{count}"
+        assert news_and_events.value.get("title") == f"title-{count}"
+        assert news_and_events.value.get("image").title == f"image-{count}"
+        assert news_and_events.value.get("content") == f"content-{count}"
+        assert news_and_events.value.get("call_to_action") == f"call_to_action-{count}"
+        assert news_and_events.value.get("action_url") == f"action_url-{count}"

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1293,7 +1293,7 @@ def test_product_program_page_news_and_events():
         assert news_and_events.value.get("action_url") == f"action_url-{count}"
 
 
-def test_product_course_page_news_and_events():
+def test_product_course_page_news_and_events_without_program():
     """
     NewsAndEvents subpage should provide expected values if comes under CoursePage
     and CoursePage is not associated with any program.
@@ -1327,7 +1327,7 @@ def test_product_course_page_news_and_events():
         assert news_and_events.value.get("action_url") == f"action_url-{count}"
 
 
-def test_product_course_page_news_and_events():
+def test_product_course_page_news_and_events_with_program():
     """
     NewsAndEvents subpage should provide expected values of program 'news and events' if comes under CoursePage
     and CoursePage is associated with a program.

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1300,31 +1300,10 @@ def test_product_course_page_news_and_events_without_program():
     """
     course_page = CoursePageFactory.create(course__program=None)
     assert not course_page.news_and_events
-    news_and_events_page = NewsAndEventsPageFactory.create(
-        parent=course_page,
-        heading="heading",
-        items__0__news_and_events__content_type="content_type-0",
-        items__0__news_and_events__title="title-0",
-        items__0__news_and_events__image__title="image-0",
-        items__0__news_and_events__content="content-0",
-        items__0__news_and_events__call_to_action="call_to_action-0",
-        items__0__news_and_events__action_url="action_url-0",
-        items__1__news_and_events__content_type="content_type-1",
-        items__1__news_and_events__title="title-1",
-        items__1__news_and_events__image__title="image-1",
-        items__1__news_and_events__content="content-1",
-        items__1__news_and_events__call_to_action="call_to_action-1",
-        items__1__news_and_events__action_url="action_url-1",
-    )
+    news_and_events_page = create_news_and_events(parent=course_page)
     assert course_page.news_and_events == news_and_events_page
     assert news_and_events_page.heading == "heading"
-    for count, news_and_events in enumerate(news_and_events_page.items):
-        assert news_and_events.value.get("content_type") == f"content_type-{count}"
-        assert news_and_events.value.get("title") == f"title-{count}"
-        assert news_and_events.value.get("image").title == f"image-{count}"
-        assert news_and_events.value.get("content") == f"content-{count}"
-        assert news_and_events.value.get("call_to_action") == f"call_to_action-{count}"
-        assert news_and_events.value.get("action_url") == f"action_url-{count}"
+    _assert_news_and_events_values(news_and_events_page)
 
 
 def test_product_course_page_news_and_events_with_program():
@@ -1335,9 +1314,48 @@ def test_product_course_page_news_and_events_with_program():
     program_page = ProgramPageFactory.create()
     course_page = CoursePageFactory.create(course__program=program_page.program)
     assert not course_page.news_and_events
-    program_news_and_events_page = NewsAndEventsPageFactory.create(
-        parent=program_page,
-        heading="heading program",
+    program_news_and_events_page = create_news_and_events(
+        parent=program_page, heading="heading program"
+    )
+    course_news_and_events_page = create_news_and_events(parent=course_page)
+
+    assert course_page.news_and_events == program_news_and_events_page
+    assert course_page.news_and_events != course_news_and_events_page
+    assert program_news_and_events_page.heading == "heading program"
+    _assert_news_and_events_values(program_news_and_events_page)
+
+
+def test_external_program_page_news_and_events():
+    """
+    NewsAndEvents subpage should provide expected values of external program.
+    """
+    external_program_page = ExternalProgramPageFactory.create()
+    assert not external_program_page.news_and_events
+    news_and_events_page = create_news_and_events(parent=external_program_page)
+    assert external_program_page.news_and_events == news_and_events_page
+    assert news_and_events_page.heading == "heading"
+    _assert_news_and_events_values(news_and_events_page)
+
+
+def test_external_course_page_news_and_events():
+    """
+    NewsAndEvents subpage should provide expected values of external course.
+    """
+    external_course_page = ExternalCoursePageFactory.create()
+    assert not external_course_page.news_and_events
+    news_and_events_page = create_news_and_events(parent=external_course_page)
+    assert external_course_page.news_and_events == news_and_events_page
+    assert news_and_events_page.heading == "heading"
+    _assert_news_and_events_values(news_and_events_page)
+
+
+def create_news_and_events(parent, heading="heading"):
+    """
+    Create a news and events page and return it.
+    """
+    return NewsAndEventsPageFactory.create(
+        parent=parent,
+        heading=heading,
         items__0__news_and_events__content_type="content_type-0",
         items__0__news_and_events__title="title-0",
         items__0__news_and_events__image__title="image-0",
@@ -1352,26 +1370,12 @@ def test_product_course_page_news_and_events_with_program():
         items__1__news_and_events__action_url="action_url-1",
     )
 
-    course_news_and_events_page = NewsAndEventsPageFactory.create(
-        parent=course_page,
-        heading="heading course",
-        items__0__news_and_events__content_type="content_type-0",
-        items__0__news_and_events__title="title-0",
-        items__0__news_and_events__image__title="image-0",
-        items__0__news_and_events__content="content-0",
-        items__0__news_and_events__call_to_action="call_to_action-0",
-        items__0__news_and_events__action_url="action_url-0",
-        items__1__news_and_events__content_type="content_type-1",
-        items__1__news_and_events__title="title-1",
-        items__1__news_and_events__image__title="image-1",
-        items__1__news_and_events__content="content-1",
-        items__1__news_and_events__call_to_action="call_to_action-1",
-        items__1__news_and_events__action_url="action_url-1",
-    )
-    assert course_page.news_and_events == program_news_and_events_page
-    assert course_page.news_and_events != course_news_and_events_page
-    assert program_news_and_events_page.heading == "heading program"
-    for count, news_and_events in enumerate(program_news_and_events_page.items):
+
+def _assert_news_and_events_values(news_and_events_page):
+    """
+    Assure the expected values for news and events page.
+    """
+    for count, news_and_events in enumerate(news_and_events_page.items):
         assert news_and_events.value.get("content_type") == f"content_type-{count}"
         assert news_and_events.value.get("title") == f"title-{count}"
         assert news_and_events.value.get("image").title == f"image-{count}"

--- a/cms/templates/partials/subnav.html
+++ b/cms/templates/partials/subnav.html
@@ -13,6 +13,7 @@
       {% if testimonials %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#testimonials">What Learners Are Saying</a></li> {% endif %}
       {% if faculty %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#faculty">Your MIT Faculty</a></li> {% endif %}
       {% if course_lineup %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#courseLineup">Courses In This Program</a></li> {% endif %}
+      {% if news_and_events %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#news-and-events">News and Events</a></li> {% endif %}
       {% if for_teams %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#forTeams">Enterprise</a></li> {% endif %}
       {% if faqs %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#faq">FAQs</a></li> {% endif %}
     </ul>

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -63,6 +63,7 @@
       {% endif %}
     {% endwith %}
   {% endif %}
+  {% if news_and_events %} {% include "partials/news-and-events-carousel.html" with page=news_and_events %} {% endif %}
   {% if for_teams %} {% include "partials/for-teams.html" with page=for_teams %} {% endif %}
   {% if faqs %} {% include "partials/faqs.html" with faqs=faqs %} {% endif %}
   {% if propel_career %} {% include "partials/text-section.html" with page=propel_career %} {% endif %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
fixes: #2276 

#### What's this PR do?
Add News and Events carousel functionality to product pages

#### How should this be manually tested?

- Go to cms
- Under Product Page create a News and Events Page
- Add the required fields and save
- A new section should appear below testimonial on your Product pages e.g. courses, programs, external courses and external programs.

#### Screenshots (if appropriate)
<img width="1433" alt="Screen Shot 2021-07-08 at 3 23 58 PM" src="https://user-images.githubusercontent.com/7334669/124907134-3d1f9080-e001-11eb-9b44-5d53c6aae1b2.png">
<img width="217" alt="Screen Shot 2021-07-08 at 3 24 38 PM" src="https://user-images.githubusercontent.com/7334669/124907161-43ae0800-e001-11eb-8d84-69690d9addd7.png">


