### PR TITLE
fix: external program url on Program Details/Product page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -766,9 +766,7 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
     @property
     def external_courseware_url(self):
         """Gets the product page type, this is used for sorting product pages."""
-        if self.product and self.product.first_unexpired_run:
-            return self.product.first_unexpired_run.external_marketing_url
-        return ""
+        return getattr(self.product, "marketing_url", "")
 
     @property
     def is_external_course_page(self):

--- a/cms/models.py
+++ b/cms/models.py
@@ -766,7 +766,7 @@ class ProductPage(MetadataPageMixin, WagtailCachedPageMixin, Page):
     @property
     def external_courseware_url(self):
         """Gets the product page type, this is used for sorting product pages."""
-        return getattr(self.product, "marketing_url", "")
+        return getattr(self.product, "marketing_url", "") or ""
 
     @property
     def is_external_course_page(self):

--- a/courses/models.py
+++ b/courses/models.py
@@ -440,7 +440,7 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
     @property
     def marketing_url(self):
         """Return the marketing URL for this course"""
-        return getattr(self.first_unexpired_run, "external_marketing_url", None)
+        return getattr(self.first_unexpired_run, "external_marketing_url", "")
 
     class Meta:
         ordering = ("program", "title")

--- a/courses/models.py
+++ b/courses/models.py
@@ -249,6 +249,15 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         """All course runs related to a program"""
         return [run for course in self.courses.all() for run in course.courseruns.all()]
 
+    @property
+    def marketing_url(self):
+        """Return the marketing URL for this program from it's latest program run"""
+        return getattr(
+            self.programruns.order_by("-start_date").first(),
+            "external_marketing_url",
+            "",
+        )
+
     def __str__(self):
         title = f"{self.readable_id} | {self.title}"
         return title if len(title) <= 100 else title[:97] + "..."
@@ -427,6 +436,11 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
                 run__course=self
             ).values_list("run__id", flat=True)
         return [run for run in self.unexpired_runs if run.id not in enrolled_runs]
+
+    @property
+    def marketing_url(self):
+        """Return the marketing URL for this course"""
+        return getattr(self.first_unexpired_run, "external_marketing_url", None)
 
     class Meta:
         ordering = ("program", "title")

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -193,8 +193,13 @@ def test_external_courseware_marketing_url():
     course_runs = CourseRunFactory.create_batch(
         2, course=course, external_marketing_url=factory.Iterator(external_course_urls)
     )
-    # Create a run further in the past soe that we know we get the marketing url from that
+    # Create multiple runs, Check the url returned by course is from the latest one starting
+    course_runs[0].start_date = now_in_utc() + timedelta(hours=2)
     course_runs[1].start_date = now_in_utc() + timedelta(hours=1)
+
+    course_runs[0].save()
+    course_runs[1].save()
+
     program_runs = ProgramRunFactory.create_batch(
         2,
         program=program,

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -15,6 +15,7 @@ from courses.factories import (
     CourseFactory,
     CourseRunFactory,
     ProgramFactory,
+    ProgramRunFactory,
     CourseRunEnrollmentFactory,
     ProgramEnrollmentFactory,
     CourseRunCertificateFactory,
@@ -172,6 +173,37 @@ def test_program_current_price():
         product=ProductFactory(content_object=program), price=price
     )
     assert program.current_price == price
+
+
+def test_external_courseware_marketing_url():
+    """
+    External courseware objects should return expected marketing url
+    """
+    course = CourseFactory.create()
+    program = ProgramFactory.create()
+    external_course_urls = [
+        "http://www.testexternalcourse1.com",
+        "http://www.testexternalcourse2.com",
+    ]
+    external_program_urls = [
+        "http://www.testexternalprogram1.com",
+        "http://www.testexternalprogram2.com",
+    ]
+
+    course_runs = CourseRunFactory.create_batch(
+        2, course=course, external_marketing_url=factory.Iterator(external_course_urls)
+    )
+    # Create a run further in the past soe that we know we get the marketing url from that
+    course_runs[1].start_date = now_in_utc() + timedelta(hours=1)
+    program_runs = ProgramRunFactory.create_batch(
+        2,
+        program=program,
+        external_marketing_url=factory.Iterator(external_program_urls),
+    )
+    program_runs[1].start_date = now_in_utc() + timedelta(hours=1)
+
+    assert course.marketing_url == "http://www.testexternalcourse2.com"
+    assert program.marketing_url == "http://www.testexternalprogram2.com"
 
 
 def test_program_page():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None, It was noticed during the testing of https://github.com/mitodl/mitxpro/pull/2585, 

**What was the Issue?**

What was actually happening was that I was getting the marketing URL from `first_unexpired_run` for both Courses, Programs. This worked fine for courses but failed for programs because `first_unexpired_run` for a program returns a course run and not a program run as I'd have assumed. So, For an external program with child courses, the `Learn More` button would show the course's marketing URL instead of the Program's.

See https://rc.xpro.mit.edu/programs/program-v1:xPRO+externalprogram/ on RC to notice this behaviour.

#### What's this PR do?
- Fixes the issue with the external Program's marketing URL 

#### How should this be manually tested?
- Create a program, in Django Admin, and create an associated page in CMS
- Create a course in Django, Admin - select the above program for this course (position=1) and then create a CMS page for this course
- Create a Program Run for the above program with a marketing URL, and create a Course Run for the above-created course.
- Open the program details page, the `Learn More` button should take you to the marketing URL that you added in Program Run and not the Course Run.

#### Screenshots (if appropriate)
Before 
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/34372316/227929850-5ac2d961-a3ba-4f10-8293-2ff5714ea03c.png">

After
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/34372316/227930173-4cade853-774a-4d85-a931-afca54cab4f5.png">



#### What GIF best describes this PR or how it makes you feel?
(Optional)
