### PR TITLE
Fixed password reset url

### DIFF
--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -65,8 +65,8 @@ urlpatterns = (
         path("signin/", index, name="login"),
         path("signin/password/", index, name="login-password"),
         re_path(r"^signin/forgot-password/$", index, name="password-reset"),
-        re_path(
-            r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
+        path(
+            "signin/forgot-password/confirm/<slug:uid>/<slug:token>/",
             index,
             name="password-reset-confirm",
         ),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #2371 

#### What's this PR do?
This fixes a regex in the url routing that broke because django changed the internal implementation of its token generator.

I chose to switch this to django's builtin `slug` parser because it's more robust against future changes like this.

#### How should this be manually tested?
- Trigger a password reset email
- The link in your email should resolve to the reset UI and you should be able to complete the password reset process.
