### PR TITLE
fix: Error creating Open edX user. user already exists or invalid name

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -77,12 +77,12 @@ def create_user(user):
 
 def is_existing_edx_user(user):
     """
-    Checks if a user already exists on edx
+    Checks if the user already exists on edX
 
     Args:
         user (user.models.User): the application user
     Returns:
-       (bool): Returns True if user is already exists on edx else False
+       bool: True if the user already exists on edX else False
     """
     if settings.OPENEDX_SERVICE_WORKER_API_TOKEN is None:
         raise ImproperlyConfigured("OPENEDX_SERVICE_WORKER_API_TOKEN is not set")

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -45,6 +45,7 @@ from mitxpro.utils import (
 log = logging.getLogger(__name__)
 User = get_user_model()
 
+OPENEDX_USER_ACCOUNT_DETAIL_PATH = "/api/user/v1/accounts"
 OPENEDX_REGISTER_USER_PATH = "/user_api/v1/account/registration/"
 OPENEDX_REQUEST_DEFAULTS = dict(country="US", honor_code=True)
 
@@ -59,6 +60,8 @@ OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS = 60
 OPENEDX_AUTH_MAX_TTL_IN_SECONDS = 60 * 60
 
 ACCESS_TOKEN_HEADER_NAME = "X-Access-Token"
+AUTH_TOKEN_HEADER_NAME = "Authorization"
+API_KEY_HEADER_NAME = "X-EdX-Api-Key"
 
 
 def create_user(user):
@@ -70,6 +73,38 @@ def create_user(user):
     """
     create_edx_user(user)
     create_edx_auth_token(user)
+
+
+def is_user_exists_on_edx(user):
+    """
+    Checks if a user already exists on edx
+
+    Args:
+        user (user.models.User): the application user
+    Returns:
+       (bool): Returns True if user is already exists on edx else False
+    """
+    if settings.OPENEDX_SERVICE_WORKER_API_TOKEN is None:
+        raise ImproperlyConfigured("OPENEDX_SERVICE_WORKER_API_TOKEN is not set")
+    req_session = requests.Session()
+    req_session.headers.update(
+        {
+            AUTH_TOKEN_HEADER_NAME: "Bearer {}".format(
+                settings.OPENEDX_SERVICE_WORKER_API_TOKEN
+            ),
+            API_KEY_HEADER_NAME: settings.OPENEDX_API_KEY,
+        }
+    )
+    get_response = req_session.get(
+        edx_url(f"{OPENEDX_USER_ACCOUNT_DETAIL_PATH}/{user.username}")
+    )
+    # user already exists on edx
+    if (
+        get_response.status_code == status.HTTP_200_OK
+        and get_response.json().get("email") == user.email
+    ):
+        return True
+    return False
 
 
 def create_edx_user(user):
@@ -112,6 +147,8 @@ def create_edx_user(user):
         )
         # edX responds with 200 on success, not 201
         if resp.status_code != status.HTTP_200_OK:
+            if is_user_exists_on_edx(user):
+                return
             raise CoursewareUserCreateError(
                 f"Error creating Open edX user. {get_error_response_summary(resp)}"
             )

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -75,7 +75,7 @@ def create_user(user):
     create_edx_auth_token(user)
 
 
-def is_user_exists_on_edx(user):
+def is_existing_edx_user(user):
     """
     Checks if a user already exists on edx
 
@@ -144,7 +144,7 @@ def create_edx_user(user):
         )
         # edX responds with 200 on success, not 201
         if resp.status_code != status.HTTP_200_OK:
-            if is_user_exists_on_edx(user):
+            if is_existing_edx_user(user):
                 return
             raise CoursewareUserCreateError(
                 f"Error creating Open edX user. {get_error_response_summary(resp)}"

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -95,15 +95,12 @@ def is_user_exists_on_edx(user):
             API_KEY_HEADER_NAME: settings.OPENEDX_API_KEY,
         }
     )
-    get_response = req_session.get(
+    response = req_session.get(
         edx_url(f"{OPENEDX_USER_ACCOUNT_DETAIL_PATH}/{user.username}")
     )
     # user already exists on edx
-    if (
-        get_response.status_code == status.HTTP_200_OK
-        and get_response.json().get("email") == user.email
-    ):
-        return True
+    if response.status_code == status.HTTP_200_OK and is_json_response(response):
+        return response.json().get("email") == user.email
     return False
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2471 

#### What's this PR do?
Partially fixes issue #2471

- If a user exists on edx with the same username and email this error will not be raised as an exception
- This PR will fix the `CoursewareUser` model entry and generate the token for that user
- Added migration for the `max_length` character check on the `name` in the `user` model
    - So that a fake user like this https://xpro.mit.edu/admin/users/user/72642/ will not be created
    - This user should be deleted before migrations are applied or before merging this PR
- If there is a user on xpro with a different username but the same email from on edx or vice versa will not be fixed
    - as discussed in the above ticket

#### How should this be manually tested?
- Change or add this `REPAIR_COURSEWARE_USERS_FREQUENCY=10` variable's value in the `.env` file
- Run this command `python manage.py createsuperuser` on `xpro` and `edx` and create a user with the same username and email
- Run the `xpro` and `edx` and check the celery logs of xpro
- You can test it without creating a new user by just deleting an existing user's entry from the [CoursewareUser](https://xpro.mit.edu/admin/courseware/coursewareuser/) and [OpenEdxApiAuth](https://xpro.mit.edu/admin/courseware/openedxapiauth/) model on your local xpro
- You'll see that a user is fixed and not an error raised as it raised before this PR

#### Where should the reviewer start?
- xPro and Edx should be running locally and linked to each other
