### PR TITLE
fix: Sheets deferral failed but no error was recorded in sheet

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -12,6 +12,7 @@ from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
 from courses.models import CourseRun, CourseRunEnrollment, ProgramEnrollment
 from courseware.api import enroll_in_edx_course_runs, unenroll_edx_course_run
 from courseware.exceptions import (
+    EdxEnrollmentCreateError,
     EdxApiEnrollErrorException,
     NoEdxApiAuthError,
     UnknownEdxApiEnrollException,
@@ -116,7 +117,7 @@ def create_run_enrollments(
         HTTPError,
         RequestsConnectionError,
     ):
-        log.exception(
+        error_message = (
             "edX enrollment failure for user: %s, runs: %s (order: %s)",
             user,
             [run.courseware_id for run in runs],
@@ -124,7 +125,8 @@ def create_run_enrollments(
         )
         edx_request_success = False
         if not keep_failed_enrollments:
-            return successful_enrollments, edx_request_success
+            raise EdxEnrollmentCreateError(str(error_message))
+        log.exception(str(error_message))
     else:
         edx_request_success = True
 
@@ -323,13 +325,17 @@ def defer_enrollment(
                 from_enrollment.run.course.title, to_run.course.title
             )
         )
-    to_enrollments, _ = create_run_enrollments(
-        user,
-        [to_run],
-        order=from_enrollment.order,
-        company=from_enrollment.company,
-        keep_failed_enrollments=keep_failed_enrollments,
-    )
+    try:
+        to_enrollments, _ = create_run_enrollments(
+            user,
+            [to_run],
+            order=from_enrollment.order,
+            company=from_enrollment.company,
+            keep_failed_enrollments=keep_failed_enrollments,
+        )
+    except EdxEnrollmentCreateError:  # pylint: disable=try-except-raise
+        raise
+
     from_enrollment = deactivate_run_enrollment(
         from_enrollment,
         ENROLL_CHANGE_STATUS_DEFERRED,

--- a/courses/api.py
+++ b/courses/api.py
@@ -118,11 +118,13 @@ def create_run_enrollments(
         RequestsConnectionError,
     ):
         error_message = (
-            "edX enrollment failure for user: %s, runs: %s (order: %s)",
-            user,
-            [run.courseware_id for run in runs],
-            order.id if order else None,
+            "edX enrollment failure for user: {}, runs: {} (order: {})".format(
+                user,
+                [run.courseware_id for run in runs],
+                order.id if order else None,
+            )
         )
+
         edx_request_success = False
         if not keep_failed_enrollments:
             raise EdxEnrollmentCreateError(str(error_message))

--- a/courses/api.py
+++ b/courses/api.py
@@ -333,12 +333,12 @@ def defer_enrollment(
             company=from_enrollment.company,
             keep_failed_enrollments=keep_failed_enrollments,
         )
+        if to_enrollments:
+            from_enrollment = deactivate_run_enrollment(
+                from_enrollment,
+                ENROLL_CHANGE_STATUS_DEFERRED,
+                keep_failed_enrollments=keep_failed_enrollments,
+            )
     except EdxEnrollmentCreateError:  # pylint: disable=try-except-raise
         raise
-
-    from_enrollment = deactivate_run_enrollment(
-        from_enrollment,
-        ENROLL_CHANGE_STATUS_DEFERRED,
-        keep_failed_enrollments=keep_failed_enrollments,
-    )
     return from_enrollment, first_or_none(to_enrollments)

--- a/courses/management/commands/create_enrollment.py
+++ b/courses/management/commands/create_enrollment.py
@@ -103,12 +103,14 @@ class Command(BaseCommand):
             )
 
             try:
-                _, edx_request_success = create_run_enrollments(
+                successful_enrollments, edx_request_success = create_run_enrollments(
                     user,
                     [run],
                     keep_failed_enrollments=options["keep_failed_enrollments"],
                     order=order,
                 )
+                if not successful_enrollments:
+                    raise EdxEnrollmentCreateError
             except EdxEnrollmentCreateError:
                 raise CommandError("Failed to create the enrollment record")
 

--- a/courses/management/commands/create_enrollment.py
+++ b/courses/management/commands/create_enrollment.py
@@ -5,6 +5,7 @@ from django.db import transaction
 
 from courses.api import create_run_enrollments
 from courses.models import CourseRun
+from courseware.exceptions import EdxEnrollmentCreateError
 from ecommerce.api import (
     best_coupon_for_product,
     get_product_version_price_with_discount,
@@ -101,13 +102,14 @@ class Command(BaseCommand):
                 total_price_paid=total_price_paid,
             )
 
-            successful_enrollments, edx_request_success = create_run_enrollments(
-                user,
-                [run],
-                keep_failed_enrollments=options["keep_failed_enrollments"],
-                order=order,
-            )
-            if not successful_enrollments:
+            try:
+                _, edx_request_success = create_run_enrollments(
+                    user,
+                    [run],
+                    keep_failed_enrollments=options["keep_failed_enrollments"],
+                    order=order,
+                )
+            except EdxEnrollmentCreateError:
                 raise CommandError("Failed to create the enrollment record")
 
         ProductCouponAssignment.objects.filter(

--- a/courseware/exceptions.py
+++ b/courseware/exceptions.py
@@ -2,6 +2,10 @@
 from mitxpro.utils import get_error_response_summary
 
 
+class EdxEnrollmentCreateError(Exception):
+    """Exception creating the CoursewareUser"""
+
+
 class CoursewareUserCreateError(Exception):
     """Exception creating the CoursewareUser"""
 

--- a/sheets/deferral_request_api.py
+++ b/sheets/deferral_request_api.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
 from courses.api import defer_enrollment
 from courses.models import CourseRunEnrollment, CourseRun
+from courseware.exceptions import EdxEnrollmentCreateError
 from mitxpro.utils import now_in_utc
 from sheets.constants import GOOGLE_API_TRUE_VAL
 from sheets.sheet_handler_api import EnrollmentChangeRequestHandler
@@ -204,6 +205,14 @@ class DeferralRequestHandler(EnrollmentChangeRequestHandler):
                 row_object=None,
                 result_type=ResultType.FAILED,
                 message="Invalid deferral: {}".format(exc),
+            )
+        except EdxEnrollmentCreateError as exc:
+            return RowResult(
+                row_index=row_index,
+                row_db_record=deferral_request,
+                row_object=None,
+                result_type=ResultType.FAILED,
+                message="Unable to defer enrollment: {}".format(exc),
             )
 
         deferral_request.date_completed = now_in_utc()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2432 

#### What's this PR do?
Fixes the errors where
- No error was recorded in the sheet if the enrollment failed
- The deferral was only attempted once. The learner was unenrolled from the "from" course, but never successfully enrolled in the "to course"


#### How should this be manually tested?
- edX and xPro should be working locally
- Follow this [sheet](https://docs.google.com/spreadsheets/d/1Ldmnp3_czm3JjiOo3DGUVUkedGHV2zqXVFwi63KupEE/edit#gid=1358082255) pattern and make one in your `gdrive` for local testing
- Enroll the user in `from course run` in any course mode except `audit` mode on edX
- Make sure that enrollment mode is not available for `to course run` on edX
- Setup your sheet with your local project
- Open the xPro shell (`./manage.py shell`) and run these commands as follows
- `from sheets.tasks import handle_unprocessed_deferral_requests`
- `handle_unprocessed_deferral_requests()`
- Validate the error is logged in the sheet
- Validate the user is not deferred from `from course run` enrollment if `to course run` enrollment is failed

#### Screenshots (if appropriate)
Before:
<img width="1770" alt="Screenshot 2023-04-07 at 1 54 11 AM" src="https://user-images.githubusercontent.com/77275478/230500523-74aa9674-2c5a-4717-b391-568bc43acee0.png">

After:
<img width="1770" alt="Screenshot 2023-04-07 at 2 57 58 AM" src="https://user-images.githubusercontent.com/77275478/230501478-b9a23ff1-60a8-44be-a179-1a1a9ba4606d.png">