### PR TITLE
Fix unused coupons query

### DIFF
--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1389,17 +1389,17 @@ def test_fetch_and_serialize_unused_coupons(user):
     if those coupons are the most recent versions and are unexpired
     """
     now = now_in_utc()
-    future = now + timedelta(days=5)
+    near_future = now + timedelta(days=2)
+    far_future = now + timedelta(days=5)
     past = now - timedelta(days=5)
 
     coupons = CouponFactory.create_batch(2)
     # Create 3 payment versions – the first 2 will apply to the same coupon, and the
-    # first will be the most up-to-date version for the coupon. The last payment version
+    # second will be the most recent version for the coupon. The last payment version
     # will be set to expired.
     payment_versions = CouponPaymentVersionFactory.create_batch(
         3,
-        expiration_date=factory.Iterator([future, future, past]),
-        created_on=factory.Iterator([future, past, future]),
+        expiration_date=factory.Iterator([far_future, near_future, past]),
         payment=factory.Iterator(
             [coupons[0].payment, coupons[0].payment, coupons[1].payment]
         ),
@@ -1407,7 +1407,7 @@ def test_fetch_and_serialize_unused_coupons(user):
     product_coupons = CouponEligibilityFactory.create_batch(
         2, coupon=factory.Iterator(coupons)
     )
-    expected_payment_version = payment_versions[0]
+    expected_payment_version = payment_versions[1]
     expected_product_coupon = product_coupons[0]
 
     # Create assignments for the user and set all to be unredeemed/unused


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2508 

#### What's this PR do?
Makes the query for a user's unused coupons marginally more efficient, and fixes a bug that returns the same coupon multiple times if there are multiple `CouponPaymentVersion` objects for it.

#### How should this be manually tested?
On master branch:
- As a superuser, go to `../ecommerce/admin/coupons/`, create a new coupon code for a certain course, expiring sometime in the future.
- Find the `CouponPaymentVersion` for the coupon you just created, change the expiration date, and save as new.
- Create a csv file containing 1 email for a user (can be the superuser).
- Go to '../ecommerce/admin/enroll/',  choose the above csv file, the coupon course, and the coupon, then click 'Enroll Learners'
- Log in as the enrolled user if you aren't already (refresh the page if you are).  You should see a "You have an unused coupon" banner.
- Go to '../dashboard/'.  Under the "Unredeemed Enrollment Code(s)" section, you will see the same course and enrollment code listed twice, with the original and updated expiration dates.  This is wrong.
- Switch to this branch.  Refresh the same page. You should still see the "unused coupon" banner, and the course/enrollment code should only be listed once, with the most up-to-date expiration.



#### Any background context you want to provide?
EXPLAIN ANALYZE results:

Before:
 Planning Time: 2.492 ms
 Execution Time: 0.275 ms

![Screen Shot 2022-12-06 at 9 08 56 AM](https://user-images.githubusercontent.com/187676/205934671-83988910-7a19-4647-8a5c-a7acb14159db.png)


After:
 Planning Time: 2.018 ms
 Execution Time: 0.209 ms

![Screen Shot 2022-12-06 at 9 10 05 AM](https://user-images.githubusercontent.com/187676/205934690-6ad08a79-48c5-4eee-81eb-acfc5a29f897.png)



#### Screenshots (if appropriate)
Before:
![Screen Shot 2022-12-05 at 4 17 49 PM](https://user-images.githubusercontent.com/187676/205753097-afa72368-8328-4ca9-a81c-e7684bca28c1.png)


After:
![Screen Shot 2022-12-05 at 6 07 41 PM](https://user-images.githubusercontent.com/187676/205762634-5347fb00-a892-49c0-88f0-9f8c919fd27a.png)


PS "Invalid date" due to null date on either coupon payment version expiration date or course start dates.  I will open another issue for this after talking w/Peter (not sure if null dates should be allowed for these or not)
