### PR TITLE
Add frontend caching for homepage

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags render_bundle cache%}
+{% load static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags render_bundle cache %}
 
 {% block title %}{{ site_name }}{% endblock %}
 

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags render_bundle %}
+{% load static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags render_bundle cache%}
 
 {% block title %}{{ site_name }}{% endblock %}
 
@@ -19,6 +19,7 @@
 {% endblock %}
 
 {% block content %}
+  {% cache 86400 self.id %}
   {% include "partials/hero.html" with action_title="Watch Now" action_url="#" %}
   {% if upcoming_courseware %}
     {% pageurl catalog_page as catalog_url %}
@@ -30,6 +31,7 @@
   {% if news_and_events %} {% include "partials/news-and-events-carousel.html" with page=news_and_events %} {% endif %}
   {% if inquiry_section %} {% include "partials/for-teams.html" with page=inquiry_section %} {% endif %}
   {% if image_carousel_section %} {% include "partials/image-carousel.html" with page=image_carousel_section %} {% endif %}
+  {% endcache %}
 {% endblock %}
 {% block contact-us %}
     {% if hubspot_new_courses_form_guid and hubspot_portal_id %}

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -20,7 +20,7 @@
 
 {% block content %}
   {% include "partials/hero.html" with action_title="Watch Now" action_url="#" %}
-  {% cache 86400 self.id %}
+  {% cache 300 self.id %}
   {% if upcoming_courseware %}
     {% pageurl catalog_page as catalog_url %}
     {% include "partials/course-carousel.html" with page=upcoming_courseware button_title="View All" button_url=catalog_url %}

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -19,8 +19,8 @@
 {% endblock %}
 
 {% block content %}
-  {% cache 86400 self.id %}
   {% include "partials/hero.html" with action_title="Watch Now" action_url="#" %}
+  {% cache 86400 self.id %}
   {% if upcoming_courseware %}
     {% pageurl catalog_page as catalog_url %}
     {% include "partials/course-carousel.html" with page=upcoming_courseware button_title="View All" button_url=catalog_url %}

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
+from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
 from wagtail.core.models import Site
@@ -98,6 +99,8 @@ def test_home_page_view(client, wagtail_basics):
         '<a id="actionButton" class="btn btn-primary text-uppercase px-5 py-2 action-button" href="#">Watch Now</a>'
         not in content
     )
+
+    cache.clear()
 
     # add video section
     about_page = TextVideoSection(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxpro/issues/2521

#### What's this PR do?

- Adds frontend caching for the homepage.
- Caching reduces about 50%+ queries.
- Cache invalidates after 24hrs.

#### How should this be manually tested?

- Make sure that you have enough data on the home page
- Visit the home page with these changes.
- Monitor Django Silk at `/silk/requests/`. Note the number of queries.
- Check out these changes and visit the home page several times. Caching should be done for the home page and the query count is also less.
- Make changes to the child pages of the home page.
- Make sure that the changes are visible on the home page.

#### Any background context you want to provide?

I went through a couple of things to improve the Home page. It seems like caching is our best bet. Wagtail invalidates the cache when there are any changes in the pages and that keeps invalidating the cache whenever needed.

There are a few queries for the child pages. Could not add caching for those due to pickling issues. Will be looking more into the caching of that data. Also, Tried to cache the images as there are a lot of queries for images.  Nothing worked better than the caching of the frontend.
