### PR TITLE
fix: enhance home page queries wagtail

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -720,11 +720,6 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
         """Returns the courseware object (Course, Program) associated with this page"""
         raise NotImplementedError
 
-    # @cached_property
-    # def child_pages(self):
-    #     """Gets child pages for the product detail page"""
-    #     return self.get_children().select_related("content_type").live()
-
     @property
     def outcomes(self):
         """Gets the learning outcomes child page"""

--- a/cms/models.py
+++ b/cms/models.py
@@ -430,9 +430,6 @@ class CertificateIndexPage(RoutablePageMixin, Page):
 class WagtailCachedPageMixin:
     """Mixin for common properties and child page queries for a WagtailPage"""
 
-    def __init__(self, *args, **kwargs):
-        super(WagtailCachedPageMixin, self).__init__(*args, **kwargs)
-
     @cached_property
     def child_pages(self):
         """Gets child pages for the wagtail page"""

--- a/cms/models.py
+++ b/cms/models.py
@@ -430,12 +430,15 @@ class CertificateIndexPage(RoutablePageMixin, Page):
 class WagtailCachedPageMixin:
     """Mixin for common properties and child page queries for a WagtailPage"""
 
+    def __init__(self, *args, **kwargs):
+        super(WagtailCachedPageMixin, self).__init__(*args, **kwargs)
+
     @cached_property
     def child_pages(self):
-        """Gets child pages for the product detail page"""
+        """Gets child pages for the wagtail page"""
         return self.get_children().select_related("content_type").live()
 
-    def get_child_page_of_type(self, cls):
+    def _get_child_page_of_type(self, cls):
         """Gets the first child page of the given type if it exists"""
 
         child = next(
@@ -501,49 +504,49 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
         """
         Gets the "Learning Experience" section subpage
         """
-        return self.get_child_page_of_type(LearningTechniquesPage)
+        return self._get_child_page_of_type(LearningTechniquesPage)
 
     @property
     def testimonials(self):
         """
         Gets the testimonials section subpage
         """
-        return self.get_child_page_of_type(UserTestimonialsPage)
+        return self._get_child_page_of_type(UserTestimonialsPage)
 
     @property
     def news_and_events(self):
         """
         Gets the news and events section subpage
         """
-        return self.get_child_page_of_type(NewsAndEventsPage)
+        return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def upcoming_courseware(self):
         """
         Gets the upcoming courseware section subpage
         """
-        return self.get_child_page_of_type(CoursesInProgramPage)
+        return self._get_child_page_of_type(CoursesInProgramPage)
 
     @property
     def inquiry_section(self):
         """
         Gets the "inquire now" section subpage
         """
-        return self.get_child_page_of_type(ForTeamsPage)
+        return self._get_child_page_of_type(ForTeamsPage)
 
     @property
     def about_mit_xpro(self):
         """
         Gets the "about mit xpro" section subpage
         """
-        return self.get_child_page_of_type(TextVideoSection)
+        return self._get_child_page_of_type(TextVideoSection)
 
     @property
     def image_carousel_section(self):
         """
         Gets the "image carousel" section sub page.
         """
-        return self.get_child_page_of_type(ImageCarouselPage)
+        return self._get_child_page_of_type(ImageCarouselPage)
 
     def get_context(self, request, *args, **kwargs):
         return {
@@ -707,17 +710,6 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
             "news_and_events": self.news_and_events,
         }
 
-    # def _get_child_page_of_type(self, cls):
-    #     """Gets the first child page of the given type if it exists"""
-    #     child = next(
-    #         (
-    #             page
-    #             for page in self.child_pages
-    #             if page.content_type.model == cls.__name__.lower()
-    #         ),
-    #         None,
-    #     )
-    #     return child.specific if child else None
 
     def save(self, clean=True, user=None, log_action=False, **kwargs):
         """If featured is True then set False in any existing product page(s)."""
@@ -739,48 +731,48 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
     @property
     def outcomes(self):
         """Gets the learning outcomes child page"""
-        return self.get_child_page_of_type(LearningOutcomesPage)
+        return self._get_child_page_of_type(LearningOutcomesPage)
 
     @property
     def who_should_enroll(self):
         """Gets the who should enroll child page"""
-        return self.get_child_page_of_type(WhoShouldEnrollPage)
+        return self._get_child_page_of_type(WhoShouldEnrollPage)
 
     @property
     def techniques(self):
         """Gets the learning techniques child page"""
-        return self.get_child_page_of_type(LearningTechniquesPage)
+        return self._get_child_page_of_type(LearningTechniquesPage)
 
     @property
     def testimonials(self):
         """Gets the testimonials carousel child page"""
-        return self.get_child_page_of_type(UserTestimonialsPage)
+        return self._get_child_page_of_type(UserTestimonialsPage)
 
     @property
     def faculty(self):
         """Gets the faculty carousel page"""
-        return self.get_child_page_of_type(FacultyMembersPage)
+        return self._get_child_page_of_type(FacultyMembersPage)
 
     @property
     def for_teams(self):
         """Gets the for teams section child page"""
-        return self.get_child_page_of_type(ForTeamsPage)
+        return self._get_child_page_of_type(ForTeamsPage)
 
     @property
     def faqs(self):
         """Gets the FAQs list from FAQs child page"""
-        faqs_page = self.get_child_page_of_type(FrequentlyAskedQuestionPage)
+        faqs_page = self._get_child_page_of_type(FrequentlyAskedQuestionPage)
         return FrequentlyAskedQuestion.objects.filter(faqs_page=faqs_page)
 
     @property
     def propel_career(self):
         """Gets the propel your career section child page"""
-        return self.get_child_page_of_type(TextSection)
+        return self._get_child_page_of_type(TextSection)
 
     @property
     def certificate_page(self):
         """Gets the certificate child page"""
-        return self.get_child_page_of_type(CertificatePage)
+        return self._get_child_page_of_type(CertificatePage)
 
     @property
     def is_course_page(self):
@@ -812,7 +804,7 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
         """
         Gets the news and events section subpage
         """
-        return self.get_child_page_of_type(NewsAndEventsPage)
+        return self._get_child_page_of_type(NewsAndEventsPage)
 
 
 class ProgramPage(ProductPage):
@@ -853,7 +845,7 @@ class ProgramPage(ProductPage):
     @property
     def course_lineup(self):
         """Gets the course carousel page"""
-        return self.get_child_page_of_type(CoursesInProgramPage)
+        return self._get_child_page_of_type(CoursesInProgramPage)
 
     @property
     def product(self):
@@ -964,7 +956,7 @@ class CoursePage(ProductPage):
         """
         if self.program_page and self.program_page.news_and_events:
             return self.program_page.news_and_events
-        return self.get_child_page_of_type(NewsAndEventsPage)
+        return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def course_pages(self):

--- a/cms/models.py
+++ b/cms/models.py
@@ -427,7 +427,28 @@ class CertificateIndexPage(RoutablePageMixin, Page):
         raise Http404()
 
 
-class HomePage(RoutablePageMixin, MetadataPageMixin, Page):
+class WagtailCachedPageMixin(object):
+
+    @cached_property
+    def child_pages(self):
+        """Gets child pages for the product detail page"""
+        return self.get_children().select_related("content_type").live()
+
+    def get_child_page_of_type(self, cls):
+        """Gets the first child page of the given type if it exists"""
+
+        child = next(
+            (
+                page
+                for page in self.child_pages
+                if page.content_type.model == cls.__name__.lower()
+            ),
+            None,
+        )
+        return child.specific if child else None
+
+
+class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Page):
     """
     CMS Page representing the home/root route
     """
@@ -474,69 +495,54 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, Page):
         "SignatoryIndexPage",
     ]
 
-    def _get_child_page_of_type(self, cls):
-        """Gets the first child page of the given type if it exists"""
-        child = self.get_children().type(cls).live().first()
-        return child.specific if child else None
-
     @property
     def learning_experience(self):
         """
         Gets the "Learning Experience" section subpage
         """
-        return list(LearningTechniquesPage.objects.child_of(self))[0]
-
-        # return self._get_child_page_of_type(LearningTechniquesPage)
+        return self.get_child_page_of_type(LearningTechniquesPage)
 
     @property
     def testimonials(self):
         """
         Gets the testimonials section subpage
         """
-        # breakpoint()
-        return list(UserTestimonialsPage.objects.child_of(self))[0]
-        # return self._get_child_page_of_type(UserTestimonialsPage)
+        return self.get_child_page_of_type(UserTestimonialsPage)
 
     @property
     def news_and_events(self):
         """
         Gets the news and events section subpage
         """
-        return list(NewsAndEventsPage.objects.child_of(self))[0]
-        # return self._get_child_page_of_type(NewsAndEventsPage)
+        return self.get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def upcoming_courseware(self):
         """
         Gets the upcoming courseware section subpage
         """
-        return list(CoursesInProgramPage.objects.child_of(self))[0]
-        # return self._get_child_page_of_type(CoursesInProgramPage)
+        return self.get_child_page_of_type(CoursesInProgramPage)
 
     @property
     def inquiry_section(self):
         """
         Gets the "inquire now" section subpage
         """
-        return list(ForTeamsPage.objects.child_of(self))[0]
-        # return self._get_child_page_of_type(ForTeamsPage)
+        return self.get_child_page_of_type(ForTeamsPage)
 
     @property
     def about_mit_xpro(self):
         """
         Gets the "about mit xpro" section subpage
         """
-        return list(TextVideoSection.objects.child_of(self))[0]
-
-        # return self._get_child_page_of_type(TextVideoSection)
+        return self.get_child_page_of_type(TextVideoSection)
 
     @property
     def image_carousel_section(self):
         """
         Gets the "image carousel" section sub page.
         """
-        return list(ImageCarouselPage.objects.child_of(self))[0]
-        # return self._get_child_page_of_type(ImageCarouselPage)
+        return self.get_child_page_of_type(ImageCarouselPage)
 
     def get_context(self, request, *args, **kwargs):
         return {

--- a/cms/models.py
+++ b/cms/models.py
@@ -562,7 +562,7 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
         }
 
 
-class ProductPage(MetadataPageMixin, Page):
+class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
     """
     Abstract product page
     """
@@ -707,17 +707,17 @@ class ProductPage(MetadataPageMixin, Page):
             "news_and_events": self.news_and_events,
         }
 
-    def _get_child_page_of_type(self, cls):
-        """Gets the first child page of the given type if it exists"""
-        child = next(
-            (
-                page
-                for page in self.child_pages
-                if page.content_type.model == cls.__name__.lower()
-            ),
-            None,
-        )
-        return child.specific if child else None
+    # def _get_child_page_of_type(self, cls):
+    #     """Gets the first child page of the given type if it exists"""
+    #     child = next(
+    #         (
+    #             page
+    #             for page in self.child_pages
+    #             if page.content_type.model == cls.__name__.lower()
+    #         ),
+    #         None,
+    #     )
+    #     return child.specific if child else None
 
     def save(self, clean=True, user=None, log_action=False, **kwargs):
         """If featured is True then set False in any existing product page(s)."""
@@ -731,56 +731,56 @@ class ProductPage(MetadataPageMixin, Page):
         """Returns the courseware object (Course, Program) associated with this page"""
         raise NotImplementedError
 
-    @cached_property
-    def child_pages(self):
-        """Gets child pages for the product detail page"""
-        return self.get_children().select_related("content_type").live()
+    # @cached_property
+    # def child_pages(self):
+    #     """Gets child pages for the product detail page"""
+    #     return self.get_children().select_related("content_type").live()
 
     @property
     def outcomes(self):
         """Gets the learning outcomes child page"""
-        return self._get_child_page_of_type(LearningOutcomesPage)
+        return self.get_child_page_of_type(LearningOutcomesPage)
 
     @property
     def who_should_enroll(self):
         """Gets the who should enroll child page"""
-        return self._get_child_page_of_type(WhoShouldEnrollPage)
+        return self.get_child_page_of_type(WhoShouldEnrollPage)
 
     @property
     def techniques(self):
         """Gets the learning techniques child page"""
-        return self._get_child_page_of_type(LearningTechniquesPage)
+        return self.get_child_page_of_type(LearningTechniquesPage)
 
     @property
     def testimonials(self):
         """Gets the testimonials carousel child page"""
-        return self._get_child_page_of_type(UserTestimonialsPage)
+        return self.get_child_page_of_type(UserTestimonialsPage)
 
     @property
     def faculty(self):
         """Gets the faculty carousel page"""
-        return self._get_child_page_of_type(FacultyMembersPage)
+        return self.get_child_page_of_type(FacultyMembersPage)
 
     @property
     def for_teams(self):
         """Gets the for teams section child page"""
-        return self._get_child_page_of_type(ForTeamsPage)
+        return self.get_child_page_of_type(ForTeamsPage)
 
     @property
     def faqs(self):
         """Gets the FAQs list from FAQs child page"""
-        faqs_page = self._get_child_page_of_type(FrequentlyAskedQuestionPage)
+        faqs_page = self.get_child_page_of_type(FrequentlyAskedQuestionPage)
         return FrequentlyAskedQuestion.objects.filter(faqs_page=faqs_page)
 
     @property
     def propel_career(self):
         """Gets the propel your career section child page"""
-        return self._get_child_page_of_type(TextSection)
+        return self.get_child_page_of_type(TextSection)
 
     @property
     def certificate_page(self):
         """Gets the certificate child page"""
-        return self._get_child_page_of_type(CertificatePage)
+        return self.get_child_page_of_type(CertificatePage)
 
     @property
     def is_course_page(self):
@@ -812,7 +812,7 @@ class ProductPage(MetadataPageMixin, Page):
         """
         Gets the news and events section subpage
         """
-        return self._get_child_page_of_type(NewsAndEventsPage)
+        return self.get_child_page_of_type(NewsAndEventsPage)
 
 
 class ProgramPage(ProductPage):
@@ -853,7 +853,7 @@ class ProgramPage(ProductPage):
     @property
     def course_lineup(self):
         """Gets the course carousel page"""
-        return self._get_child_page_of_type(CoursesInProgramPage)
+        return self.get_child_page_of_type(CoursesInProgramPage)
 
     @property
     def product(self):
@@ -964,7 +964,7 @@ class CoursePage(ProductPage):
         """
         if self.program_page and self.program_page.news_and_events:
             return self.program_page.news_and_events
-        return self._get_child_page_of_type(NewsAndEventsPage)
+        return self.get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def course_pages(self):

--- a/cms/models.py
+++ b/cms/models.py
@@ -707,7 +707,6 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
             "news_and_events": self.news_and_events,
         }
 
-
     def save(self, clean=True, user=None, log_action=False, **kwargs):
         """If featured is True then set False in any existing product page(s)."""
         if self.featured:

--- a/cms/models.py
+++ b/cms/models.py
@@ -427,7 +427,8 @@ class CertificateIndexPage(RoutablePageMixin, Page):
         raise Http404()
 
 
-class WagtailCachedPageMixin(object):
+class WagtailCachedPageMixin:
+    """Mixin for common properties and child page queries for a WagtailPage"""
 
     @cached_property
     def child_pages(self):

--- a/cms/models.py
+++ b/cms/models.py
@@ -484,49 +484,59 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, Page):
         """
         Gets the "Learning Experience" section subpage
         """
-        return self._get_child_page_of_type(LearningTechniquesPage)
+        return list(LearningTechniquesPage.objects.child_of(self))[0]
+
+        # return self._get_child_page_of_type(LearningTechniquesPage)
 
     @property
     def testimonials(self):
         """
         Gets the testimonials section subpage
         """
-        return self._get_child_page_of_type(UserTestimonialsPage)
+        # breakpoint()
+        return list(UserTestimonialsPage.objects.child_of(self))[0]
+        # return self._get_child_page_of_type(UserTestimonialsPage)
 
     @property
     def news_and_events(self):
         """
         Gets the news and events section subpage
         """
-        return self._get_child_page_of_type(NewsAndEventsPage)
+        return list(NewsAndEventsPage.objects.child_of(self))[0]
+        # return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property
     def upcoming_courseware(self):
         """
         Gets the upcoming courseware section subpage
         """
-        return self._get_child_page_of_type(CoursesInProgramPage)
+        return list(CoursesInProgramPage.objects.child_of(self))[0]
+        # return self._get_child_page_of_type(CoursesInProgramPage)
 
     @property
     def inquiry_section(self):
         """
         Gets the "inquire now" section subpage
         """
-        return self._get_child_page_of_type(ForTeamsPage)
+        return list(ForTeamsPage.objects.child_of(self))[0]
+        # return self._get_child_page_of_type(ForTeamsPage)
 
     @property
     def about_mit_xpro(self):
         """
         Gets the "about mit xpro" section subpage
         """
-        return self._get_child_page_of_type(TextVideoSection)
+        return list(TextVideoSection.objects.child_of(self))[0]
+
+        # return self._get_child_page_of_type(TextVideoSection)
 
     @property
     def image_carousel_section(self):
         """
         Gets the "image carousel" section sub page.
         """
-        return self._get_child_page_of_type(ImageCarouselPage)
+        return list(ImageCarouselPage.objects.child_of(self))[0]
+        # return self._get_child_page_of_type(ImageCarouselPage)
 
     def get_context(self, request, *args, **kwargs):
         return {

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -159,6 +159,9 @@ def test_home_page_testimonials():
     """
     home_page = HomePageFactory.create()
     assert not home_page.testimonials
+
+    del home_page.child_pages
+
     testimonials_page = UserTestimonialsPageFactory.create(
         parent=home_page,
         heading="heading",
@@ -188,6 +191,8 @@ def test_home_page_news_and_events():
     """
     home_page = HomePageFactory.create()
     assert not home_page.news_and_events
+    del home_page.child_pages
+
     news_and_events_page = NewsAndEventsPageFactory.create(
         parent=home_page,
         heading="heading",
@@ -221,6 +226,9 @@ def test_home_page_inquiry_section():
     """
     home_page = HomePageFactory.create()
     assert not home_page.inquiry_section
+
+    del home_page.child_pages
+
     inquiry_page = ForTeamsPageFactory.create(
         parent=home_page,
         content="<p>content</p>",
@@ -241,6 +249,9 @@ def test_home_page_upcoming_courseware():
     """
     home_page = HomePageFactory.create()
     assert not home_page.upcoming_courseware
+
+    del home_page.child_pages
+
     course = CourseFactory.create(page=None)
     carousel_page = CoursesInProgramPageFactory.create(
         parent=home_page,
@@ -262,6 +273,9 @@ def test_home_page_about_mit_xpro():
     """
     home_page = HomePageFactory.create()
     assert not home_page.about_mit_xpro
+
+    del home_page.child_pages
+
     about_page = TextVideoSectionFactory.create(
         parent=home_page,
         content="<p>content</p>",
@@ -284,6 +298,9 @@ def test_image_carousel_section():
     """
     home_page = HomePageFactory.create()
     assert not home_page.image_carousel_section
+
+    del home_page.child_pages
+
     image_carousel_page = ImageCarouselPageFactory.create(
         parent=home_page,
         title="title",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2484

#### What's this PR do?
- Attempts to reduce the number of queries we are hitting on home page
- Refactors the HomePage and Product Page common functionality into a mixin
- Reduces the number of queries on HomePage

#### How should this be manually tested?
Before testing it might be a good idea to setup [django-silk](https://github.com/jazzband/django-silk) to see the performances of the pages since I've been testing it with that.
- Make sure to add a HomePage and all the child pages in it through `/cms`
- Make sure that you have enough program and course, external program, external course pages, and all their child pages through `/cms`
- Make sure that your HomePage `http://xpro.odl.local:8053/` works fine and shows all the child pages
- Make sure the number of queries on HomePage has been reduced w.r.t to the master branch
- Make sure the Course, EXternal Course, Program, and External Programs are working fine. Also, notice that the number of queries has been reduced w.r.t master branch


#### Screenshots (if appropriate)
**Queries on HomePage After**

<img width="306" alt="image" src="https://user-images.githubusercontent.com/34372316/206190849-a46c2de0-ffdc-44d3-9f7d-d5faa3e772d4.png">

**HomePage queries before:**
<img width="151" alt="image" src="https://user-images.githubusercontent.com/34372316/206196853-72084d41-1ed9-4736-8374-7d725cd6e3af.png">




