### PR TITLE
Only return courses/programs with live cms pages in the catalog API response

### DIFF
--- a/cms/factories.py
+++ b/cms/factories.py
@@ -68,6 +68,7 @@ class ProgramPageFactory(wagtail_factories.PageFactory):
     certificate_page = factory.RelatedFactory(
         "cms.factories.CertificatePageFactory", "parent"
     )
+    live = True
 
     class Meta:
         model = ProgramPage
@@ -97,6 +98,7 @@ class CoursePageFactory(wagtail_factories.PageFactory):
     certificate_page = factory.RelatedFactory(
         "cms.factories.CertificatePageFactory", "parent"
     )
+    live = True
 
     class Meta:
         model = CoursePage

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -44,10 +44,14 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = []
     serializer_class = ProgramSerializer
     queryset = (
-        Program.objects.filter(live=True)
-        .exclude(products=None)
-        .select_related("programpage")
-        .prefetch_related(courses_prefetch, products_prefetch)
+        (
+            Program.objects.filter(live=True)
+            .exclude(products=None)
+            .select_related("programpage")
+            .prefetch_related(courses_prefetch, products_prefetch)
+        )
+        .exclude(programpage__isnull=True)
+        .filter(programpage__live=True)
     )
 
 
@@ -64,9 +68,13 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         queryset = (
-            Course.objects.filter(live=True)
-            .select_related("coursepage")
-            .prefetch_related("topics", self.course_runs_prefetch)
+            (
+                Course.objects.filter(live=True)
+                .select_related("coursepage")
+                .prefetch_related("topics", self.course_runs_prefetch)
+            )
+            .exclude(coursepage__isnull=True)
+            .filter(coursepage__live=True)
         )
 
         if self.request.user.is_authenticated:

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -44,13 +44,10 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = []
     serializer_class = ProgramSerializer
     queryset = (
-        (
-            Program.objects.filter(live=True)
-            .exclude(products=None)
-            .select_related("programpage")
-            .prefetch_related(courses_prefetch, products_prefetch)
-        )
-        .exclude(programpage__isnull=True)
+        Program.objects.filter(live=True)
+        .exclude(products=None)
+        .select_related("programpage")
+        .prefetch_related(courses_prefetch, products_prefetch)
         .filter(programpage__live=True)
     )
 
@@ -68,12 +65,9 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         queryset = (
-            (
-                Course.objects.filter(live=True)
-                .select_related("coursepage")
-                .prefetch_related("topics", self.course_runs_prefetch)
-            )
-            .exclude(coursepage__isnull=True)
+            Course.objects.filter(live=True)
+            .select_related("coursepage")
+            .prefetch_related("topics", self.course_runs_prefetch)
             .filter(coursepage__live=True)
         )
 

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -64,7 +64,8 @@ def test_get_programs(user_drf_client, programs):
     ProgramPageFactory.create_batch(
         2, live=False
     )  # create live programs with draft pages
-    ProgramFactory.create_batch(2, live=False)  # create draft programs
+    ProgramFactory.create(live=False)  # draft program
+    ProgramFactory.create(page=None)  # live program, no CMS page
     resp = user_drf_client.get(reverse("programs_api-list"))
     programs_data = sorted(resp.json(), key=op.itemgetter("id"))
     assert len(programs_data) == len(programs)
@@ -116,7 +117,8 @@ def test_get_courses(user_drf_client, courses, mock_context, is_anonymous):
     CoursePageFactory.create_batch(
         2, live=False
     )  # create live courses with draft pages
-    CourseFactory.create_batch(2, live=False)  # Create draft courses
+    CourseFactory.create(page=None)  # live course with no cms page
+    CourseFactory.create(live=False)  # Draft course
     if is_anonymous:
         user_drf_client.logout()
     resp = user_drf_client.get(reverse("courses_api-list"))

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -12,6 +12,7 @@ from mitol.digitalcredentials.models import DigitalCredentialRequest
 from mitol.digitalcredentials.serializers import DigitalCredentialRequestSerializer
 from rest_framework import status
 
+from cms.factories import ProgramPageFactory, CoursePageFactory
 from courses.api import UserEnrollments
 from courses.factories import (
     CourseFactory,
@@ -60,6 +61,10 @@ def course_runs():
 
 def test_get_programs(user_drf_client, programs):
     """Test the view that handles requests for all Programs"""
+    ProgramPageFactory.create_batch(
+        2, live=False
+    )  # create live programs with draft pages
+    ProgramFactory.create_batch(2, live=False)  # create draft programs
     resp = user_drf_client.get(reverse("programs_api-list"))
     programs_data = sorted(resp.json(), key=op.itemgetter("id"))
     assert len(programs_data) == len(programs)
@@ -108,6 +113,10 @@ def test_delete_program(user_drf_client, programs):
 @pytest.mark.parametrize("is_anonymous", [True, False])
 def test_get_courses(user_drf_client, courses, mock_context, is_anonymous):
     """Test the view that handles requests for all Courses"""
+    CoursePageFactory.create_batch(
+        2, live=False
+    )  # create live courses with draft pages
+    CourseFactory.create_batch(2, live=False)  # Create draft courses
     if is_anonymous:
         user_drf_client.logout()
     resp = user_drf_client.get(reverse("courses_api-list"))


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2542

#### What's this PR do?
Excludes courses/programs without live CMS pages from the catalog API results

#### How should this be manually tested?
Go to http://xpro.odl.local/api/programs and http://xpro.odl.local/api/courses.  Only results with live CMS pages should be returned.
