### PR TITLE
Course urls in catalog API

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -98,11 +98,17 @@ class CourseRunSerializer(BaseCourseRunSerializer):
 class CourseSerializer(serializers.ModelSerializer):
     """Course model serializer - also serializes child course runs"""
 
+    url = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
     courseruns = serializers.SerializerMethodField()
     next_run_id = serializers.SerializerMethodField()
     topics = serializers.SerializerMethodField()
+
+    def get_url(self, instance):
+        """Get CMS Page URL for the course"""
+        page = instance.page
+        return page.get_full_url() if page else None
 
     def get_thumbnail_url(self, instance):
         """Thumbnail URL"""
@@ -149,6 +155,7 @@ class CourseSerializer(serializers.ModelSerializer):
             "id",
             "title",
             "description",
+            "url",
             "thumbnail_url",
             "readable_id",
             "courseruns",

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -166,6 +166,7 @@ def test_serialize_course(mock_context, is_anonymous, all_runs):
         {
             "title": course.title,
             "description": course.page.description,
+            "url": f"http://localhost{course.page.get_url()}",
             "readable_id": course.readable_id,
             "id": course.id,
             "courseruns": [


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2539 

#### What's this PR do?
Adds the course CMS page to catalog API results

#### How should this be manually tested?
Go to "http://xpro.odl.local:8053/api/courses/", there should be a populated `url` field for every course that has a CMS page.
Ditto for all the courses listed under each program at "http://xpro.odl.local:8053/api/programs"
