### PR TITLE
Updated styles for news and event carousel

### DIFF
--- a/static/scss/detail/news-and-events-carousel.scss
+++ b/static/scss/detail/news-and-events-carousel.scss
@@ -1,7 +1,7 @@
 // sass-lint:disable mixins-before-declarations
 .news-and-events-block {
   padding: 100px 0 50px;
-  background: white;
+  background: $gray-bg;
   min-height: 400px;
   overflow: hidden;
   position: relative;
@@ -61,7 +61,7 @@
   }
 
   .slide-holder {
-    background: $events-background;
+    background: white;
     border-radius: 5px;
     box-shadow: 5px 5px 10px 0 rgba(0, 0, 0, 0.1);
     height: 100%;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2302 

#### What's this PR do?
This PR updates the news and event carousel styles in the following way
- Updated  the background of the carousel section to be the color: #ebebeb
- Updated background of the carousel cards to be while: #ffffff

#### How should this be manually tested?
This PR can be tested the following way
- Add News and Event carousel and items
- Verify Background color is #ebebeb
- Verify card color is white

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
(Optional)

<img width="1440" alt="Screenshot 2021-09-14 at 5 32 46 PM" src="https://user-images.githubusercontent.com/87968618/133258917-76d35568-6569-435e-9bd3-81a4abac871e.png">

<img width="691" alt="Screenshot 2021-09-14 at 5 33 01 PM" src="https://user-images.githubusercontent.com/87968618/133258949-15d87e67-4f0c-4930-8ca8-b616a4a05287.png">
