### PR TITLE
Adds a separate step for black formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Lint
         run: pylint ./**/*.py
 
-      - name: Black Formatting
-        run: black . --check
+      - name: Code Formatting (Black)
+        run: black --check .
 
       # Configurations required for elasticsearch.
       - name: Configure sysctl limits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Lint
         run: pylint ./**/*.py
 
+      - name: Black Formatting
+        run: black . --check
+
       # Configurations required for elasticsearch.
       - name: Configure sysctl limits
         run: |

--- a/cms/models.py
+++ b/cms/models.py
@@ -456,8 +456,7 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
 
     template = "home_page.html"
 
-    subhead = models.CharField(
-        max_length=255,
+    subhead = models.CharField(max_length=255,
         help_text="The subhead to display in the hero section on the home page.",
     )
     background_image = models.ForeignKey(

--- a/cms/models.py
+++ b/cms/models.py
@@ -456,7 +456,8 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
 
     template = "home_page.html"
 
-    subhead = models.CharField(max_length=255,
+    subhead = models.CharField(
+        max_length=255,
         help_text="The subhead to display in the hero section on the home page.",
     )
     background_image = models.ForeignKey(

--- a/scripts/test/python_tests.sh
+++ b/scripts/test/python_tests.sh
@@ -16,7 +16,6 @@ function run_test {
     return $status
 }
 
-run_test black --check .
 run_test pytest
 run_test ./scripts/test/detect_missing_migrations.sh
 run_test ./scripts/test/no_auto_migrations.sh


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Adds a separate step for black formatting check. It is better to add an extra step as we did for Pylint.
MOTIVATION: Black formatting check is added with the `Tests` step. If there is any issue with the formatting and everything else is fine then it is a bit difficult to find the cause of failure of the `Tests` step as happened [here](https://github.com/mitodl/mitxpro/actions/runs/3695611774/jobs/6258212803).

#### How should this be manually tested?
Maybe commit a formatting issue with these changes and push the change. CI should fail at the newly added formatting step.

#### Screenshots (if appropriate)
<img width="1029" alt="Screenshot 2022-12-15 at 11 34 20 AM" src="https://user-images.githubusercontent.com/52656433/207789577-e6c30fe9-2241-47e6-9280-6e27eeca23fb.png">

