### PR TITLE
Prevent promo code from applying to products that require enrollment code

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -306,6 +306,13 @@ def get_valid_coupon_versions(
         coupon__in=global_coupon_subquery.values_list("pk", flat=True)
     )
 
+    if product:
+        product_version = latest_product_version(product)
+        if product_version and product_version.requires_enrollment_code:
+            global_coupon_version_subquery = global_coupon_version_subquery.exclude(
+                payment_version__coupon_type=CouponPaymentVersion.PROMO
+            )
+
     if full_discount:
         # We can only get full discount for dollars-off when we know the price
 
@@ -952,7 +959,7 @@ def validate_basket_for_checkout(user):
 
     # check for require enrollment code
     if product_version.requires_enrollment_code and not coupon_version:
-        raise ValidationError({"coupons": "Enrollment / Promotional Code is required"})
+        raise ValidationError({"coupons": "Enrollment Code is required"})
 
     # User must have signed any data consent agreements necessary for the basket
     data_consent_users = get_or_create_data_consent_users(basket)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2558

#### What's this PR do?
Adds logic to prevent applying a global promo code to a product that requires an enrollment code, applying the enrollment code created for the product should be allowed

#### How should this be manually tested?
- Create a product if not exist
- Create a product version http://xpro.odl.local:8053/admin/ecommerce/productversion/, and check "Requires enrollment code"
- Create a promo coupon "XPRO23" from http://xpro.odl.local:8053/ecommerce/admin/coupons/ (Promo), check "Global coupon" but don't check "Automatically apply coupon to eligible products in basket"
- Create an enrollment code  from http://xpro.odl.local:8053/ecommerce/admin/coupons/ (Coupon codes), and select the course run or program associated with the product you just created
- Verify the two codes you just created http://xpro.odl.local:8053/admin/ecommerce/coupon/
- Go to http://xpro.odl.local:8053/checkout/?product=<PRODUCT_ID>, and attempt to 
    - apply the promo code you just created, you should receive "Enrollment / Promotional Code 'XPRO23' is invalid"
    - apply the enrollment code you just created, you should receive "Success! Promo Code applied."

#### Screenshots (if appropriate)
Applying a promo code to a course run or program (ProductVersion has requires_enrollment_code=Tue)  expect this error
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/3138890/217934099-c02e381d-19bd-462d-b447-34c2a612a44a.png">

Applying an enrollment code that is eligible for this product should look like this, You should be able to place your order after this
<img width="582" alt="image" src="https://user-images.githubusercontent.com/3138890/217935034-7976f43c-123c-4ae7-bb23-c73ff0b06b7b.png">
