### PR TITLE
xPro-2411 Fix search for data consent agreements admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -536,7 +536,7 @@ class DataConsentAgreementAdmin(TimestampedModelAdmin):
     include_created_on_in_list = True
     list_filter = ("company",)
     list_display = ("id", "company")
-    search_fields = ("company", "content")
+    search_fields = ("company__name", "content")
     raw_id_fields = ("courses",)
 
     form = DataConsentAgreementForm


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxpro/issues/2411

#### What's this PR do?
Fixes search for Data Consent Agreement list in Django admin.

#### How should this be manually tested?

- Visit admin/ecommerce/dataconsentagreement/ in xpro
- Search something in the search field.
- Search will work fine now.
