### PR TITLE
Fix flaky test

### DIFF
--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -1,8 +1,10 @@
 """User utils tests"""
+import re
 from unittest.mock import patch
 
 import pytest
 
+from users.factories import UserFactory
 from users.utils import (
     ensure_active_user,
     format_recipient,
@@ -73,6 +75,18 @@ def test_ensure_active_user(mock_repair_faulty_edx_user, user):
     assert user.is_active
 
 
-def test_format_recipient(user):
+@pytest.mark.parametrize(
+    "name, email",
+    [
+        ["Mrs. Tammy Smith DDS", "HeSNMtNMfVdo@example.com"],
+        ["John Doe", "jd_123@example.com"],
+        ["Doe, Jane", "jd_456@example.com"],
+    ],
+)
+def test_format_recipient(name, email):
     """Verify that format_recipient correctly format's a user's name and email"""
-    assert format_recipient(user) == f"{user.name} <{user.email}>"
+    user = UserFactory.build(name=name, email=email)
+    assert (
+        re.fullmatch(fr"(\"?){user.name}(\"?)\s+<{user.email}>", format_recipient(user))
+        is not None
+    )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #2556 

#### What's this PR do?
Tests `users.utils.format_recipient` against `Users` with specified names and emails, with and without prefixes and titles.

#### How should this be manually tested?
Unit tests should pass, functionality is unaffected

#### Where should the reviewer start?
`format_recipient` calls `email.utils.formataddr` which sometimes surrounds the name with double quotes (typically when the name includes a prefix or title).  This would cause the previous version of the unit test to fail if the randomly generated user name had a prefix.
