### PR TITLE
Updated nginx to drop Vary header on wagtail images

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -3,6 +3,11 @@ server {
     listen 8053 default_server;
     root /src;
 
+    include uwsgi_params;
+    uwsgi_pass_request_headers on;
+    uwsgi_pass_request_body on;
+    client_max_body_size 25M;
+
     location = /.well-known/dnt-policy.txt {
         return 204;
     }
@@ -21,11 +26,12 @@ server {
         try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
     }
 
-    location / {
-        include uwsgi_params;
+    location ~* /images/.*$ {
+        uwsgi_hide_header Vary;
         uwsgi_pass web:8051;
-        uwsgi_pass_request_headers on;
-        uwsgi_pass_request_body on;
-        client_max_body_size 25M;
+    }
+
+    location / {
+        uwsgi_pass web:8051;
     }
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -43,6 +43,26 @@ http {
         server_name _;
         root /app;
 
+        uwsgi_param QUERY_STRING $query_string;
+        uwsgi_param REQUEST_METHOD $request_method;
+        uwsgi_param CONTENT_TYPE $content_type;
+        uwsgi_param CONTENT_LENGTH $content_length;
+        uwsgi_param REQUEST_URI $request_uri;
+        uwsgi_param PATH_INFO $document_uri;
+        uwsgi_param DOCUMENT_ROOT $document_root;
+        uwsgi_param SERVER_PROTOCOL $server_protocol;
+        uwsgi_param REMOTE_ADDR $remote_addr;
+        uwsgi_param REMOTE_PORT $remote_port;
+        uwsgi_param SERVER_ADDR $server_addr;
+        uwsgi_param SERVER_PORT $server_port;
+        uwsgi_param SERVER_NAME $server_name;
+
+        uwsgi_pass_request_headers on;
+        uwsgi_pass_request_body on;
+        uwsgi_ignore_client_abort on;
+        
+        client_max_body_size 25M;
+
         location = /favicon.ico {
             try_files /static/images/favicon.ico /favicon.ico;
         }
@@ -66,25 +86,13 @@ http {
             try_files /fastly_verification.html =404;
         }
 
-        location / {
-            uwsgi_param QUERY_STRING $query_string;
-            uwsgi_param REQUEST_METHOD $request_method;
-            uwsgi_param CONTENT_TYPE $content_type;
-            uwsgi_param CONTENT_LENGTH $content_length;
-            uwsgi_param REQUEST_URI $request_uri;
-            uwsgi_param PATH_INFO $document_uri;
-            uwsgi_param DOCUMENT_ROOT $document_root;
-            uwsgi_param SERVER_PROTOCOL $server_protocol;
-            uwsgi_param REMOTE_ADDR $remote_addr;
-            uwsgi_param REMOTE_PORT $remote_port;
-            uwsgi_param SERVER_ADDR $server_addr;
-            uwsgi_param SERVER_PORT $server_port;
-            uwsgi_param SERVER_NAME $server_name;
+        location ~* /images/.*$ {
+            uwsgi_hide_header Vary;
             uwsgi_pass unix:/tmp/nginx.socket;
-            uwsgi_pass_request_headers on;
-            uwsgi_pass_request_body on;
-            uwsgi_ignore_client_abort on;
-            client_max_body_size 25M;
+        }
+
+        location / {
+            uwsgi_pass unix:/tmp/nginx.socket;
         }
     }
 }

--- a/loadtest.js
+++ b/loadtest.js
@@ -1,0 +1,33 @@
+// Creator: k6 Browser Recorder 0.6.0
+
+import { sleep, group } from 'k6'
+import http from 'k6/http'
+
+export const options = {}
+
+export default function main() {
+  let response
+
+  group('page_2 - http://xpro.odl.local:8053/catalog/', function () {
+    for (var i = 0; i < 10 ; i++) {
+      response = http.get('http://xpro.odl.local:8053/catalog/', {
+        headers: {
+          host: 'xpro.odl.local:8053',
+          'user-agent':
+            'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0',
+          accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+          'accept-language': 'en-US,en;q=0.5',
+          'accept-encoding': 'gzip, deflate',
+          connection: 'keep-alive',
+          cookie:
+            'csrftoken=fdY1Ywpf39ohyKG3wTNAGGGHkFGSKAzH5oCKLtfiQ9NuWHrTh0JHVNljUKiMG7IV; sessionid=.eJxVjDsOwjAQBe_iGlnxf6Gkzxksr3eNA8iR4qRC3B0ipYD2zcx7iZi2tcat8xInEhehxOl3w5Qf3HZA99Rus8xzW5cJ5a7Ig3Y5zsTP6-H-HdTU67e2gyKmgsAlaOOd8mzQIzijLThwweYQAFwiCoNVdGYwbAqSIc6kUbw_2po4GA:1ozibr:f80fQ7ovkY4wsmpk1DugFyxzjm7bgrRXbDKVQ8J8b7c',
+          'upgrade-insecure-requests': '1',
+        },
+      })
+    }
+  })
+
+  // Automatically added sleep
+  sleep(1)
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
#### What are the relevant tickets?
Part of #2484 

#### What's this PR do?
This updates the nginx config to drop the `Vary` header on wagtail images. This will allow fastly to consistently cache these regardless of any headers present.

#### How should this be manually tested?
Browse around and verify wagtail images don't return this header anymore. Other resources like html pages should still have it.