### PR TITLE
Fix bug with calling b2b deal sync function from helper task

### DIFF
--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -43,7 +43,15 @@ def task_obj_lock(
     Returns:
         str: The lock id for the task and object
     """
-    return f"{func_name}_{args[0]}"
+    if args:
+        # Assumes first arg is object id
+        return f"{func_name}_{args[0]}"
+    elif kwargs:
+        # Assumes there is one key:value, for the object id
+        # For tasks where this isn't true, a different function should be used
+        return f"{func_name}_{list(kwargs.values())[0]}"
+    else:
+        return func_name
 
 
 def max_concurrent_chunk_size(obj_count: int) -> int:

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -353,13 +353,16 @@ def test_batch_upsert_associations_chunked(mocker):
     )
 
 
-@pytest.mark.parametrize("func_name,args,kwargs,result", [
-    ["func1", [2345], None, "func1_2345"],
-    ["func2", None, {"order_id": 5678}, "func2_5678"],
-    ["func2a", [], {"user_id": 5678}, "func2a_5678"],
-    ["func3", None, None, "func3"],
-    ["func3a", None, {}, "func3a"],
-])
+@pytest.mark.parametrize(
+    "func_name,args,kwargs,result",
+    [
+        ["func1", [2345], None, "func1_2345"],
+        ["func2", None, {"order_id": 5678}, "func2_5678"],
+        ["func2a", [], {"user_id": 5678}, "func2a_5678"],
+        ["func3", None, None, "func3"],
+        ["func3a", None, {}, "func3a"],
+    ],
+)
 def test_task_obj_lock(func_name, args, kwargs, result):
     """task_obj_lock should return expected result string"""
     assert task_obj_lock(func_name, args, kwargs) == result

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -26,6 +26,7 @@ from ecommerce.factories import (
 from ecommerce.models import Order, Product
 from hubspot_xpro import tasks
 from hubspot_xpro.api import make_contact_sync_message
+from hubspot_xpro.tasks import task_obj_lock
 from users.factories import UserFactory
 
 
@@ -350,3 +351,15 @@ def test_batch_upsert_associations_chunked(mocker):
             inputs=expected_contact_associations
         ),
     )
+
+
+@pytest.mark.parametrize("func_name,args,kwargs,result", [
+    ["func1", [2345], None, "func1_2345"],
+    ["func2", None, {"order_id": 5678}, "func2_5678"],
+    ["func2a", [], {"user_id": 5678}, "func2a_5678"],
+    ["func3", None, None, "func3"],
+    ["func3a", None, {}, "func3a"],
+])
+def test_task_obj_lock(func_name, args, kwargs, result):
+    """task_obj_lock should return expected result string"""
+    assert task_obj_lock(func_name, args, kwargs) == result


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2550 

#### What's this PR do?
Modifies the `hubspot_xpro.tasks.task_obj_lock` function so that it properly handles cases where the object id is passed in a kwargs dict instead of an args list (for example, `hubspot_xpro.task_helpers.sync_hubspot_b2b_deal`)

#### How should this be manually tested?
- Set `MITOL_HUBSPOT_API_PRIVATE_TOKEN` to the same as RC and `MITOL_HUBSPOT_API_ID_PREFIX` to something unique to you in your .env file.
- From the UI, you can create an `Order` (just buy something) and a `B2BOrder` (https://xpro.odl.local/ecommerce/bulk/) if you don't already have one of each.  If you do and don't want to create more, you can run this in a shell instead:
```python
from b2b_ecommerce.models import *
from ecommerce.models import *
from hubspot_xpro.task_helpers import *

sync_hubspot_deal(Order.objects.last())
sync_hubspot_b2b_deal(B2BOrder.objects.last())
```

Both tasks should run successfully (the b2b order task will be delayed by 2 minutes before running).

