### PR TITLE
Setup django-silk when DEBUG=True

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,6 @@ services:
       - .:/src
       - django_media:/var/media
     environment:
-      DEBUG: 'True'
       NODE_ENV: 'development'
       WEBPACK_USE_DEV_SERVER: 'True'
       WEBPACK_DEV_SERVER_PORT: ${WEBPACK_DEV_SERVER_PORT:-8052}
@@ -16,7 +15,6 @@ services:
       - .:/src
       - django_media:/var/media
     environment:
-      DEBUG: 'True'
       NODE_ENV: 'development'
       WEBPACK_USE_DEV_SERVER: 'True'
       WEBPACK_DEV_SERVER_PORT: ${WEBPACK_DEV_SERVER_PORT:-8052}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3.6'
 
 x-environment:
   &py-environment
-  DEBUG: 'False'
   NODE_ENV: 'production'
   DEV_ENV: 'True'  # necessary to have nginx connect to web container
   SECRET_KEY: local_unsafe_key

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -220,8 +220,14 @@ MIDDLEWARE = (
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:
-    INSTALLED_APPS += ("nplusone.ext.django",)
-    MIDDLEWARE += ("nplusone.ext.django.NPlusOneMiddleware",)
+    INSTALLED_APPS += (
+        "nplusone.ext.django",
+        "silk",
+    )
+    MIDDLEWARE += (
+        "nplusone.ext.django.NPlusOneMiddleware",
+        "silk.middleware.SilkyMiddleware",
+    )
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
@@ -314,6 +320,10 @@ ROBOTS_CACHE_TIMEOUT = get_int(
     default=60 * 60 * 24,
     description="How long the robots.txt file should be cached",
 )
+
+# profiling
+
+SILKY_ANALYZE_QUERIES = True
 
 # social auth
 AUTHENTICATION_BACKENDS = (

--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -94,6 +94,14 @@ urlpatterns = (
         re_path(r"^cms/", include(wagtailadmin_urls)),
         re_path(r"^documents/", include(wagtaildocs_urls)),
     ]
+    + (
+        [
+            path("__debug__/", include("debug_toolbar.urls")),
+            path("silk/", include("silk.urls", namespace="silk")),
+        ]
+        if settings.DEBUG
+        else []
+    )
     + decorate_urlpatterns(
         # NOTE: This route enables dynamic Wagtail image loading. It comes directly from the Wagtail docs:
         #       https://docs.wagtail.io/en/v2.7/advanced_topics/images/image_serve_view.html#setup
@@ -120,8 +128,3 @@ urlpatterns = (
 
 handler404 = not_found_handler
 handler500 = server_error_handler
-
-if settings.DEBUG:
-    import debug_toolbar  # pylint: disable=wrong-import-position, wrong-import-order
-
-    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ django-hijack-admin==2.1.10
 django-ipware==3.0.0
 django-redis~=5.0.0
 django-robots~=4.0.0
+django-silk
 django-webpack-loader==0.7.0
 django-oauth-toolkit==1.4.0
 django-user-agents==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ attrs==21.4.0
     # via
     #   pytest
     #   zeep
+autopep8==2.0.0
+    # via django-silk
 backcall==0.2.0
     # via ipython
 beautifulsoup4==4.8.2
@@ -95,6 +97,7 @@ django==3.2.15
     #   django-filter
     #   django-oauth-toolkit
     #   django-redis
+    #   django-silk
     #   django-storages
     #   django-taggit
     #   django-treebeard
@@ -139,6 +142,8 @@ django-oauth-toolkit==1.4.0
 django-redis==5.0.0
     # via -r requirements.in
 django-robots==4.0
+    # via -r requirements.in
+django-silk==5.0.2
     # via -r requirements.in
 django-storages==1.13.1
     # via -r requirements.in
@@ -199,6 +204,8 @@ google-auth-httplib2==0.1.0
     # via google-api-python-client
 google-auth-oauthlib==0.5.0
     # via pygsheets
+gprof2dot==2022.7.29
+    # via django-silk
 html5lib==1.1
     # via
     #   mitol-django-mail
@@ -222,7 +229,9 @@ itypes==1.2.0
 jedi==0.18.1
     # via ipython
 jinja2==3.0.3
-    # via coreschema
+    # via
+    #   coreschema
+    #   django-silk
 jmespath==0.10.0
     # via
     #   boto3
@@ -302,6 +311,8 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
+pycodestyle==2.10.0
+    # via autopep8
 pycountry==19.7.15
     # via -r requirements.in
 pycparser==2.21
@@ -328,6 +339,7 @@ python-dateutil==2.5.3
     # via
     #   botocore
     #   celery-redbeat
+    #   django-silk
     #   edx-api-client
     #   faker
     #   hubspot-api-client
@@ -353,6 +365,7 @@ requests==2.27.1
     #   coreapi
     #   django-anymail
     #   django-oauth-toolkit
+    #   django-silk
     #   edx-api-client
     #   mitol-django-common
     #   mitol-django-digital-credentials
@@ -401,7 +414,9 @@ social-auth-core==4.2.0
 soupsieve==2.3.1
     # via beautifulsoup4
 sqlparse==0.4.2
-    # via django
+    # via
+    #   django
+    #   django-silk
 tablib[xls,xlsx]==3.2.0
     # via wagtail
 telepath==0.2
@@ -410,6 +425,8 @@ tenacity==8.0.1
     # via celery-redbeat
 toml==0.10.2
     # via pytest
+tomli==2.0.1
+    # via autopep8
 toolz==0.11.2
     # via mitol-django-mail
 traitlets==5.1.1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds `django-silk` and makes it available when `DEBUG=True`, this will initially be just for local and possibly RC debugging.

#### How should this be manually tested?
- With `DEBUG=True`, verify you can go to `/silk/` and see profiling results as you navigate the app
- With `DEBUG=False`, verify `/silk/` is unreachable