### PR TITLE
fix: Only link courses in programs that have live CMS page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -824,7 +824,7 @@ class ProgramProductPage(ProductPage):
             self.program.courses.all(), key=lambda course: course.position_in_program
         )
         # We only want actual page values, Wagtail's 'pageurl' template tag breaks with None
-        return [course.page for course in courses if course.page]
+        return [course.page for course in courses if (course.page and course.page.live)]
 
     @property
     def course_lineup(self):

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -106,6 +106,20 @@ def test_program_page_course_pages():
     assert list(program_page.course_pages) == [course_page]
 
 
+def test_program_page_course_pages_live_only():
+    """
+    Verify `course_pages` property from the program page returns only live course pages
+    """
+    program_page = ProgramPageFactory.create()
+    assert list(program_page.course_pages) == []
+    course_pages = CoursePageFactory.create_batch(
+        2, course__program=program_page.program
+    )
+    # The below page should not be included in course pages
+    CoursePageFactory.create(course__program=program_page.program, live=False)
+    assert list(program_page.course_pages) == course_pages
+
+
 def test_custom_detail_page_urls():
     """Verify that course/external-course/program detail pages return our custom URL path"""
     readable_id = "some:readable-id"

--- a/cms/templates/partials/card_details_top.html
+++ b/cms/templates/partials/card_details_top.html
@@ -35,7 +35,7 @@
     {% if object_type == "program" %}
       <li>
         <strong>Number of Courses:</strong>
-        {{ courseware_page.product.courses.count }}
+        {{ courseware_page.product.num_courses }}
       </li>
     {% endif %}
     {% if courseware_page.duration %}

--- a/courses/models.py
+++ b/courses/models.py
@@ -171,7 +171,7 @@ class Program(TimestampedModel, PageProperties, ValidateOnSaveMixin):
     @property
     def num_courses(self):
         """Gets the number of courses in this program"""
-        return self.courses.count()
+        return self.courses.live().count()
 
     @cached_property
     def next_run_date(self):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
None, Noticed this while testing https://github.com/mitodl/mitxpro/pull/2598. Actually a bug from before but we just noticed it in this release.

The program Detail page and in the Catalog page also link to the draft courses that resolve to be 404 for the users.

#### What's this PR do?
- Updates the logic on Catalog, To show only those subcourses link under program details that are published and visible to users.

#### How should this be manually tested?
- First reproduce, Create a program and create three or more associated courses in Django Admin
- Create a CMS page for one of the courses above, and create another CMS page for the other courses but this time keep it `Draft`. Keep the third course as is in Django Admin.
- Make sure you see that program in the catalog
- Click `Details` and notice that you should only see one course link here that should resolve to an actual course details page.

#### Where should the reviewer start?
- Create a program and a bunch of courses under it

#### Screenshots (if appropriate)
**Before**
<img width="904" alt="image" src="https://user-images.githubusercontent.com/34372316/231720602-d253fd0c-ec54-450d-a7b6-e063df212bfb.png">

**After**
<img width="970" alt="image" src="https://user-images.githubusercontent.com/34372316/231720808-78e3f5b3-3165-424f-8ced-205407bc567a.png">


#### What GIF best describes this PR or how it makes you feel?
(Optional)
