### PR TITLE
fix: temporarily remove codecov until it's PyPI package distribution is fixed

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,6 @@
 astroid==2.6.6
 black==20.8b1
 bpython
-codecov
 django-debug-toolbar
 freezegun==0.3.12
 ipdb


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
None, Noticed an issue with PyPi with this in a build failure https://github.com/mitodl/mitxpro/actions/runs/4679245915/jobs/8289469070

#### What's this PR do?
Temporarily removed the `codecov` because it's PyPI distribution is gone.

**NOTE:** I didn't remove the codecov action from `ci.yml`.

#### How should this be manually tested?
All the actions should pass.

#### Any background context you want to provide?
See [this](https://mitodl.slack.com/archives/GG8B4C3JP/p1681310383242929) Slack thread.

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
