### PR TITLE
Reduce API queries

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -411,6 +411,8 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             list of CourseRun: Unexpired and unenrolled Course runs
 
         """
+        # `enrolled_runs` is a prefetched attribute.
+        # Added a conditional to avoid issues when prefetched attribute is not there.
         if hasattr(self, "enrolled_runs"):
             enrolled_runs = [run.id for run in self.enrolled_runs]
         else:

--- a/courses/models.py
+++ b/courses/models.py
@@ -241,6 +241,11 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             else []
         )
 
+    @property
+    def course_runs(self):
+        """All course runs related to a program"""
+        return [run for course in self.courses.all() for run in course.courseruns.all()]
+
     def __str__(self):
         title = f"{self.readable_id} | {self.title}"
         return title if len(title) <= 100 else title[:97] + "..."

--- a/courses/models.py
+++ b/courses/models.py
@@ -411,9 +411,12 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             list of CourseRun: Unexpired and unenrolled Course runs
 
         """
-        enrolled_runs = user.courserunenrollment_set.filter(
-            run__course=self
-        ).values_list("run__id", flat=True)
+        if hasattr(self, "enrolled_runs"):
+            enrolled_runs = [run.id for run in self.enrolled_runs]
+        else:
+            enrolled_runs = user.courserunenrollment_set.filter(
+                run__course=self
+            ).values_list("run__id", flat=True)
         return [run for run in self.unexpired_runs if run.id not in enrolled_runs]
 
     class Meta:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxpro/issues/2520

#### What's this PR do?
Reduces queries for the following APIs:

1. `api/programs/`
2. `api/course_runs/`
3. `api/courses/`

#### How should this be manually tested?

1. Make sure that you have enough data for Programs, Courses and Course runs.
2. Hit the endpoints mentioned above.
3. Monitor Django-Silk at `/silk/requests/`
4. There should be no N+1 queries.
(Note: `api/course_runs/` still contains a few N+1 queries as I could not figure out a good fix. It still reduces queries by 80%-90%)

