### PR TITLE
set react version to get rid of an eslint warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,12 @@
 {
   "extends": "eslint-config-mitodl",
+  "settings": {
+    "react": {
+      "pragma": "React",
+      "version": "detect",
+      "flowVersion": "0.2.3"
+    }
+  },
   rules: {
     "no-unused-vars": 0,
     // module importing pattern have huge impact over performance, especially when it comes to lodash


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

what it says on the can

#### How should this be manually tested?

run `yarn lint` locally on `master`, and then on this branch. on master there should be a warning message about configuring the react plugin, on this branch that should go away.