### PR TITLE
fix: Error creating Open edX user. user already exists or invalid name (follow-up)

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -88,7 +88,7 @@ class OpenEdxUser:
             True if the username of the User object matches the 'username' field in
             'openedx_data', False otherwise.
         """
-        return self.user.username == self.openedx_data["username"]
+        return self.user.username == self.openedx_data.get("username")
 
 
 def create_user(user):

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -211,7 +211,9 @@ def create_edx_user(user):
                     f"Error creating Open edX user. {get_error_response_summary(resp)}"
                 )
             if not openedx_user.is_username_match():
-                if not update_xpro_user_username(openedx_user):
+                if not update_xpro_user_username(
+                    user, openedx_user.openedx_data["username"]
+                ):
                     raise CoursewareUserCreateError(
                         f"Error creating Open edX user. {get_error_response_summary(resp)}"
                     )

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -769,7 +769,7 @@ def test_update_edx_user_name_failure(
 @pytest.fixture
 def test_user():
     """
-    Fixture that creates a `User` object for testing.
+    Fixture that creates a `User` with username="test_user" object for testing.
     """
     return UserFactory.create(username="test_user")
 
@@ -777,7 +777,7 @@ def test_user():
 @pytest.fixture
 def openedx_data():
     """
-    Fixture that creates a `User` object for testing.
+    Fixture providing a sample dictionary with OpenEdx user data.
     """
     return {"username": "test_user"}
 

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -9,7 +9,6 @@ import pytest
 import responses
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from django.db.utils import IntegrityError
 from django.db import transaction
 from edx_api.enrollments import Enrollments
 from freezegun import freeze_time

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -3,12 +3,13 @@
 import itertools
 from datetime import timedelta
 from types import SimpleNamespace
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlencode
 
 import pytest
 import responses
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
+from django.db.utils import IntegrityError
 from edx_api.enrollments import Enrollments
 from freezegun import freeze_time
 from oauth2_provider.models import AccessToken, Application
@@ -18,6 +19,7 @@ from rest_framework import status
 
 from courses.factories import CourseRunEnrollmentFactory, CourseRunFactory
 from courseware.api import (
+    OpenEdxUser,
     ACCESS_TOKEN_HEADER_NAME,
     OPENEDX_AUTH_DEFAULT_TTL_IN_SECONDS,
     create_edx_auth_token,
@@ -32,6 +34,7 @@ from courseware.api import (
     unenroll_edx_course_run,
     update_edx_user_email,
     update_edx_user_name,
+    update_xpro_user_username,
 )
 from courseware.constants import (
     COURSEWARE_REPAIR_GRACE_PERIOD_MINS,
@@ -209,7 +212,7 @@ def test_create_edx_user_conflict(settings, user):
     )
     responses.add(
         responses.GET,
-        f"{settings.OPENEDX_API_BASE_URL}/api/user/v1/accounts/{user.username}",
+        f"{settings.OPENEDX_API_BASE_URL}/api/user/v1/accounts?{urlencode({'email': user.email})}",
         status=status.HTTP_200_OK,
     )
 
@@ -244,6 +247,26 @@ def test_create_edx_auth_token(settings, user, create_token_responses):
     assert auth.access_token_expires_on == now_in_utc() + timedelta(
         minutes=59, seconds=50
     )
+
+
+def test_update_xpro_user_username_successfully(user):
+    """Tests update_xpro_user_username updates user successfully"""
+    new_username = "new_username"
+    assert update_xpro_user_username(user, new_username) is True
+    # reload user object from database to get latest value of username
+    user.refresh_from_db()
+    assert user.username == new_username
+
+
+def test_update_xpro_user_username_integrity_error(user, mocker):
+    """Tests update_xpro_user_username raises IntegrityError"""
+    mocker.patch("users.models.User.save", side_effect=IntegrityError())
+    old_username = user.username
+    new_username = "new_username"
+    assert update_xpro_user_username(user, new_username) is False
+    # reload user object from database to get latest value of username
+    user.refresh_from_db()
+    assert user.username == old_username
 
 
 @responses.activate
@@ -741,3 +764,75 @@ def test_update_edx_user_name_failure(
     mocker.patch("courseware.api.get_edx_api_client", return_value=mock_client)
     with pytest.raises(expected_exception):
         update_edx_user_name(user)
+
+
+@pytest.fixture
+def test_user():
+    """
+    Fixture that creates a `User` object for testing.
+    """
+    return UserFactory.create(username="test_user")
+
+
+@pytest.fixture
+def openedx_data():
+    """
+    Fixture that creates a `User` object for testing.
+    """
+    return {"username": "test_user"}
+
+
+@pytest.fixture
+def open_edx_user(test_user, openedx_data):
+    """
+    Fixture that creates an `OpenEdxUser` object for testing.
+    """
+    return OpenEdxUser(user=test_user, openedx_data=openedx_data)
+
+
+def test_is_username_match_returns_true(open_edx_user):
+    """
+    Test that `is_username_match()` returns True when the username of the `User` object matches
+    the 'username' field in `openedx_data`.
+    """
+    assert open_edx_user.is_username_match() is True
+
+
+def test_is_username_match_returns_false(test_user, openedx_data):
+    """
+    Test that `is_username_match()` returns False when the username of the `User` object does not
+    match the 'username' field in `openedx_data`.
+    """
+    openedx_data["username"] = "wrong_username"
+    open_edx_user = OpenEdxUser(user=test_user, openedx_data=openedx_data)
+    assert open_edx_user.is_username_match() is False
+
+
+def test_is_username_match_with_mock(mocker, test_user, openedx_data):
+    """
+    Test that `is_username_match()` works correctly when the `user` argument is replaced by a
+    `MagicMock` object with a different username.
+    """
+    test_user.username = "new_username"
+    magic_mock_user = mocker.MagicMock(spec=User)
+    open_edx_user = OpenEdxUser(user=magic_mock_user, openedx_data=openedx_data)
+    assert not open_edx_user.is_username_match()
+
+
+def test_is_username_match_with_empty_openedx_data(test_user):
+    """
+    Test that `is_username_match()` returns False when `openedx_data` is an empty dictionary.
+    """
+    open_edx_user = OpenEdxUser(user=test_user, openedx_data={})
+    assert open_edx_user.is_username_match() is False
+
+
+def test_is_username_match_with_missing_openedx_data(test_user):
+    """
+    Test that `is_username_match()` returns False when `openedx_data` does not contain a 'username'
+    field.
+    """
+    open_edx_user = OpenEdxUser(
+        user=test_user, openedx_data={"email": "test@example.com"}
+    )
+    assert open_edx_user.is_username_match() is False

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -808,12 +808,11 @@ def test_is_username_match_returns_false(test_user, openedx_data):
     assert open_edx_user.is_username_match() is False
 
 
-def test_is_username_match_with_mock(mocker, test_user, openedx_data):
+def test_is_username_match_with_mock(mocker, openedx_data):
     """
     Test that `is_username_match()` works correctly when the `user` argument is replaced by a
     `MagicMock` object with a different username.
     """
-    test_user.username = "new_username"
     magic_mock_user = mocker.MagicMock(spec=User)
     open_edx_user = OpenEdxUser(user=magic_mock_user, openedx_data=openedx_data)
     assert not open_edx_user.is_username_match()


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2471 

#### What's this PR do?
Follow up of #2579. Fixes issue #2471. Where the email is the same and the xPro username is different from edX

- If an xPro user exists on edX with a different username but the same email this error will not be raised as an exception anymore
- This PR will fix the `CoursewareUser` model entry and generate the token for that user by updating the username on xPro
- This also fixes the edge case when another user already exists on xPro with an edX username

#### How should this be manually tested?
- Change or add this `REPAIR_COURSEWARE_USERS_FREQUENCY=10` variable's value in the `.env` file
- Run this command `python manage.py createsuperuser` on `xpro` and `edx` and create a user with a different username but the same email
- Run the `xpro` and `edx` and check the celery logs of xpro
- You can test it without creating a new user by just deleting an existing user's entry from the [CoursewareUser](https://xpro.mit.edu/admin/courseware/coursewareuser/) and [OpenEdxApiAuth](https://xpro.mit.edu/admin/courseware/openedxapiauth/) model on your local xpro and changing the username on xPro
- You'll see that a user is fixed and not an error raised as it raised before this PR

#### Where should the reviewer start?
- xPro and Edx should be running locally and linked to each other