### PR TITLE
fix: fix topic height when line length increases

### DIFF
--- a/static/scss/catalog/body.scss
+++ b/static/scss/catalog/body.scss
@@ -63,7 +63,6 @@ h1, h2, h3, h4, h5 {
   }
 
   .topic {
-    height: 70px;
     width: 220px;
     text-align: left;
     padding: 21px 15px;

--- a/static/scss/detail/catalog-topics.scss
+++ b/static/scss/detail/catalog-topics.scss
@@ -20,7 +20,6 @@
       }
 
       .topic {
-        height: 88px;
         width: 344px !important;
         text-align: center;
         padding: 30px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes topic height when line length increases.

#### How should this be manually tested?

- Add a topic with line length that goes over multiple lines.
- Verify that the height is fine.

#### Screenshots (if appropriate)
AFTER:
<img width="1711" alt="Screen Shot 2023-04-14 at 3 50 19 PM" src="https://user-images.githubusercontent.com/52656433/232025349-08c07e6f-413f-4752-be45-b1b7254ff9c0.png">
BEFORE:
<img width="1711" alt="Screen Shot 2023-04-14 at 3 50 48 PM" src="https://user-images.githubusercontent.com/52656433/232025365-3bc88106-8934-4a21-af5a-113d1104b18f.png">

