### PR TITLE
fix: customer name fixed on order receipt page

### DIFF
--- a/static/js/containers/pages/b2b/B2BReceiptPage.js
+++ b/static/js/containers/pages/b2b/B2BReceiptPage.js
@@ -103,7 +103,6 @@ export class B2BReceiptPage extends React.Component<Props, State> {
   render() {
     const {
       orderStatus,
-      currentUser,
       location: { search }
     } = this.props
 
@@ -124,9 +123,9 @@ export class B2BReceiptPage extends React.Component<Props, State> {
       coupon_code: couponCode,
       receipt_data: receiptData,
       reference_number: referenceNumber,
+      customer_name: customerName,
       product_version: { content_title: title, readable_id: readableId }
     } = orderStatus
-
     return (
       <React.Fragment>
         <div className="b2b-receipt-page container">
@@ -150,10 +149,10 @@ export class B2BReceiptPage extends React.Component<Props, State> {
                   <span className="description">Order Date:</span>
                   {formatPrettyDate(moment(createdOn))}
                 </p>
-                {currentUser && currentUser.is_authenticated && (
+                {customerName && (
                   <p className="customer-name">
                     <span className="description">Customer Name:</span>
-                    {currentUser.name}
+                    {customerName}
                   </p>
                 )}
                 <p className="email">
@@ -232,7 +231,6 @@ export class B2BReceiptPage extends React.Component<Props, State> {
 }
 
 const mapStateToProps = state => ({
-  currentUser: state.entities.currentUser,
   orderStatus: state.entities.b2b_order_status
 })
 

--- a/static/js/factories/ecommerce.js
+++ b/static/js/factories/ecommerce.js
@@ -305,7 +305,8 @@ export const makeB2BOrderStatus = (): B2BOrderStatus => {
     coupon_code:      "1234",
     reference_number: "reference-b2b-xyz",
     receipt_data:     { card_type: null, card_number: null },
-    contract_number:  contractNumber
+    contract_number:  contractNumber,
+    customer_name:    "Some Name"
   }
 }
 

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -77,6 +77,7 @@ export type B2BOrderStatus = {
   created_on: ?string,
   coupon_code: ?string,
   reference_number: ?string,
+  customer_name: ?string,
   receipt_data: { card_type: ?string, card_number: ?string },
   product_version: ProductVersion
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2280 

#### What's this PR do?
- Fixes customer name on the order receipt page
- Fetches the customer name based on the existing user associated with the order email
- If there is no associated user in the system with order email. it tries to fetch the user from order receipt details
- If there is no name in the receipt it hides the customer name field.

Associated ticket's expected behavior part can be seen for further details on the priority of fetching the customer name. 

**Note:**
In the case of receipts the name that is fetched is basically the value for the keys `req_bill_to_forename` and `req_bill_to_surname` from receipt data

#### How should this be manually tested?
- Create a B2b bulk order
- Follow the steps mentioned on the ticket

#### Where should the reviewer start?
- Bulk order

#### Screenshots (if appropriate)
**No associated email account or receipt**
<img width="751" alt="Screenshot 2021-07-19 at 6 11 48 PM" src="https://user-images.githubusercontent.com/34372316/126165251-0a60e5be-18ce-493c-8ccf-485d14fae2dd.png">

**No associated email found but we found name in receipt**
<img width="797" alt="Screenshot 2021-07-19 at 6 10 30 PM" src="https://user-images.githubusercontent.com/34372316/126165234-5ba0763c-8f25-41ed-8e66-0d28cbd7032e.png">


**Associated email account found**
<img width="769" alt="Screenshot 2021-07-19 at 6 10 50 PM" src="https://user-images.githubusercontent.com/34372316/126165243-ce6bff7c-85d9-4845-a064-8fb7a95f5948.png">

