### PR TITLE
fix: data collision issue with existing Readable Ids

### DIFF
--- a/cms/migrations/0054_create_external_courseware_asociations.py
+++ b/cms/migrations/0054_create_external_courseware_asociations.py
@@ -55,24 +55,44 @@ def migrate_external_courses(apps, schema_editor):
 
     external_courses = ExternalCoursePage.objects.all()
     for external_course in external_courses:
-        generated_course, _ = Course.objects.get_or_create(
-            is_external=True,
-            title=external_course.title,
+        # It is possible that we might find a course with same readable Id, In this case let's just mark that
+        # as external and not change other things to keep on safe side from overwriting data.
+        generated_course, is_created = Course.objects.get_or_create(
             readable_id=external_course.readable_id,
-            live=external_course.live,
+            defaults={
+                "is_external": True,
+                "title": external_course.title,
+                "live" "": external_course.live,
+            },
         )
-        generated_course_run, _ = CourseRun.objects.get_or_create(
-            course=generated_course,
-            title=generated_course.title,
-            start_date=get_zone_aware_datetime(external_course.start_date),
-            courseware_id=external_course.readable_id,
-            external_marketing_url=external_course.external_url,
-            live=generated_course.live,
-            run_tag="R1",
-        )
-        check_and_generate_associated_product(
-            apps, schema_editor, external_course, generated_course_run.id
-        )
+        # If already exists, Just set value for newly added field
+        if not is_created:
+            generated_course.is_external = True
+            generated_course.save()
+
+        # It's possible for a course to have multiple runs already created in the system, To be on safe side if we get
+        # existing course runs let's just update the external URL in them to be on safe side
+        generated_course_run = None
+        existing_course_runs = CourseRun.objects.filter(course=generated_course)
+        if existing_course_runs.exists():
+            existing_course_runs.update(
+                external_marketing_url=external_course.external_url
+            )
+        else:
+            generated_course_run, _ = CourseRun.objects.get_or_create(
+                course=generated_course,
+                title=generated_course.title,
+                start_date=get_zone_aware_datetime(external_course.start_date),
+                courseware_id=external_course.readable_id,
+                external_marketing_url=external_course.external_url,
+                live=generated_course.live,
+                run_tag="R1",
+            )
+        # To be safe, Let's create products only if there was no existing course run and we created the first one ever
+        if generated_course_run:
+            check_and_generate_associated_product(
+                apps, schema_editor, external_course, generated_course_run.id
+            )
         external_course.course = generated_course
         external_course.save()
 
@@ -85,12 +105,22 @@ def migrate_external_programs(apps, schema_editor):
 
     external_programs = ExternalProgramPage.objects.all()
     for external_program in external_programs:
-        generated_program, _ = Program.objects.get_or_create(
-            is_external=True,
-            title=external_program.title,
+        # It is possible that we might find a program with same readable Id, In this case let's just mark that
+        # as external and not change other things to be on safe side from overwriting data.
+
+        generated_program, is_created = Program.objects.get_or_create(
             readable_id=external_program.readable_id,
-            live=external_program.live,
+            defaults={
+                "is_external": True,
+                "title": external_program.title,
+                "live": external_program.live,
+            },
         )
+        # If already exists, Just set value for newly added field
+        if not is_created:
+            generated_program.is_external = True
+            generated_program.save()
+
         program_course_lineup = (
             external_program.course_lineup.content_pages
             if external_program.course_lineup
@@ -101,15 +131,24 @@ def migrate_external_programs(apps, schema_editor):
             course_in_program.course.position_in_program = idx + 1
             course_in_program.course.save()
 
-        generated_program_run, _ = ProgramRun.objects.get_or_create(
-            program=generated_program,
-            external_marketing_url=external_program.external_url,
-            start_date=get_zone_aware_datetime(external_program.start_date),
-            run_tag="R1",
-        )
-        check_and_generate_associated_product(
-            apps, schema_editor, external_program, generated_program.id
-        )
+        # It's possible that we might have existing runs for this program
+        existing_programs = ProgramRun.objects.filter(program=generated_program)
+        if existing_programs.exists():
+            existing_programs.objects.update(
+                external_marketing_url=external_program.external_url
+            )
+        else:
+            generated_program_run, _ = ProgramRun.objects.get_or_create(
+                program=generated_program,
+                external_marketing_url=external_program.external_url,
+                start_date=get_zone_aware_datetime(external_program.start_date),
+                run_tag="R1",
+            )
+        # To be safe, Let's create product only if there was no existing program we created the first one ever
+        if is_created:
+            check_and_generate_associated_product(
+                apps, schema_editor, external_program, generated_program.id
+            )
 
         external_program.program_id = generated_program.id
         external_program.save()

--- a/cms/migrations/0054_create_external_courseware_asociations.py
+++ b/cms/migrations/0054_create_external_courseware_asociations.py
@@ -88,11 +88,12 @@ def migrate_external_courses(apps, schema_editor):
                 live=generated_course.live,
                 run_tag="R1",
             )
-        # To be safe, Let's create products only if there was no existing course run and we created the first one ever
-        if generated_course_run:
+            # To be safe, Let's create products only if there was no existing course run and we created
+            # the first one ever.
             check_and_generate_associated_product(
                 apps, schema_editor, external_course, generated_course_run.id
             )
+
         external_course.course = generated_course
         external_course.save()
 
@@ -116,8 +117,13 @@ def migrate_external_programs(apps, schema_editor):
                 "live": external_program.live,
             },
         )
+        # To be safe, Let's create product only if there was no existing program we created the first one ever
+        if is_created:
+            check_and_generate_associated_product(
+                apps, schema_editor, external_program, generated_program.id
+            )
         # If already exists, Just set value for newly added field
-        if not is_created:
+        else:
             generated_program.is_external = True
             generated_program.save()
 
@@ -132,9 +138,9 @@ def migrate_external_programs(apps, schema_editor):
             course_in_program.course.save()
 
         # It's possible that we might have existing runs for this program
-        existing_programs = ProgramRun.objects.filter(program=generated_program)
-        if existing_programs.exists():
-            existing_programs.objects.update(
+        existing_program_runs = ProgramRun.objects.filter(program=generated_program)
+        if existing_program_runs.exists():
+            existing_program_runs.update(
                 external_marketing_url=external_program.external_url
             )
         else:
@@ -143,11 +149,6 @@ def migrate_external_programs(apps, schema_editor):
                 external_marketing_url=external_program.external_url,
                 start_date=get_zone_aware_datetime(external_program.start_date),
                 run_tag="R1",
-            )
-        # To be safe, Let's create product only if there was no existing program we created the first one ever
-        if is_created:
-            check_and_generate_associated_product(
-                apps, schema_editor, external_program, generated_program.id
             )
 
         external_program.program_id = generated_program.id


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
For reference take a look at [this Slack thread](https://mitodl.slack.com/archives/GG8B4C3JP/p1680709865870479?thread_ts=1680708663.243279&cid=GG8B4C3JP).
Take a look at the failing logs on prod [here](https://mitodl.slack.com/archives/GG8B4C3JP/p1680708336267129).

This was noticed when we deployed the last release to production https://github.com/mitodl/mitxpro/pull/2606. The existence of this data was unexpected because we would not expect any `Course, CourseRun, Program, ProgramRun, or Product` entries for External courseware that were present before the release.

Since this data wasn't expected to be there, so now this PR makes the data migration less aggressive in these ways so that the production release goes out:
1. If there is an existing course with the same `readable_id` value as the external course page just mark that `is_external=True` and leave the other things be. 
2. If there are existing Course runs for the course, Just update `external_marketing_url` in all of them and let the other things be as is.
3. Same as 1&2 goes with Programs too.
4. So, We'll only create the product if the course run or the program is created by us for the first time.

#### Why/How did this happen?

A scenario, Where the marketing team wanted internal courses/programs to behave like external courseware with `Learn More` button instead of `Enroll Now`. For this, they did as follows: 
- Created both internal and external pages in CMS for the same program and its courses.
- They created a program Django model for both. (This means the created one for the external program with a same readable id that we defined on the CMS page)
- Now they marked the internal program page in CMS to be draft so that it doesn't show up but they kept all other Django models in the system e.g. Course Runs, and products in the system because they wanted to show the `External Courseware Page` but enroll the users in the internal courseware through `Enrollment Codes`. 

Now we know why the Django models for external courses exist. Although they are useless/unnecessary they have associated products as well which were also unnecessary in the case of external courseware before this release.

#### What's this PR do?
Since this data wasn't expected to be there, so now this PR makes the data migration less aggressive in these ways so that the production release goes out:
1. If there is an existing course with the same `readable_id` value as the external course page just mark that `is_external=True` and leave the other things be. 
2. If there are existing Course runs for the course, Just update `external_marketing_url` in all of them and let the other things be as is.
3. Same as 1&2 goes with Programs too.
4. So, We'll only create the product if the course run or the program is created by us for the first time.


#### How should this be manually tested?
You will have to take your master to a commit behind the https://github.com/mitodl/mitxpro/pull/2606 release. Now create data that matches the above scenario. Create both internal and external courses, programs, the course runs, and the program runs. Also, create Django `Course, CourseRun, and Product, ProductVersion` entries for external courses as well because that's the case on production right now.

Get back to this branch and now run the migrations, They should succeed and the data should be migrated correctly.

Please also take a look at https://github.com/mitodl/mitxpro/pull/2587 for reference where we added the original thing.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
- We did the original thing in https://github.com/mitodl/mitxpro/pull/2587. There are a lot of details as well.

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
