### PR TITLE
Fix processing of scheduled sheet coupon assignment tasks

### DIFF
--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -1,5 +1,4 @@
 """Sheets app tasks"""
-import json
 import logging
 from datetime import datetime, timedelta
 from itertools import chain, repeat

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -111,7 +111,10 @@ def _get_scheduled_assignment_task_ids(file_id):
     # provided the given file_id as a kwarg, add its task id to the list
     for scheduled in chain.from_iterable(app.control.inspect().scheduled().values()):
         task_metadata = scheduled["request"]
-        if task_metadata["name"] == task_name and task_metadata.get("kwargs", {}).get("file_id") == file_id:
+        if (
+            task_metadata["name"] == task_name
+            and task_metadata.get("kwargs", {}).get("file_id") == file_id
+        ):
             already_scheduled_task_ids.append(task_metadata["id"])
     return already_scheduled_task_ids
 

--- a/sheets/tasks.py
+++ b/sheets/tasks.py
@@ -112,15 +112,8 @@ def _get_scheduled_assignment_task_ids(file_id):
     # provided the given file_id as a kwarg, add its task id to the list
     for scheduled in chain.from_iterable(app.control.inspect().scheduled().values()):
         task_metadata = scheduled["request"]
-        if task_metadata["name"] == task_name:
-            # NOTE: Celery provides metadata for scheduled tasks, and the args/kwargs passed to
-            # that task are stored as serialized strings (e.g.: "{'file_id': '123'}"). Here the kwargs
-            # are being parsed as JSON after coercing the string to use double-quotes.
-            task_kwargs = json.loads(
-                task_metadata.get("kwargs", "{}").replace("'", '"')
-            )
-            if task_kwargs.get("file_id") == file_id:
-                already_scheduled_task_ids.append(task_metadata["id"])
+        if task_metadata["name"] == task_name and task_metadata.get("kwargs", {}).get("file_id") == file_id:
+            already_scheduled_task_ids.append(task_metadata["id"])
     return already_scheduled_task_ids
 
 

--- a/sheets/tasks_test.py
+++ b/sheets/tasks_test.py
@@ -1,7 +1,10 @@
 """Tests for sheets app views"""
 import pytest
 
-from sheets.tasks import handle_unprocessed_coupon_requests, _get_scheduled_assignment_task_ids
+from sheets.tasks import (
+    handle_unprocessed_coupon_requests,
+    _get_scheduled_assignment_task_ids,
+)
 
 
 def test_handle_unprocessed_coupon_requests(mocker):
@@ -21,19 +24,27 @@ def test_get_scheduled_assignment_task_ids(mocker, same_name, same_id):
     """The expected task ids should be returned"""
     mock_app_control = mocker.patch("sheets.tasks.app.control")
     file_id = "correct_file_id" if same_id else "different_id"
-    task_name = "sheets.tasks.process_coupon_assignment_sheet" if same_name else "sheets.tasks.other_sheet"
+    task_name = (
+        "sheets.tasks.process_coupon_assignment_sheet"
+        if same_name
+        else "sheets.tasks.other_sheet"
+    )
     task_id = "123-456-7890"
-    mock_app_control.inspect.return_value.scheduled.return_value.values.return_value = [[
-        {
-            "request": {
-                "id": task_id,
-                "name": task_name,
-                "args": [],
-                "kwargs": {
-                    "file_id": file_id,
-                    "change_date": "2023-02-06T21:35:11.280503+00:00"
+    mock_app_control.inspect.return_value.scheduled.return_value.values.return_value = [
+        [
+            {
+                "request": {
+                    "id": task_id,
+                    "name": task_name,
+                    "args": [],
+                    "kwargs": {
+                        "file_id": file_id,
+                        "change_date": "2023-02-06T21:35:11.280503+00:00",
+                    },
                 }
             }
-        }
-    ]]
-    assert _get_scheduled_assignment_task_ids("correct_file_id") == ([task_id] if (same_name and same_id) else [])
+        ]
+    ]
+    assert _get_scheduled_assignment_task_ids("correct_file_id") == (
+        [task_id] if (same_name and same_id) else []
+    )

--- a/sheets/tasks_test.py
+++ b/sheets/tasks_test.py
@@ -1,5 +1,7 @@
 """Tests for sheets app views"""
-from sheets.tasks import handle_unprocessed_coupon_requests
+import pytest
+
+from sheets.tasks import handle_unprocessed_coupon_requests, _get_scheduled_assignment_task_ids
 
 
 def test_handle_unprocessed_coupon_requests(mocker):
@@ -11,3 +13,27 @@ def test_handle_unprocessed_coupon_requests(mocker):
     )
     handle_unprocessed_coupon_requests.delay()
     patched_req_handler.return_value.process_sheet.assert_called_once()
+
+
+@pytest.mark.parametrize("same_name", [True, False])
+@pytest.mark.parametrize("same_id", [True, False])
+def test_get_scheduled_assignment_task_ids(mocker, same_name, same_id):
+    """The expected task ids should be returned"""
+    mock_app_control = mocker.patch("sheets.tasks.app.control")
+    file_id = "correct_file_id" if same_id else "different_id"
+    task_name = "sheets.tasks.process_coupon_assignment_sheet" if same_name else "sheets.tasks.other_sheet"
+    task_id = "123-456-7890"
+    mock_app_control.inspect.return_value.scheduled.return_value.values.return_value = [[
+        {
+            "request": {
+                "id": task_id,
+                "name": task_name,
+                "args": [],
+                "kwargs": {
+                    "file_id": file_id,
+                    "change_date": "2023-02-06T21:35:11.280503+00:00"
+                }
+            }
+        }
+    ]]
+    assert _get_scheduled_assignment_task_ids("correct_file_id") == ([task_id] if (same_name and same_id) else [])


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2456

#### What's this PR do?
Stops treating celery task metadata kwargs as a serialized string, because it is now a proper dict (maybe as a result of a prior celery upgrade?)

#### How should this be manually tested?
In a shell run the following:
```python
from sheets.tasks import schedule_coupon_assignment_sheet_handling, _get_scheduled_assignment_task_ids
schedule_coupon_assignment_sheet_handling.delay("1xMmUnWm95uyMKXQm-_262tARY0uGYLcSay0qKhud1Zo")
print(_get_scheduled_assignment_task_ids("1xMmUnWm95uyMKXQm-_262tARY0uGYLcSay0qKhud1Zo"))
```
On this branch, the print statement should show a list with one value.  On master branch, it will throw an error (`AttributeError: 'dict' object has no attribute 'replace'`)
