### PR TITLE
Added unittest for expired program runs

### DIFF
--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1410,7 +1410,7 @@ def test_products_viewset_expired_programs(user_drf_client):
         for product in products
         if product["product_type"] == "program"
     ]
-    # For all the programs in the list there should be on enrollable course run for each associated course
+    # assert non expired programs are in list.
     assert set(program_ids) == {programs[0].id, programs[1].id, programs[2].id}
 
     # Expired program should be excluded.

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1384,6 +1384,54 @@ def test_products_viewset_detail(user_drf_client, coupon_product_ids):
     )
 
 
+def test_products_viewset_expired_programs(user_drf_client):
+    """ Test that the ProductViewSet returns contains only valid programs products and exclude the expired programs correctly"""
+    now = now_in_utc()
+    programs = ProgramFactory.create_batch(3)
+    runs = CourseRunFactory.create_batch(2, course__program=factory.Iterator(programs))
+    index = 0
+    while index < len(programs):
+        ProgramRunFactory.create(
+            program=programs[index],
+            start_date=(now + timedelta(days=1))
+            if index < (len(programs) - 1)
+            else (now - timedelta(days=3)),
+            end_date=(now + timedelta(days=2))
+            if index < (len(programs) - 1)
+            else (now - timedelta(days=1)),
+        )
+        index += 1
+
+    ProductVersionFactory.create_batch(
+        4, product__content_object=factory.Iterator(runs + programs)
+    )
+    response = user_drf_client.get(reverse("products_api-list"))
+    assert response.status_code == status.HTTP_200_OK
+    products = response.json()
+    expired_courseruns = CourseRun.objects.filter(enrollment_end__lt=now).values_list(
+        "id", flat=True
+    )
+    program_ids = [
+        product["latest_version"]["object_id"]
+        for product in products
+        if product["product_type"] == "program"
+    ]
+    # For all the programs in the list there should be on enrollable course run for each associated course
+    assert set(program_ids) == {programs[0].id, programs[1].id}
+    # Expired program should be excluded.
+    assert programs[2].id not in program_ids
+    for program_id in program_ids:
+        program = Program.objects.get(pk=program_id)
+        count = (
+            program.courses.annotate(
+                runs=Count("courseruns", filter=~Q(courseruns__in=expired_courseruns))
+            )
+            .filter(runs=0)
+            .count()
+        )
+        assert count == 0
+
+
 @pytest.mark.django_db
 def test_products_viewset_performance(
     user_drf_client, coupon_product_ids, django_assert_num_queries

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1402,9 +1402,6 @@ def test_products_viewset_expired_programs(user_drf_client):
     response = user_drf_client.get(reverse("products_api-list"))
     assert response.status_code == status.HTTP_200_OK
     products = response.json()
-    expired_courseruns = CourseRun.objects.filter(enrollment_end__lt=now).values_list(
-        "id", flat=True
-    )
     program_ids = [
         product["latest_version"]["object_id"]
         for product in products

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1414,6 +1414,8 @@ def test_products_viewset_expired_programs(user_drf_client):
     assert set(program_ids) == {programs[0].id, programs[1].id, programs[2].id}
     # Expired program should be excluded.
     assert programs[3].id not in program_ids
+    
+    # For all the programs in the list there should be on enrollable course run for each associated course
     for program_id in program_ids:
         program = Program.objects.get(pk=program_id)
         count = (

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1412,20 +1412,9 @@ def test_products_viewset_expired_programs(user_drf_client):
     ]
     # For all the programs in the list there should be on enrollable course run for each associated course
     assert set(program_ids) == {programs[0].id, programs[1].id, programs[2].id}
+
     # Expired program should be excluded.
     assert programs[3].id not in program_ids
-    
-    # For all the programs in the list there should be on enrollable course run for each associated course
-    for program_id in program_ids:
-        program = Program.objects.get(pk=program_id)
-        count = (
-            program.courses.annotate(
-                runs=Count("courseruns", filter=~Q(courseruns__in=expired_courseruns))
-            )
-            .filter(runs=0)
-            .count()
-        )
-        assert count == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
fixes: #2378 

#### What's this PR do?
Add test to cover expired program runs in product list while visiting `/ecommerce/bulk`

