### PR TITLE
feat: update APIs to support external courseware data and additional fields

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1784,7 +1784,12 @@ class CertificatePage(CourseProgramChildPage):
         __empty__ = "No display"
 
     template = "certificate_page.html"
-    parent_page_types = ["CoursePage", "ProgramPage"]
+    parent_page_types = [
+        "CoursePage",
+        "ExternalCoursePage",
+        "ProgramPage",
+        "ExternalProgramPage",
+    ]
 
     product_name = models.CharField(
         max_length=250,

--- a/courses/models.py
+++ b/courses/models.py
@@ -428,7 +428,9 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
                 sorted(
                     [
                         course_run
-                        for course_run in self.courseruns.all()
+                        for course_run in self.courseruns.filter(
+                            start_date__isnull=False
+                        )
                         if course_run.live
                     ],
                     key=lambda course_run: course_run.start_date,

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -1,5 +1,5 @@
 """Course views verson 1"""
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from mitol.digitalcredentials.mixins import DigitalCredentialsRequestViewSetMixin
 from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
@@ -46,9 +46,9 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = (
         Program.objects.filter(live=True)
         .exclude(products=None)
-        .select_related("programpage")
+        .select_related("programpage", "externalprogrampage")
         .prefetch_related(courses_prefetch, products_prefetch)
-        .filter(programpage__live=True)
+        .filter(Q(programpage__live=True) | Q(externalprogrampage__live=True))
     )
 
 
@@ -66,9 +66,9 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         queryset = (
             Course.objects.filter(live=True)
-            .select_related("coursepage")
+            .select_related("coursepage", "externalcoursepage")
             .prefetch_related("topics", self.course_runs_prefetch)
-            .filter(coursepage__live=True)
+            .filter(Q(coursepage__live=True) | Q(externalcoursepage__live=True))
         )
 
         if self.request.user.is_authenticated:


### PR DESCRIPTION
Last part of https://github.com/mitodl/mitxpro/issues/2546

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2582 

#### What's this PR do?
- Enable certificate pages to be added under external courseware pages
- Updates `api/courses` and `/api/programs` to return external courseware as part of the response
- Add additional fields mentioned in https://github.com/mitodl/mitxpro/issues/2546 to the API response

#### How should this be manually tested?
**NOTE:** You should create the topics through CMS now. Also, you should associate the topics to courses pages moving onward, The topics can't be added or associated with courses through Django Admin.

**Case 1 APIs**
- Check that '/api/courses' and `/api/programs` APIs return data as per expectations
- Ideally, the course and program details should include fields such as:
    - `is_external`
    - `time_commitment`
    - `duration`
    - `video_url`
    - `format`
    - `credits`
 - The course run details should include 
     - `marketing_site_url`
- Also make sure, that the previous API response fields are not affected by any means
- Check the usage of these APIs to make sure that things are working fine

**Case 2 APIs**
- There was another older issue that came to notice, So we were using `sorted` from python on course run start and end dates and it happens that when the values for start or end dates are none the API would break because `sorted` can't handle it.

**NOTE:** Would be a good idea to read through the discussions and tickets mentioned in the ticket because things are a little scattered.


**- [Sample Programs API response](https://docs.google.com/document/d/11BzeKwSj1MZ4mdIfL5C8wsFWaR-DmbSj-VYzmygQFHg/edit)**

**- [Sample Courses API response](https://docs.google.com/document/d/1zcESIm6WqG06PPTgpaiKEGqxlUJlqSIihmXUM5K10iA/edit)**

#### Any background context you want to provide?
We restructured the external courseware recently at https://github.com/mitodl/mitxpro/pull/2585. That was what we had to do to actually achieve all this in the PR.

#### Screenshots (if appropriate)

**Courses Response**
_Internal Course_

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/34372316/230070881-c53c4cd1-4911-484d-8895-73427fb5e22e.png">


_External Course_
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/34372316/230070963-343aca58-a749-4b64-97e8-3a753628e60e.png">


**Programs Response**

_Internal Program_
<img width="1519" alt="image" src="https://user-images.githubusercontent.com/34372316/230073164-4b29bda6-65ef-49bf-9966-9ca858c92a69.png">

_External Program_
<img width="1523" alt="image" src="https://user-images.githubusercontent.com/34372316/230073251-cf4fb2f4-c97f-4cce-823a-554b7f7633ee.png">


