### PR TITLE
fix: 404 page doesn't need authentication

### DIFF
--- a/mitxpro/templates/404.html
+++ b/mitxpro/templates/404.html
@@ -13,7 +13,7 @@
 {% block content %}
 <div class="error-block">
   <div class="container text-center">
-    <h2 id="error-page-rendered"><strong>Oops!</strong> it looks like you have encountered an error. We are unable to find the page you are looking for.</h2>
+    <h2><strong>Oops!</strong> it looks like you have encountered an error. We are unable to find the page you are looking for.</h2>
     <img class="not-found-img" src="{% static 'images/404.png' %}" alt="Page not found">
     <div class="bottom-holder">
       <span class="title">Here's a helpful link to get you back on track:</span>

--- a/mitxpro/templates/404.html
+++ b/mitxpro/templates/404.html
@@ -5,7 +5,7 @@
 {% block title %}{{ site_name }}{% endblock %}
 
 {% block headercontent %}
-  <div id="header"></div>
+  <div id="header" class="error-page-header"></div>
   {% render_bundle 'header' %}
 {% endblock %}
 
@@ -13,7 +13,7 @@
 {% block content %}
 <div class="error-block">
   <div class="container text-center">
-    <h2><strong>Oops!</strong> it looks like you have encountered an error. We are unable to find the page you are looking for.</h2>
+    <h2 id="error-page-rendered"><strong>Oops!</strong> it looks like you have encountered an error. We are unable to find the page you are looking for.</h2>
     <img class="not-found-img" src="{% static 'images/404.png' %}" alt="Page not found">
     <div class="bottom-holder">
       <span class="title">Here's a helpful link to get you back on track:</span>

--- a/mitxpro/templates/500.html
+++ b/mitxpro/templates/500.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 <div class="error-block d-flex flex-column justify-content-center">
-  <div id="error-page-rendered" class="container text-center">
+  <div class="container text-center">
     <img class="server-error-img img-fluid" src="{% static 'images/500.png' %}" alt="">
   </div>
 </div>

--- a/mitxpro/templates/500.html
+++ b/mitxpro/templates/500.html
@@ -5,14 +5,14 @@
 {% block title %}{{ site_name }}{% endblock %}
 
 {% block headercontent %}
-  <div id="header"></div>
+  <div id="header" class="error-page-header"></div>
   {% render_bundle 'header' %}
 {% endblock %}
 
 
 {% block content %}
 <div class="error-block d-flex flex-column justify-content-center">
-  <div class="container text-center">
+  <div id="error-page-rendered" class="container text-center">
     <img class="server-error-img img-fluid" src="{% static 'images/500.png' %}" alt="">
   </div>
 </div>

--- a/static/js/components/Header.js
+++ b/static/js/components/Header.js
@@ -10,10 +10,11 @@ import type { Location } from "react-router"
 
 type Props = {
   currentUser: CurrentUser,
-  location: ?Location
+  location: ?Location,
+  errorPageHeader: ?boolean
 }
 
-const Header = ({ currentUser, location }: Props) => {
+const Header = ({ currentUser, location, errorPageHeader }: Props) => {
   if (currentUser && currentUser.is_authenticated) {
     Sentry.configureScope(scope => {
       scope.setUser({
@@ -30,7 +31,7 @@ const Header = ({ currentUser, location }: Props) => {
   }
   return (
     <React.Fragment>
-      <TopAppBar currentUser={currentUser} location={location} />
+      <TopAppBar currentUser={currentUser} location={location} errorPageHeader={errorPageHeader} />
       <NotificationContainer />
     </React.Fragment>
   )

--- a/static/js/components/Header.js
+++ b/static/js/components/Header.js
@@ -9,7 +9,7 @@ import type { CurrentUser } from "../flow/authTypes"
 import type { Location } from "react-router"
 
 type Props = {
-  currentUser: CurrentUser,
+  currentUser: ?CurrentUser,
   location: ?Location,
   errorPageHeader: ?boolean
 }

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -10,7 +10,7 @@ import type { Location } from "react-router"
 import type { CurrentUser } from "../flow/authTypes"
 
 type Props = {
-  currentUser: CurrentUser,
+  currentUser: ?CurrentUser,
   location: ?Location,
   errorPageHeader: ?boolean
 }

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -11,7 +11,8 @@ import type { CurrentUser } from "../flow/authTypes"
 
 type Props = {
   currentUser: CurrentUser,
-  location: ?Location
+  location: ?Location,
+  errorPageHeader: ?boolean
 }
 
 const shouldShowLoginSignup = location =>
@@ -21,12 +22,12 @@ const shouldShowLoginSignup = location =>
     location.pathname === routes.ecommerceBulk.receipt
   )
 
-const TopAppBar = ({ currentUser, location }: Props) => (
+const TopAppBar = ({ currentUser, location, errorPageHeader }: Props) => (
   <header className="header-holder">
     <div className="container">
       <nav
         className={`sub-nav navbar navbar-expand-md link-section ${
-          currentUser.is_authenticated ? "nowrap login" : ""
+          currentUser && currentUser.is_authenticated ? "nowrap login" : ""
         }`}
       >
         <div className="navbar-brand">
@@ -45,7 +46,7 @@ const TopAppBar = ({ currentUser, location }: Props) => (
             height={47.5}
           />
         </div>
-        {currentUser.is_authenticated ? null : (
+        {(currentUser && currentUser.is_authenticated) || errorPageHeader ? null : (
           <button
             className="navbar-toggler nav-opener"
             type="button"
@@ -59,46 +60,48 @@ const TopAppBar = ({ currentUser, location }: Props) => (
             Menu
           </button>
         )}
-        <ul
-          id="nav"
-          className={`${
-            currentUser.is_authenticated ? "" : "collapse"
-          } navbar-collapse px-0 justify-content-end`}
-        >
-          <li>
-            <a href={routes.catalog} className="" aria-label="catalog">
-              Catalog
-            </a>
-          </li>
-          {shouldShowLoginSignup(location) ? (
-            currentUser.is_authenticated ? (
-              <li>
-                <UserMenu currentUser={currentUser} />
-              </li>
-            ) : (
-              <React.Fragment>
+        {errorPageHeader ? null : (
+          <ul
+            id="nav"
+            className={`${
+              currentUser && currentUser.is_authenticated ? "" : "collapse"
+            } navbar-collapse px-0 justify-content-end`}
+          >
+            <li>
+              <a href={routes.catalog} className="" aria-label="catalog">
+                Catalog
+              </a>
+            </li>
+            {shouldShowLoginSignup(location) ? (
+              currentUser && currentUser.is_authenticated ? (
                 <li>
-                  <MixedLink
-                    dest={routes.login.begin}
-                    className="button"
-                    aria-label="Login"
-                  >
-                    Sign In
-                  </MixedLink>
+                  <UserMenu currentUser={currentUser} />
                 </li>
-                <li>
-                  <MixedLink
-                    dest={routes.register.begin}
-                    className="button"
-                    aria-label="Login"
-                  >
-                    Create Account
-                  </MixedLink>
-                </li>
-              </React.Fragment>
-            )
-          ) : null}
-        </ul>
+              ) : (
+                <React.Fragment>
+                  <li>
+                    <MixedLink
+                      dest={routes.login.begin}
+                      className="button"
+                      aria-label="Login"
+                    >
+                      Sign In
+                    </MixedLink>
+                  </li>
+                  <li>
+                    <MixedLink
+                      dest={routes.register.begin}
+                      className="button"
+                      aria-label="Login"
+                    >
+                      Create Account
+                    </MixedLink>
+                  </li>
+                </React.Fragment>
+              )
+            ) : null}
+          </ul>
+        )}
       </nav>
     </div>
   </header>

--- a/static/js/components/TopAppBar_test.js
+++ b/static/js/components/TopAppBar_test.js
@@ -13,7 +13,7 @@ describe("TopAppBar component", () => {
     const user = makeAnonymousUser()
     it("has a link to login", () => {
       assert.equal(
-        shallow(<TopAppBar currentUser={user} location={null} />)
+        shallow(<TopAppBar currentUser={user} location={null} errorPageHeader={null} />)
           .find("MixedLink")
           .at(0)
           .prop("dest"),
@@ -23,7 +23,7 @@ describe("TopAppBar component", () => {
 
     it("has a link to register", () => {
       assert.equal(
-        shallow(<TopAppBar currentUser={user} location={null} />)
+        shallow(<TopAppBar currentUser={user} location={null} errorPageHeader={null} />)
           .find("MixedLink")
           .at(1)
           .prop("dest"),
@@ -33,7 +33,7 @@ describe("TopAppBar component", () => {
 
     it("has a button to collapse the menu", () => {
       assert.isOk(
-        shallow(<TopAppBar currentUser={user} location={null} />)
+        shallow(<TopAppBar currentUser={user} location={null} errorPageHeader={null} />)
           .find("button")
           .exists()
       )
@@ -42,7 +42,7 @@ describe("TopAppBar component", () => {
     it("does not have a login/register on ecommerce bulk page", () => {
       const location = { pathname: "/ecommerce/bulk/", hash: "", search: "" }
       const wrapper = shallow(
-        <TopAppBar currentUser={user} location={location} />
+        <TopAppBar currentUser={user} location={location} errorPageHeader={null} />
       )
       assert.isNotOk(wrapper.find("UserMenu").exists())
       assert.isNotOk(wrapper.find("MixedLink").exists())
@@ -55,7 +55,7 @@ describe("TopAppBar component", () => {
         search:   ""
       }
       const wrapper = shallow(
-        <TopAppBar currentUser={user} location={location} />
+        <TopAppBar currentUser={user} location={location} errorPageHeader={null} />
       )
       assert.isNotOk(wrapper.find("UserMenu").exists())
       assert.isNotOk(wrapper.find("MixedLink").exists())
@@ -66,7 +66,7 @@ describe("TopAppBar component", () => {
 
     it("has a UserMenu component", () => {
       assert.isOk(
-        shallow(<TopAppBar currentUser={user} location={null} />)
+        shallow(<TopAppBar currentUser={user} location={null} errorPageHeader={null} />)
           .find("UserMenu")
           .exists()
       )
@@ -74,7 +74,7 @@ describe("TopAppBar component", () => {
 
     it("does not have a button to collapse the menu", () => {
       assert.isNotOk(
-        shallow(<TopAppBar currentUser={user} location={null} />)
+        shallow(<TopAppBar currentUser={user} location={null} errorPageHeader={null} />)
           .find("button")
           .exists()
       )
@@ -82,7 +82,7 @@ describe("TopAppBar component", () => {
 
     it("does not have MixedLink's for login/registration", () => {
       assert.isNotOk(
-        shallow(<TopAppBar currentUser={user} location={null} />)
+        shallow(<TopAppBar currentUser={user} location={null} errorPageHeader={null} />)
           .find("MixedLink")
           .exists()
       )
@@ -91,7 +91,7 @@ describe("TopAppBar component", () => {
     it("does not have a login/register on ecommerce bulk page", () => {
       const location = { pathname: "/ecommerce/bulk/", hash: "", search: "" }
       const wrapper = shallow(
-        <TopAppBar currentUser={user} location={location} />
+        <TopAppBar currentUser={user} location={location} errorPageHeader={null} />
       )
       assert.isNotOk(wrapper.find("UserMenu").exists())
       assert.isNotOk(wrapper.find("MixedLink").exists())
@@ -104,7 +104,7 @@ describe("TopAppBar component", () => {
         search:   ""
       }
       const wrapper = shallow(
-        <TopAppBar currentUser={user} location={location} />
+        <TopAppBar currentUser={user} location={location} errorPageHeader={null} />
       )
       assert.isNotOk(wrapper.find("UserMenu").exists())
       assert.isNotOk(wrapper.find("MixedLink").exists())

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -74,7 +74,7 @@ export class App extends React.Component<Props, void> {
 
     return (
       <div className="app">
-        <Header currentUser={currentUser} location={location} />
+        <Header currentUser={currentUser} location={location} errorPageHeader={null} />
         <Switch>
           <PrivateRoute
             exact

--- a/static/js/containers/HeaderApp.js
+++ b/static/js/containers/HeaderApp.js
@@ -49,7 +49,7 @@ export class HeaderApp extends React.Component<Props, void> {
   render() {
     const { currentUser } = this.props
 
-    if (!currentUser && !errorPageHeader){
+    if (!currentUser && !errorPageHeader) {
       // application is still loading
       return <div />
     }

--- a/static/js/containers/HeaderApp.js
+++ b/static/js/containers/HeaderApp.js
@@ -20,7 +20,7 @@ type Props = {
   addUserNotification: Function
 }
 
-const errorPageHeader = !!document.getElementsByClassName("error-page-header")
+const errorPageHeader = document.getElementsByClassName("error-page-header").length > 0 ? true : false
 
 export class HeaderApp extends React.Component<Props, void> {
   componentDidUpdate(prevProps: Props) {
@@ -48,6 +48,11 @@ export class HeaderApp extends React.Component<Props, void> {
 
   render() {
     const { currentUser } = this.props
+
+    if (!currentUser && !errorPageHeader){
+      // application is still loading
+      return <div />
+    }
 
     return <Header currentUser={currentUser} location={null} errorPageHeader={errorPageHeader} />
   }

--- a/static/js/containers/HeaderApp.js
+++ b/static/js/containers/HeaderApp.js
@@ -20,6 +20,8 @@ type Props = {
   addUserNotification: Function
 }
 
+const errorPageHeader = !!document.getElementsByClassName("error-page-header")
+
 export class HeaderApp extends React.Component<Props, void> {
   componentDidUpdate(prevProps: Props) {
     if (this.shouldShowUnusedCouponAlert(prevProps, this.props)) {
@@ -47,12 +49,7 @@ export class HeaderApp extends React.Component<Props, void> {
   render() {
     const { currentUser } = this.props
 
-    if (!currentUser) {
-      // application is still loading
-      return <div />
-    }
-
-    return <Header currentUser={currentUser} location={null} />
+    return <Header currentUser={currentUser} location={null} errorPageHeader={errorPageHeader} />
   }
 }
 
@@ -60,7 +57,7 @@ const mapStateToProps = createStructuredSelector({
   currentUser: currentUserSelector
 })
 
-const mapPropsToConfig = () => [users.currentUserQuery()]
+const mapPropsToConfig = () => errorPageHeader ? [] : [users.currentUserQuery()]
 
 const mapDispatchToProps = {
   addUserNotification


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2518 

#### What's this PR do?
Revoke user profile API call on `404 not found` and `500 internal server error` pages

#### How should this be manually tested?

- Checkout to this branch
- Run the project and visit any random invalid URL to get the `404 page`
- Validate in the browser development network tab that there is no `/api/users/me` call
- Validate on the `404 page` header has no `user info` section or `signing` or `create account` buttons

#### Screenshots
##### Before:
Logged-out page header
<img width="1792" alt="Screenshot 2022-12-29 at 6 35 48 PM" src="https://user-images.githubusercontent.com/77275478/209961744-bc11eb03-6749-41c1-b1fb-c356ea9a83b1.png">

Logged-In page header
<img width="1792" alt="Screenshot 2022-12-29 at 6 37 32 PM" src="https://user-images.githubusercontent.com/77275478/209961937-c784b3ab-de5e-4bc5-8d48-6e712e34086c.png">

##### After:
<img width="1792" alt="Screenshot 2022-12-29 at 6 34 39 PM" src="https://user-images.githubusercontent.com/77275478/209962018-9f6e3e7b-e0f4-4924-97a7-80aeb5a4a7aa.png">