### PR TITLE
Vertically center the certificate when printing

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -57,7 +57,7 @@
     {% endif %}
     <div class="row">
         <div class="col certificate-wrapper">
-            <div class="certificate">
+            <div class="certificate content-center">
                 <div class="certificate-holder">
                     {% if page.partner_logo %}
                     {% if page.partner_logo_placement == page.PartnerLogoPlacement.SECOND %}

--- a/static/scss/certificates/certificate.scss
+++ b/static/scss/certificates/certificate.scss
@@ -338,6 +338,8 @@ $text-gray-light: #d2d0d1;
   }
 
   .certificate-page {
+    background: white;
+
     .certificate-logo {
       max-width: 170px;
       margin: 0 auto 10px;
@@ -354,6 +356,12 @@ $text-gray-light: #d2d0d1;
           max-width: 140px;
           margin-bottom: 10px;
         }
+      }
+
+      .content-center {
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
       }
 
       .certificate-holder {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2417 

#### What's this PR do?
(Required)

#### How should this be manually tested?
- Checkout the branch
- Open certificate page
- Open print preview or get the print (`command + p` on Macbook or `ctrl + p` on Windows PC)
- Validate the certificate content is centered vertically and horizontally

#### Screenshots of Chrome and Firefox
<img width="1252" alt="Screenshot 2022-09-13 at 6 02 07 PM" src="https://user-images.githubusercontent.com/77275478/189909827-47f025b8-2419-452d-9cee-1a7146578d13.png">
<img width="1252" alt="Screenshot 2022-09-13 at 6 01 35 PM" src="https://user-images.githubusercontent.com/77275478/189909766-8c3b8022-c31e-4d07-96ae-ab56d2a267fe.png">

