### PR TITLE
fix: certificates jobs should continue on errors rather than halting

### DIFF
--- a/courses/utils.py
+++ b/courses/utils.py
@@ -166,17 +166,15 @@ def get_or_create_program_enrollment(user, program):
         ProgramEnrollment object paired with a boolean
         indicating whether the enrollment was newly created.
     """
-    if not ProgramEnrollment.objects.filter(program=program, user=user).exists():
-        return (
-            ProgramEnrollment.objects.create(
-                program=program, user=user, active=True, change_status=None
-            ),
-            True,
+    try:
+        return ProgramEnrollment.objects.get_or_create(
+            program=program, user=user, defaults={"active": True, "change_status": None}
         )
-    return (
-        ProgramEnrollment.objects.filter(program=program, user=user).first(),
-        False,
-    )
+    except ProgramEnrollment.MultipleObjectsReturned:
+        return (
+            ProgramEnrollment.objects.filter(program=program, user=user).first(),
+            False,
+        )
 
 
 def revoke_program_certificate(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2568 

#### What's this PR do?
The certificate job suspending due to an error where the `ProgramEnrollment` model has multiple entries for a user in a single program. This PR will ignore this error and continues to generate certificates

#### How should this be manually tested?
In order to test before and after this change

- **Open the terminal from running the xpro app and run these commands**
- `python manage.py shell`
- `from django.contrib.auth import get_user_model`
- `from courses.models import Program, ProgramEnrollment, ProgramCertificate`
- `from courses.utils import generate_program_certificate`
- `User = get_user_model()`
- `user = User.objects.get(id=<EXISTING_USER_ID>)`
- `program = Program.objects.get(id=<EXISTING_PROGRAM_ID>)`
- `ProgramEnrollment.objects.create(user=user, program=program)` **_Run this command two times to create duplicate enrollments_**
- `ProgramEnrollment.objects.create(user=user, program=program)`
- `ProgramCertificate.objects.create(user=user, program=program)` **_Generate Certificate Manually_**
- `generate_program_certificate(user, program)` **_This should return the `MultipleObjectsReturned` error before this PR and return (certificate_object, False) tuple after this PR_**