### PR TITLE
Revert "Force django app to load ASAP after uwsgi workers are restarted"

### DIFF
--- a/mitxpro/wsgi.py
+++ b/mitxpro/wsgi.py
@@ -1,84 +1,15 @@
 """
-WSGI config for xpro django app.
+WSGI config for ui app.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
-
-Based on https://gist.github.com/rbarrois/044b2d9f7052a6542f7a3d79695d64c6
 """
-import io
-import logging
 import os
-import sys
-import wsgiref.util
 
-import uwsgidecorators
-from django.conf import settings
-from django.core import wsgi
-from django.db import connections
-
-
-# pylint: disable=global-statement,unused-argument
+from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mitxpro.settings")
 
-
-DJANGO_WARMUP_URL = os.environ.get("DJANGO_WARMUP_URL", "/")  # Default to home page
-
-log = logging.getLogger()
-
-
-@uwsgidecorators.postfork
-def setup_postfork():
-    """Ensure each worker is warm after fork as well."""
-    # Warmup as well
-    warmup_django()
-
-
-def warmup_django(close_connections=False):
-    """Warm up the lazy django app"""
-    global application
-
-    log.debug("warming up")
-
-    if settings.ALLOWED_HOSTS:
-        host = settings.ALLOWED_HOSTS[0].replace("*", "warmup")
-    else:
-        host = "localhost"
-    env = {
-        "REQUEST_METHOD": "GET",
-        "PATH_INFO": DJANGO_WARMUP_URL,
-        "SERVER_NAME": host,
-        "wsgi.error": sys.stderr,
-    }
-    # Setup the whole wsgi standard headers we do not care about.
-    wsgiref.util.setup_testing_defaults(env)
-
-    def start_response(status, response_headers, exc_info=None):
-        """Start the warmup response"""
-        log.debug("starting warmup response")
-        assert status == "200 OK"
-        fake_socket = io.BytesIO()
-        return fake_socket
-
-    application(env, start_response)
-
-    if close_connections:
-        # Close connections before forking
-        log.debug("Closing connection")
-        for conn in connections.all():
-            conn.close()
-
-
-def get_wsgi_application():
-    """Call the standard wsgi.get_wsgi_application() and then the warmup function"""
-    global application
-    application = wsgi.get_wsgi_application()
-    if DJANGO_WARMUP_URL:
-        warmup_django(close_connections=True)
-    return application
-
-
-application = get_wsgi_application()
+application = get_wsgi_application()  # pylint: disable=invalid-name


### PR DESCRIPTION
This reverts commit 76f315fd2f7cec97546838903fc3c92711139d97 because it does not play nice with heroku.

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
#2526

#### What's this PR do?
Reverts a previous PR

#### How should this be manually tested?
Will need to be tested on RC, but your local instance should still start up
