### PR TITLE
Fixed improper usages of get_rendition

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -101,8 +101,10 @@ class PageProperties(models.Model):
     @property
     def background_image_url(self):
         """Gets the url for the background image (if that image exists)"""
+        from wagtail.images.views.serve import generate_image_url
+
         return (
-            self.background_image.get_rendition(COURSE_BG_IMG_WAGTAIL_FILL).url
+            generate_image_url(self.background_image, COURSE_BG_IMG_WAGTAIL_FILL)
             if self.background_image
             else None
         )
@@ -110,8 +112,10 @@ class PageProperties(models.Model):
     @property
     def background_image_mobile_url(self):
         """Gets the url for the background image (if that image exists)"""
+        from wagtail.images.views.serve import generate_image_url
+
         return (
-            self.background_image.get_rendition(COURSE_BG_IMG_MOBILE_WAGTAIL_FILL).url
+            generate_image_url(self.background_image, COURSE_BG_IMG_MOBILE_WAGTAIL_FILL)
             if self.background_image
             else None
         )
@@ -119,8 +123,12 @@ class PageProperties(models.Model):
     @property
     def catalog_image_url(self):
         """Gets the url for the thumbnail image as it appears in the catalog (if that image exists)"""
+        from wagtail.images.views.serve import generate_image_url
+
         return (
-            self.page.thumbnail_image.get_rendition(CATALOG_COURSE_IMG_WAGTAIL_FILL).url
+            generate_image_url(
+                self.page.thumbnail_image, CATALOG_COURSE_IMG_WAGTAIL_FILL
+            )
             if self.page and self.page.thumbnail_image
             else None
         )

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -169,22 +169,18 @@ def test_thumbnail_url():
     """
     thumbnail_url should return a url of the Product's thumbnail
     """
+    from wagtail.images.views.serve import generate_image_url
+
     program = ProgramFactory.create()
     program_product = ProductFactory.create(content_object=program)
     run = CourseRunFactory.create()
     run_product = ProductFactory.create(content_object=run)
 
-    assert (
-        program_product.thumbnail_url
-        == program.page.thumbnail_image.get_rendition(
-            CATALOG_COURSE_IMG_WAGTAIL_FILL
-        ).url
+    assert program_product.thumbnail_url == generate_image_url(
+        program.page.thumbnail_image, CATALOG_COURSE_IMG_WAGTAIL_FILL
     )
-    assert (
-        run_product.thumbnail_url
-        == run.course.page.thumbnail_image.get_rendition(
-            CATALOG_COURSE_IMG_WAGTAIL_FILL
-        ).url
+    assert run_product.thumbnail_url == generate_image_url(
+        run.course.page.thumbnail_image, CATALOG_COURSE_IMG_WAGTAIL_FILL
     )
 
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -140,6 +140,8 @@ def test_serialize_basket_product_version_programrun(mock_context):
 
 def test_basket_thumbnail_courserun(basket_and_coupons, mock_context):
     """Basket thumbnail should be serialized for a courserun"""
+    from wagtail.images.views.serve import generate_image_url
+
     thumbnail_filename = "abcde.jpg"
     course_page = CoursePageFactory.create(
         thumbnail_image__file__filename=thumbnail_filename
@@ -149,16 +151,15 @@ def test_basket_thumbnail_courserun(basket_and_coupons, mock_context):
     data = FullProductVersionSerializer(
         instance=product_version, context=mock_context
     ).data
-    assert (
-        data["thumbnail_url"]
-        == course_page.thumbnail_image.get_rendition(
-            CATALOG_COURSE_IMG_WAGTAIL_FILL
-        ).url
+    assert data["thumbnail_url"] == generate_image_url(
+        course_page.thumbnail_image, CATALOG_COURSE_IMG_WAGTAIL_FILL
     )
 
 
 def test_basket_thumbnail_program(basket_and_coupons, mock_context):
     """Basket thumbnail should be serialized for a program"""
+    from wagtail.images.views.serve import generate_image_url
+
     thumbnail_filename = "abcde.jpg"
     program_page = ProgramPageFactory.create(
         thumbnail_image__file__filename=thumbnail_filename
@@ -168,11 +169,8 @@ def test_basket_thumbnail_program(basket_and_coupons, mock_context):
     data = FullProductVersionSerializer(
         instance=product_version, context=mock_context
     ).data
-    assert (
-        data["thumbnail_url"]
-        == program_page.thumbnail_image.get_rendition(
-            CATALOG_COURSE_IMG_WAGTAIL_FILL
-        ).url
+    assert data["thumbnail_url"] == generate_image_url(
+        program_page.thumbnail_image, CATALOG_COURSE_IMG_WAGTAIL_FILL
     )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
This hopefully fixes some performance issues, at the very least it avoids the possibility of it, by switching to a function that generates the image url rather than using `get_rendition` which can potentially cause a fetch from S3 if the image isn't cached.

#### How should this be manually tested?
I haven't been able to reproduce this locally, so for local testing just verify that with S3 storage configured you can upload image assets and they display without error on the catalog pages.