### PR TITLE
Force django app to load ASAP after uwsgi workers are restarted/forked

### DIFF
--- a/mitxpro/wsgi.py
+++ b/mitxpro/wsgi.py
@@ -1,12 +1,15 @@
 """
-WSGI config for ui app.
+WSGI config for xpro django app.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+
+Based on https://gist.github.com/rbarrois/044b2d9f7052a6542f7a3d79695d64c6
 """
 import io
+import logging
 import os
 import sys
 import wsgiref.util
@@ -14,56 +17,66 @@ import wsgiref.util
 import uwsgidecorators
 
 
+# pylint: disable=global-statement,unused-argument
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mitxpro.settings")
 
 
-DJANGO_WARMUP_URL = os.environ.get('DJANGO_WARMUP_URL', '/')
+DJANGO_WARMUP_URL = os.environ.get("DJANGO_WARMUP_URL", "/")  # Default to home page
 
-application = None
+log = logging.getLogger()
 
 
 @uwsgidecorators.postfork
 def setup_postfork():
-    """Ensure each worker is warm *after* fork as well."""
+    """Ensure each worker is warm after fork as well."""
     # Warmup as well
     warmup_django()
 
 
 def warmup_django(close_connections=False):
+    """Warm up the lazy django app"""
     from django.conf import settings
-    print("WARMUP")
+
+    global application
+
+    log.debug("warming up")
+
     if settings.ALLOWED_HOSTS:
-        host = settings.ALLOWED_HOSTS[0].replace('*', 'warmup')
+        host = settings.ALLOWED_HOSTS[0].replace("*", "warmup")
     else:
-        host = 'localhost'
+        host = "localhost"
     env = {
-        'REQUEST_METHOD': 'GET',
-        'PATH_INFO': DJANGO_WARMUP_URL,
-        'SERVER_NAME': host,
-        'wsgi.error': sys.stderr,
+        "REQUEST_METHOD": "GET",
+        "PATH_INFO": DJANGO_WARMUP_URL,
+        "SERVER_NAME": host,
+        "wsgi.error": sys.stderr,
     }
     # Setup the whole wsgi standard headers we do not care about.
     wsgiref.util.setup_testing_defaults(env)
 
     def start_response(status, response_headers, exc_info=None):
-        print("START RESPONSE")
+        """Start the warmup response"""
+        log.debug("starting warmup response")
         assert status == "200 OK"
         fake_socket = io.BytesIO()
         return fake_socket
 
-    global application
     application(env, start_response)
 
     if close_connections:
         # Close connections before forking
-        print("CLOSE CONNECTION")
         from django.db import connections
+
+        log.debug("Closing connection")
         for conn in connections.all():
             conn.close()
 
 
 def get_wsgi_application():
+    """Call the standard wsgi.get_wsgi_application() and then the warmup function"""
     from django.core import wsgi
+
     global application
     application = wsgi.get_wsgi_application()
     if DJANGO_WARMUP_URL:

--- a/mitxpro/wsgi.py
+++ b/mitxpro/wsgi.py
@@ -6,10 +6,69 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
+import io
 import os
+import sys
+import wsgiref.util
 
-from django.core.wsgi import get_wsgi_application
+import uwsgidecorators
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mitxpro.settings")
 
-application = get_wsgi_application()  # pylint: disable=invalid-name
+
+DJANGO_WARMUP_URL = os.environ.get('DJANGO_WARMUP_URL', '/')
+
+application = None
+
+
+@uwsgidecorators.postfork
+def setup_postfork():
+    """Ensure each worker is warm *after* fork as well."""
+    # Warmup as well
+    warmup_django()
+
+
+def warmup_django(close_connections=False):
+    from django.conf import settings
+    print("WARMUP")
+    if settings.ALLOWED_HOSTS:
+        host = settings.ALLOWED_HOSTS[0].replace('*', 'warmup')
+    else:
+        host = 'localhost'
+    env = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': DJANGO_WARMUP_URL,
+        'SERVER_NAME': host,
+        'wsgi.error': sys.stderr,
+    }
+    # Setup the whole wsgi standard headers we do not care about.
+    wsgiref.util.setup_testing_defaults(env)
+
+    def start_response(status, response_headers, exc_info=None):
+        print("START RESPONSE")
+        assert status == "200 OK"
+        fake_socket = io.BytesIO()
+        return fake_socket
+
+    global application
+    application(env, start_response)
+
+    if close_connections:
+        # Close connections before forking
+        print("CLOSE CONNECTION")
+        from django.db import connections
+        for conn in connections.all():
+            conn.close()
+
+
+def get_wsgi_application():
+    from django.core import wsgi
+    global application
+    application = wsgi.get_wsgi_application()
+    if DJANGO_WARMUP_URL:
+        warmup_django(close_connections=True)
+    return application
+
+
+application = get_wsgi_application()

--- a/mitxpro/wsgi.py
+++ b/mitxpro/wsgi.py
@@ -15,6 +15,9 @@ import sys
 import wsgiref.util
 
 import uwsgidecorators
+from django.conf import settings
+from django.core import wsgi
+from django.db import connections
 
 
 # pylint: disable=global-statement,unused-argument
@@ -36,8 +39,6 @@ def setup_postfork():
 
 def warmup_django(close_connections=False):
     """Warm up the lazy django app"""
-    from django.conf import settings
-
     global application
 
     log.debug("warming up")
@@ -66,8 +67,6 @@ def warmup_django(close_connections=False):
 
     if close_connections:
         # Close connections before forking
-        from django.db import connections
-
         log.debug("Closing connection")
         for conn in connections.all():
             conn.close()
@@ -75,8 +74,6 @@ def warmup_django(close_connections=False):
 
 def get_wsgi_application():
     """Call the standard wsgi.get_wsgi_application() and then the warmup function"""
-    from django.core import wsgi
-
     global application
     application = wsgi.get_wsgi_application()
     if DJANGO_WARMUP_URL:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2526 

#### What's this PR do?
Based off a gist, loads the xpro home page (or another url defined by `DJANGO_WARMUP_URL` env variable) after uwsgi starts the app and/or restarts workers.

#### How should this be manually tested?
Everything should still work as before.

You can set `MITXPRO_LOG_LEVEL=DEBUG` and then repeatedly reload the `/catalog` page (manually or via load test), eventually you should see this in the logs:

```
web_1     | worker 2 killed successfully (pid: 250)
web_1     | Respawned uWSGI worker 2 (new pid: 379)
web_1     | spawned 2 offload threads for uWSGI worker 2
web_1     | [2022-12-14 17:35:44] DEBUG 379 [root] wsgi.py:40 - [583ea7151673] - warming up

.....

web_1     | [2022-12-14 17:35:44] DEBUG 379 [root] wsgi.py:56 - [583ea7151673] - starting warmup response
```


#### Any background context you want to provide?
https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html#dealing-with-ultra-lazy-apps-like-django

