### PR TITLE
bulk assignment instance already created

### DIFF
--- a/sheets/management/commands/process_coupon_assignment_sheet.py
+++ b/sheets/management/commands/process_coupon_assignment_sheet.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         )
 
         if (
-            not created
+            bulk_assignment.sheet_last_modified_date
             and sheet_last_modified <= bulk_assignment.sheet_last_modified_date
             and not options["force"]
         ):


### PR DESCRIPTION
#### Pre-Flight checklist


- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/mitxpro/issues/2415

#### What's this PR do?
The issue above was fixed, however there is a bug, where we check for BulkCouponAssignment to be created and that is causing a problem since the instance gets created in the previous command `process_coupon_assignments`. 
Instead of creation, we just need to check is the sheet was ever manually updated before.

As a result, we need to run this command `process_coupon_assignment_sheet` twice, since it fails on first run.
This PR fixes the issue, so that the command succeeds on first run.
`

#### How should this be manually tested?
Set up google sheets locally (here are the [instructions](https://github.com/mitodl/mitxpro/blob/master/sheets/dev-setup.md))
and then you would need to go through the whole [process](https://github.com/mitodl/mitxpro/blob/master/sheets/dev-setup.md#usage) of assigning coupon codes:
1) fill out a request form, similar to (RC) B2B Student Enrollment Code Request
2) run `./manage.py process_coupon_requests`. This should create an coupon assignment sheet
3) run `./manage.py process_coupon_assignment_sheet -i "Enrollment code assignment spreadsheet id"`

This should succeed on first run.
