### PR TITLE
Check if edx enrollment already exists for failed enrollments

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -596,7 +596,7 @@ def retry_failed_edx_enrollments():
         course_run = enrollment.run
         try:
             enroll_in_edx_course_runs(user, [course_run])
-        except HTTPError as exc:
+        except EdxApiEnrollErrorException as exc:
             # Check if user is already enrolled
             if get_enrollment(user, course_run) is None:
                 log.exception(str(exc))

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qsl
 import pytest
 import responses
 from django.contrib.auth import get_user_model
+from edx_api.enrollments import Enrollments
 from freezegun import freeze_time
 from oauth2_provider.models import AccessToken, Application
 from oauthlib.common import generate_token
@@ -497,8 +498,10 @@ def test_retry_failed_edx_enrollments(mocker, exception_raised):
         }
 
 
-@pytest.mark.parametrize("edx_enrollment_exists", [True, False])
-def test_retry_failed_edx_enrollments_exists(mocker, edx_enrollment_exists):
+@pytest.mark.parametrize(
+    "edx_enrollment_exists, is_active", [[False, False], [True, True], [True, False]]
+)
+def test_retry_failed_edx_enrollments_exists(mocker, edx_enrollment_exists, is_active):
     """
     Tests that retry_failed_edx_enrollments loops through enrollments that failed in edX
     and attempts to enroll them again
@@ -514,25 +517,32 @@ def test_retry_failed_edx_enrollments_exists(mocker, edx_enrollment_exists):
             failed_enrollment.user, failed_enrollment.run, MockHttpError()
         ),
     )
-    edx_enrollments = (
-        {f"{failed_enrollment.run.courseware_id}": "foo"}
+    edx_enrollments = [
+        {
+            "is_active": is_active,
+            "course_details": {"course_id": failed_enrollment.run.courseware_id},
+        }
         if edx_enrollment_exists
         else {"foo": "bar"}
-    )
+    ]
     mock_edx_client = mocker.patch("courseware.api.get_edx_api_client", autospec=True)
-    mock_edx_client.return_value.enrollments.get_student_enrollments.return_value.enrollments = (
-        edx_enrollments
+    mock_edx_client.return_value.enrollments.get_student_enrollments.return_value = (
+        Enrollments(edx_enrollments)
     )
 
     patched_log = mocker.patch("courseware.api.log")
     successful_enrollments = retry_failed_edx_enrollments()
 
     assert patched_enroll_in_edx.call_count == 1
-    assert len(successful_enrollments) == (1 if edx_enrollment_exists else 0)
-    assert patched_log.exception.called == bool(not edx_enrollment_exists)
-    assert patched_log.warning.called == bool(edx_enrollment_exists)
+    assert len(successful_enrollments) == (
+        1 if edx_enrollment_exists and is_active else 0
+    )
+    assert patched_log.exception.called == bool(
+        not edx_enrollment_exists or not is_active
+    )
+    assert patched_log.warning.called == bool(edx_enrollment_exists and is_active)
     failed_enrollment.refresh_from_db()
-    assert failed_enrollment.edx_enrolled is edx_enrollment_exists
+    assert failed_enrollment.edx_enrolled is (edx_enrollment_exists and is_active)
 
 
 def test_retry_failed_enroll_grace_period(mocker):

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -497,6 +497,42 @@ def test_retry_failed_edx_enrollments(mocker, exception_raised):
         }
 
 
+@pytest.mark.parametrize("edx_enrollment_exists", [True, False])
+def test_retry_failed_edx_enrollments_exists(mocker, edx_enrollment_exists):
+    """
+    Tests that retry_failed_edx_enrollments loops through enrollments that failed in edX
+    and attempts to enroll them again
+    """
+    with freeze_time(now_in_utc() - timedelta(days=1)):
+        failed_enrollment = CourseRunEnrollmentFactory.create(
+            edx_enrolled=False, user__is_active=True
+        )
+        CourseRunEnrollmentFactory.create(edx_enrolled=False, user__is_active=False)
+    patched_enroll_in_edx = mocker.patch(
+        "courseware.api.enroll_in_edx_course_runs",
+        side_effect=MockHttpError(),
+    )
+    edx_enrollments = (
+        {f"{failed_enrollment.run.courseware_id}": "foo"}
+        if edx_enrollment_exists
+        else {"foo": "bar"}
+    )
+    mock_edx_client = mocker.patch("courseware.api.get_edx_api_client", autospec=True)
+    mock_edx_client.return_value.enrollments.get_student_enrollments.return_value.enrollments = (
+        edx_enrollments
+    )
+
+    patched_log = mocker.patch("courseware.api.log")
+    successful_enrollments = retry_failed_edx_enrollments()
+
+    assert patched_enroll_in_edx.call_count == 1
+    assert len(successful_enrollments) == (1 if edx_enrollment_exists else 0)
+    assert patched_log.exception.called == bool(not edx_enrollment_exists)
+    assert patched_log.warning.called == bool(edx_enrollment_exists)
+    failed_enrollment.refresh_from_db()
+    assert failed_enrollment.edx_enrolled is edx_enrollment_exists
+
+
 def test_retry_failed_enroll_grace_period(mocker):
     """
     Tests that retry_failed_edx_enrollments does not attempt to repair any enrollments that were recently created

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -510,7 +510,9 @@ def test_retry_failed_edx_enrollments_exists(mocker, edx_enrollment_exists):
         CourseRunEnrollmentFactory.create(edx_enrolled=False, user__is_active=False)
     patched_enroll_in_edx = mocker.patch(
         "courseware.api.enroll_in_edx_course_runs",
-        side_effect=MockHttpError(),
+        side_effect=EdxApiEnrollErrorException(
+            failed_enrollment.user, failed_enrollment.run, MockHttpError()
+        ),
     )
     edx_enrollments = (
         {f"{failed_enrollment.run.courseware_id}": "foo"}


### PR DESCRIPTION
#2473 should be merged before this one

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #2470

#### What's this PR do?
Marks an xpro enrollment as enrolled in edx too if the enrollment exists there and is active

#### How should this be manually tested?
You will need devstack up and running for this.

- In xpro, modify the course run "course-v1:edX+DemoX+Demo_Course" (which should also exist in your devstack edx instance) so that the enrollment start date begins now, and the run start/end dates are in the future.
- As any user, register for the course.
- As admin, go to the details page for that new enrollment in django admin, and uncheck 'Edx enrolled'
- Modify `courseware.api.enroll_in_edx_course_runs` to always raise an Exception:
   ```python
    for course_run in course_runs:
        raise EdxApiEnrollErrorException(user, course_run, MockHttpError())
   ```
- In a shell, run:
```python
from courseware.api import retry_failed_edx_enrollments
retry_failed_edx_enrollments() 
```
- Refresh the details page for the enrollment in django admin, 'Edx enrolled' should be checked again.
