### PR TITLE
Hubspot batch sync improvements

### DIFF
--- a/hubspot_xpro/management/commands/configure_hubspot_properties.py
+++ b/hubspot_xpro/management/commands/configure_hubspot_properties.py
@@ -4,9 +4,6 @@ Management command to configure custom Hubspot properties for Contacts, Deals, P
 import sys
 
 from django.core.management import BaseCommand
-
-from ecommerce import models
-from hubspot_xpro.serializers import ORDER_TYPE_B2B, ORDER_TYPE_B2C
 from mitol.hubspot_api.api import (
     delete_object_property,
     delete_property_group,
@@ -15,6 +12,9 @@ from mitol.hubspot_api.api import (
     sync_object_property,
     sync_property_group,
 )
+
+from ecommerce import models
+from hubspot_xpro.serializers import ORDER_TYPE_B2B, ORDER_TYPE_B2C
 
 
 CUSTOM_ECOMMERCE_PROPERTIES = {

--- a/hubspot_xpro/management/commands/sync_hubspot_ids_to_db.py
+++ b/hubspot_xpro/management/commands/sync_hubspot_ids_to_db.py
@@ -6,6 +6,7 @@ from typing import List
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import BaseCommand
+from mitol.hubspot_api.models import HubspotObject
 
 from b2b_ecommerce.models import B2BLine, B2BOrder
 from ecommerce.models import Line, Order, Product
@@ -14,7 +15,6 @@ from hubspot_xpro.api import (
     sync_deal_hubspot_ids_to_db,
     sync_product_hubspot_ids_to_db,
 )
-from mitol.hubspot_api.models import HubspotObject
 from users.models import User
 
 

--- a/hubspot_xpro/serializers_test.py
+++ b/hubspot_xpro/serializers_test.py
@@ -16,7 +16,7 @@ from b2b_ecommerce.constants import B2B_ORDER_PREFIX
 from b2b_ecommerce.factories import B2BCouponFactory
 from b2b_ecommerce.models import B2BOrder
 from courses.factories import CourseRunFactory
-from ecommerce.constants import DISCOUNT_TYPE_PERCENT_OFF, DISCOUNT_TYPE_DOLLARS_OFF
+from ecommerce.constants import DISCOUNT_TYPE_DOLLARS_OFF, DISCOUNT_TYPE_PERCENT_OFF
 from ecommerce.factories import (
     CouponRedemptionFactory,
     ProductFactory,

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -283,7 +283,7 @@ def batch_update_hubspot_objects_chunked(
 
 
 @app.task(bind=True)
-def batch_upsert_hubspot_objects(
+def batch_upsert_hubspot_objects(  # pylint:disable=too-many-arguments
     self,
     hubspot_type: str,
     model_name: str,

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -9,14 +9,16 @@ from typing import List, Tuple
 import celery
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
 from hubspot.crm.objects import BatchInputSimplePublicObjectInput
 from mitol.common.utils import chunks
-from mitol.hubspot_api.api import HubspotApi
+from mitol.hubspot_api.api import HubspotApi, HubspotAssociationType, HubspotObjectType
 from mitol.hubspot_api.models import HubspotObject
 
 from b2b_ecommerce.models import B2BOrder
 from ecommerce.models import Order
 from hubspot_xpro import api
+from hubspot_xpro.api import get_hubspot_id_for_object
 from mitxpro.celery import app
 from users.models import User
 
@@ -212,6 +214,9 @@ def batch_create_hubspot_objects_chunked(
           list(str): list of processed hubspot ids
     """
     created_ids = []
+    content_type = ContentType.objects.exclude(app_label="auth").get(
+        model=ct_model_name
+    )
     # Chunk again, by max allowed for object type (10 for contacts, 100 for all else)
     chunked_ids = batched_chunks(hubspot_type, object_ids)
     for chunk in chunked_ids:
@@ -227,12 +232,12 @@ def batch_create_hubspot_objects_chunked(
         for result in response.results:
             if ct_model_name == "user":
                 object_id = User.objects.get(
-                    email__iexact=result.properties["email"]
+                    email__iexact=result.properties["email"], is_active=True
                 ).id
             else:
                 object_id = result.properties["unique_app_id"].split("-")[-1]
             HubspotObject.objects.update_or_create(
-                content_type=ContentType.objects.get(model=ct_model_name),
+                content_type=content_type,
                 hubspot_id=result.id,
                 object_id=object_id,
             )
@@ -279,7 +284,12 @@ def batch_update_hubspot_objects_chunked(
 
 @app.task(bind=True)
 def batch_upsert_hubspot_objects(
-    self, hubspot_type: str, model_name: str, app_label: str, create: bool = True
+    self,
+    hubspot_type: str,
+    model_name: str,
+    app_label: str,
+    create: bool = True,
+    object_ids: List[int] = None,
 ):
     """
     Batch create or update objects in hubspot, no associations (so ideal for contacts and products)
@@ -291,15 +301,20 @@ def batch_upsert_hubspot_objects(
         create(bool): Create if true, update if false
     """
     content_type = ContentType.objects.get_by_natural_key(app_label, model_name)
-    synced_object_ids = HubspotObject.objects.filter(
-        content_type=content_type
-    ).values_list("object_id", "hubspot_id")
-    unsynced_object_ids = (
-        content_type.model_class()
-        .objects.exclude(id__in=[id[0] for id in synced_object_ids])
-        .values_list("id", flat=True)
-    )
-    object_ids = sorted(unsynced_object_ids if create else synced_object_ids)
+    if not object_ids:
+        synced_object_ids = HubspotObject.objects.filter(
+            content_type=content_type
+        ).values_list("object_id", "hubspot_id")
+        unsynced_object_ids = (
+            content_type.model_class()
+            .objects.exclude(id__in=[id[0] for id in synced_object_ids])
+            .values_list("id", flat=True)
+        )
+        object_ids = sorted(unsynced_object_ids if create else synced_object_ids)
+    elif not create:
+        object_ids = HubspotObject.objects.filter(
+            content_type=content_type, object_id__in=object_ids
+        ).values_list("object_id", "hubspot_id")
     # Limit number of chunks to avoid rate limit
     chunk_size = max_concurrent_chunk_size(len(object_ids))
     chunk_func = (
@@ -310,5 +325,83 @@ def batch_upsert_hubspot_objects(
     chunked_tasks = [
         chunk_func.s(hubspot_type, model_name, chunk)
         for chunk in chunks(object_ids, chunk_size=chunk_size)
+    ]
+    raise self.replace(celery.group(chunked_tasks))
+
+
+@app.task(acks_late=True)
+def batch_upsert_associations_chunked(order_ids: List[int]):
+    """
+    Upsert batches of deal-contact and line-deal associations
+
+    Args:
+        order_ids(list): List of Order IDs
+    """
+    contact_associations_batch = []
+    line_associations_batch = []
+    hubspot_client = HubspotApi()
+    deal_count = len(order_ids)
+    for idx, order_id in enumerate(order_ids):
+        deal = Order.objects.get(id=order_id)
+        contact_id = get_hubspot_id_for_object(deal.purchaser)
+        deal_id = get_hubspot_id_for_object(deal)
+        for line in deal.lines.iterator():
+            line_id = get_hubspot_id_for_object(line)
+            if contact_id and deal_id:
+                contact_associations_batch.append(
+                    PublicAssociation(
+                        _from=deal_id,
+                        to=contact_id,
+                        type=HubspotAssociationType.DEAL_CONTACT.value,
+                    )
+                )
+            if line_id and deal_id:
+                line_associations_batch.append(
+                    PublicAssociation(
+                        _from=line_id,
+                        to=deal_id,
+                        type=HubspotAssociationType.LINE_DEAL.value,
+                    )
+                )
+            if (
+                len(contact_associations_batch) == 100
+                or len(line_associations_batch) == 100
+                or idx == deal_count - 1
+            ):
+                hubspot_client.crm.associations.batch_api.create(
+                    HubspotObjectType.LINES.value,
+                    HubspotObjectType.DEALS.value,
+                    batch_input_public_association=BatchInputPublicAssociation(
+                        inputs=line_associations_batch
+                    ),
+                )
+                line_associations_batch = []
+                hubspot_client.crm.associations.batch_api.create(
+                    HubspotObjectType.DEALS.value,
+                    HubspotObjectType.CONTACTS.value,
+                    batch_input_public_association=BatchInputPublicAssociation(
+                        inputs=contact_associations_batch
+                    ),
+                )
+                contact_associations_batch = []
+    return order_ids
+
+
+@app.task(bind=True)
+def batch_upsert_associations(self, order_ids: List[int] = None):
+    """
+    Upsert chunked batches of deal-contact and line-deal associations
+
+    Args:
+        order_ids(list): List of Order IDs
+    """
+    deal_ids = Order.objects.all()
+    if order_ids:
+        deal_ids = deal_ids.filter(id__in=order_ids)
+    deal_ids = deal_ids.values_list("id", flat=True)
+    chunk_size = max_concurrent_chunk_size(len(deal_ids))
+    chunked_tasks = [
+        batch_upsert_associations_chunked.s(chunk)
+        for chunk in chunks(sorted(deal_ids), chunk_size=chunk_size)
     ]
     raise self.replace(celery.group(chunked_tasks))

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -2,18 +2,26 @@
 Tests for hubspot_xpro tasks
 """
 # pylint: disable=redefined-outer-name
+from decimal import Decimal
 from math import ceil
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from faker import Faker
+from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
 from hubspot.crm.objects import BatchInputSimplePublicObjectInput
-from mitol.hubspot_api.api import HubspotObjectType
+from mitol.hubspot_api.api import HubspotAssociationType, HubspotObjectType
 from mitol.hubspot_api.factories import HubspotObjectFactory, SimplePublicObjectFactory
+from mitol.hubspot_api.models import HubspotObject
 
 from b2b_ecommerce.factories import B2BOrderFactory
 from b2b_ecommerce.models import B2BOrder
-from ecommerce.factories import OrderFactory, ProductFactory
+from ecommerce.factories import (
+    LineFactory,
+    OrderFactory,
+    ProductFactory,
+    ProductVersionFactory,
+)
 from ecommerce.models import Order, Product
 from hubspot_xpro import tasks
 from hubspot_xpro.api import make_contact_sync_message
@@ -244,5 +252,86 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
                 make_contact_sync_message(mock_id)
                 for mock_id in mock_ids[0 : min(id_count, 10)]
             ]
+        ),
+    )
+
+
+def test_batch_upsert_associations(settings, mocker, mocked_celery):
+    """
+    batch_upsert_associations should call batch_upsert_associations_chunked w/correct lists of ids
+    """
+    mock_assoc_chunked = mocker.patch(
+        "hubspot_xpro.tasks.batch_upsert_associations_chunked"
+    )
+    settings.HUBSPOT_MAX_CONCURRENT_TASKS = 4
+    order_ids = sorted([app.id for app in OrderFactory.create_batch(10)])
+    with pytest.raises(TabError):
+        tasks.batch_upsert_associations.delay()
+    mock_assoc_chunked.s.assert_any_call(order_ids[0:3])
+    mock_assoc_chunked.s.assert_any_call(order_ids[6:9])
+    mock_assoc_chunked.s.assert_any_call([order_ids[9]])
+    assert mock_assoc_chunked.s.call_count == 4
+
+    with pytest.raises(TabError):
+        tasks.batch_upsert_associations.delay(order_ids[3:5])
+    mock_assoc_chunked.s.assert_any_call([order_ids[3]])
+    mock_assoc_chunked.s.assert_any_call([order_ids[4]])
+
+
+def test_batch_upsert_associations_chunked(settings, mocker):
+    """
+    batch_upsert_associations_chunked should make expected API calls
+    """
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    orders = OrderFactory.create_batch(5)
+    for order in orders:
+        LineFactory.create(
+            order=order,
+            product_version=ProductVersionFactory.create(price=Decimal(200.00)),
+        )
+    expected_line_associations = [
+        PublicAssociation(
+            _from=HubspotObjectFactory.create(
+                content_type=ContentType.objects.get_for_model(order.lines.first()),
+                object_id=order.lines.first().id,
+                content_object=order.lines.first(),
+            ).hubspot_id,
+            to=HubspotObjectFactory.create(
+                content_type=ContentType.objects.get_for_model(order),
+                object_id=order.id,
+                content_object=order,
+            ).hubspot_id,
+            type=HubspotAssociationType.LINE_DEAL.value,
+        )
+        for order in orders
+    ]
+    expected_contact_associations = [
+        PublicAssociation(
+            _from=HubspotObject.objects.get(
+                content_type=ContentType.objects.get_for_model(order),
+                object_id=order.id,
+            ).hubspot_id,
+            to=HubspotObjectFactory.create(
+                content_type=ContentType.objects.get_for_model(order.purchaser),
+                object_id=order.purchaser.id,
+                content_object=order.purchaser,
+            ).hubspot_id,
+            type=HubspotAssociationType.DEAL_CONTACT.value,
+        )
+        for order in orders
+    ]
+    tasks.batch_upsert_associations_chunked.delay([order.id for order in orders])
+    mock_hubspot_api.return_value.crm.associations.batch_api.create.assert_any_call(
+        HubspotObjectType.LINES.value,
+        HubspotObjectType.DEALS.value,
+        batch_input_public_association=BatchInputPublicAssociation(
+            inputs=expected_line_associations
+        ),
+    )
+    mock_hubspot_api.return_value.crm.associations.batch_api.create.assert_any_call(
+        HubspotObjectType.DEALS.value,
+        HubspotObjectType.CONTACTS.value,
+        batch_input_public_association=BatchInputPublicAssociation(
+            inputs=expected_contact_associations
         ),
     )

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -256,7 +256,9 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     )
 
 
-def test_batch_upsert_associations(settings, mocker, mocked_celery):
+def test_batch_upsert_associations(
+    settings, mocker, mocked_celery
+):  # pylint:disable=unused-argument
     """
     batch_upsert_associations should call batch_upsert_associations_chunked w/correct lists of ids
     """
@@ -278,7 +280,7 @@ def test_batch_upsert_associations(settings, mocker, mocked_celery):
     mock_assoc_chunked.s.assert_any_call([order_ids[4]])
 
 
-def test_batch_upsert_associations_chunked(settings, mocker):
+def test_batch_upsert_associations_chunked(mocker):
     """
     batch_upsert_associations_chunked should make expected API calls
     """


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2463 

#### What's this PR do?
Copies the more efficient batch syncing functions for deals/lines/associations from bootcamps & mitxonline to xpro.

#### How should this be manually tested?
Follow the README on hubspot integration.  You can use the same value for `MITOL_HUBSPOT_API_PRIVATE_TOKEN` as RC, but your `MITOL_HUBSPOT_API_ID_PREFIX` value should be unique to your instance.

Assuming you already have some data, run the following:
```python
manage.py sync_hubspot_ids_to_db --users
manage.py sync_db_to_hubspot  --users create
manage.py sync_db_to_hubspot  --products create
manage.py sync_db_to_hubspot  --deals create
manage.py sync_db_to_hubspot  --lines create
manage.py sync_db_to_hubspot  --associations create
```

Then check the hubspot UI (I can provide a login) to verify that all your deals are synced, and have associated products and contacts.  There will likely be duplicate deals with the same name (from RC and other dev instances) so try to match by your instance's specific user, price, product, etc.
