### PR TITLE
Certificate page should not be moved to Certificate Index Page child

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -186,14 +186,6 @@ def ensure_index_pages():
         )
         home_page.add_child(instance=certificate_index)
 
-    if (
-        certificate_index.get_children_count()
-        != cms_models.CertificatePage.objects.count()
-    ):
-        for cert_page in cms_models.CertificatePage.objects.all():
-            cert_page.move(certificate_index, "last-child")
-        log.info("Moved certificate pages under certificate index page")
-
 
 def configure_wagtail():
     """


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2409 

#### What's this PR do?
The certificate page is a child of course this should not be moved from course child to certificate index page child

#### How should this be manually tested?
- Open any course with a Certificate Page available
- Run command in terminal `docker-compose run web ./manage.py configure_wagtail`
- Validate in CMS that the certificate page of the course is not removed from the course and not added to Certificate Index Page

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
