### PR TITLE
Upgrade django-storages

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 beautifulsoup4==4.8.2
 celery==5.2.2
 celery-redbeat==2.0.0
-boto3==1.16.63
+boto3==1.26.18
 dj-database-url==0.5.0
 django==3.2.15
 django-anymail[mailgun]==8.4
@@ -17,7 +17,7 @@ django-user-agents==0.4.0
 djangorestframework==3.12.4
 djoser==2.1.0
 edx-api-client==0.10.0
-django-storages==1.11.1
+django-storages==1.13.1
 drf-flex-fields==0.8.5
 google-api-python-client==1.7.11
 google-auth==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,9 +27,9 @@ beautifulsoup4==4.8.2
     #   wagtail
 billiard==3.6.4.0
     # via celery
-boto3==1.16.63
+boto3==1.26.18
     # via -r requirements.in
-botocore==1.19.63
+botocore==1.29.18
     # via
     #   boto3
     #   s3transfer
@@ -140,7 +140,7 @@ django-redis==5.0.0
     # via -r requirements.in
 django-robots==4.0
     # via -r requirements.in
-django-storages==1.11.1
+django-storages==1.13.1
     # via -r requirements.in
 django-taggit==1.5.1
     # via wagtail
@@ -371,7 +371,7 @@ requests-toolbelt==0.9.1
     # via zeep
 rsa==4.8
     # via google-auth
-s3transfer==0.3.7
+s3transfer==0.6.0
     # via boto3
 sentry-sdk==1.11.0
     # via -r requirements.in


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #2484 

#### What's this PR do?
This upgrades `django-storages` and `boto3`. `django-storages` has had [this issue](https://github.com/jschneier/django-storages/pull/358) fixed since the version we're using. The upgrade to `boto3` is being done since that library was almost 2 years behind.

#### How should this be manually tested?
- Verify you can still upload images
- Verify the catalog pages still work both with images uploaded on this branch and existing images.