### PR TITLE
Fixed notification when changing password from account settings

### DIFF
--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -24,6 +24,7 @@ from hypothesis.extra.django import TestCase as HTestCase
 import pytest
 import responses
 from rest_framework import status
+from rest_framework.response import Response
 from social_core.backends.email import EmailAuth
 
 from authentication.serializers import PARTIAL_PIPELINE_TOKEN_KEY
@@ -789,26 +790,8 @@ def test_register_email_hijacked(client, user, admin_user):
     assert response.status_code == 403
 
 
-class DjoserViewTests:
+class TestDjoserView:
     """Tests for views that modify Djoser views"""
-
-    # pylint: disable=too-many-arguments
-    @pytest.mark.parametrize(
-        "url", ["password-reset-api", "password-reset-confirm-api", "set-password-api"]
-    )
-    def test_password_reset_coerce_204(self, mocker, client, user, url):
-        """
-        Verify that password reset views coerce a 204 response to a 200 in order
-        to play nice with redux-hammock.
-        """
-        mocker.patch(
-            "authentication.views.ActionViewMixin.post",
-            return_value=mocker.Mock(status_code=status.HTTP_400_BAD_REQUEST),
-        )
-        client.force_login(user)
-        response = client.post(reverse(url), {})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {}
 
     @pytest.mark.parametrize(
         "response_status,expected_session_update",
@@ -826,8 +809,8 @@ class DjoserViewTests:
         request succeeds.
         """
         mocker.patch(
-            "authentication.views.ActionViewMixin.post",
-            return_value=mocker.Mock(status_code=response_status),
+            "authentication.views.UserViewSet.set_password",
+            return_value=Response(data={}, status=response_status),
         )
         update_session_patch = mocker.patch(
             "authentication.views.update_session_auth_hash", return_value=mocker.Mock()

--- a/static/js/containers/pages/settings/AccountSettingsPage.js
+++ b/static/js/containers/pages/settings/AccountSettingsPage.js
@@ -52,7 +52,7 @@ export class AccountSettingsPage extends React.Component<Props> {
       )
 
       let alertText, color
-      if (response.status === 200) {
+      if (response.status === 200 || response.status === 204) {
         alertText = "Your password has been updated successfully."
         color = "success"
       } else {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2306 
#### What's this PR do?
This PR accomplishes the following:
- Catches 204 response status on Account Setting Page as redux-query can handle 204's. Kindly refer to the following PR https://github.com/mitodl/mitxpro/pull/2193
- Updates django session after password change
- Removes a unnecessary Test for checking if 204 is converted to 200 status code in Djoser Views
- Fixes Tests which were not previously running.

#### How should this be manually tested?
- From the drop down menu, go to account settings.
- Change user password.
- Verify you get correct notification
- Verify you remain logged in.


#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-09-17 at 4 15 30 PM" src="https://user-images.githubusercontent.com/87968618/133774564-e1e01e6d-fdf3-478a-814b-9139dbe5aba8.png">

