### PR TITLE
display start and end date on certificate template

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -107,13 +107,15 @@
                     {% endif %}
                     {% if page.CEUs %}
                         <span class="award-text">Awarded {{ CEUs }} Continuing Education Units (CEUs) <br>
-                            {% if is_program_certificate %}
-                                {{ end_date|date }}
-                            {% else %}
-                                {{ start_date|date }} - {{ end_date|date }}
-                            {% endif %}
                         </span>
                     {% endif %}
+                    <span>
+                        {% if is_program_certificate %}
+                            {{ end_date|date }}
+                        {% else %}
+                            {{ start_date|date }} - {{ end_date|date }}
+                        {% endif %}
+                    </span>
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-24 certify-by">

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -107,15 +107,21 @@
                     {% endif %}
                     {% if page.CEUs %}
                         <span class="award-text">Awarded {{ CEUs }} Continuing Education Units (CEUs) <br>
+                            {% if is_program_certificate %}
+                                {{ end_date|date }}
+                            {% else %}
+                                {{ start_date|date }} - {{ end_date|date }}
+                            {% endif %}
+                        </span>
+                    {% else %}
+                        <span class="award-text">
+                            {% if is_program_certificate %}
+                                {{ end_date|date }}
+                            {% else %}
+                                {{ start_date|date }} - {{ end_date|date }}
+                            {% endif %}
                         </span>
                     {% endif %}
-                    <span>
-                        {% if is_program_certificate %}
-                            {{ end_date|date }}
-                        {% else %}
-                            {{ start_date|date }} - {{ end_date|date }}
-                        {% endif %}
-                    </span>
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-24 certify-by">

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -105,23 +105,15 @@
                     {% if is_program_certificate %}
                         <span class="program-degree-text">Professional Certificate Program<br></span>
                     {% endif %}
-                    {% if page.CEUs %}
-                        <span class="award-text">Awarded {{ CEUs }} Continuing Education Units (CEUs) <br>
-                            {% if is_program_certificate %}
-                                {{ end_date|date }}
-                            {% else %}
-                                {{ start_date|date }} - {{ end_date|date }}
-                            {% endif %}
-                        </span>
-                    {% else %}
-                        <span class="award-text">
-                            {% if is_program_certificate %}
-                                {{ end_date|date }}
-                            {% else %}
-                                {{ start_date|date }} - {{ end_date|date }}
-                            {% endif %}
-                        </span>
-                    {% endif %}
+                    <span class="award-text">
+                        {% if page.CEUs %} Awarded {{ CEUs }} Continuing Education Units (CEUs) <br> {% endif %}
+                        
+                        {% if is_program_certificate %}
+                            {{ end_date|date }}
+                        {% else %}
+                            {{ start_date|date }} - {{ end_date|date }}
+                        {% endif %}
+                    </span>
                     <div class="row justify-content-center certify-by-row">
                         {% for signatory in page.signatory_pages %}
                             <div class="col-sm-4 col-24 certify-by">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2420 

#### What's this PR do?
(Required)

#### How should this be manually tested?
- Open any certificate page
- Validate course start and end date on certificate page with and without CEUs

#### Screenshots
<img width="1100" alt="Screenshot 2022-09-15 at 2 42 16 AM" src="https://user-images.githubusercontent.com/77275478/190268672-8025f56c-ee99-4c15-8ae6-70e5aa9f4326.png">
<img width="1100" alt="Screenshot 2022-09-15 at 2 42 33 AM" src="https://user-images.githubusercontent.com/77275478/190268688-f59a4518-fcbf-4e71-a372-cd3a24aded62.png">

