### PR TITLE
fix: Bad B2BOrder email values cause exceptions when syncing to Hubspot

### DIFF
--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -4,6 +4,7 @@ import logging
 from urllib.parse import urlencode, urljoin
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import validate_email
 from django.db import transaction
 from django.http.response import Http404
@@ -61,8 +62,8 @@ class B2BCheckoutView(APIView):
 
         try:
             validate_email(email)
-        except ValidationError:  # pylint: disable=try-except-raise
-            raise
+        except DjangoValidationError:
+            raise ValidationError({"email": "Invalid email"})
 
         try:
             num_seats = int(num_seats)

--- a/b2b_ecommerce/views.py
+++ b/b2b_ecommerce/views.py
@@ -4,6 +4,7 @@ import logging
 from urllib.parse import urlencode, urljoin
 
 from django.conf import settings
+from django.core.validators import validate_email
 from django.db import transaction
 from django.http.response import Http404
 from django.urls import reverse
@@ -57,6 +58,11 @@ class B2BCheckoutView(APIView):
             run_id = request.data.get("run_id")
         except KeyError as ex:
             raise ValidationError(f"Missing parameter {ex.args[0]}")
+
+        try:
+            validate_email(email)
+        except ValidationError:  # pylint: disable=try-except-raise
+            raise
 
         try:
             num_seats = int(num_seats)

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -168,7 +168,8 @@ def test_create_order_with_invalid_code(client):
     assert resp.json() == {"errors": ["Invalid coupon code"]}
 
 
-def test_create_order_with_invalid_email(client):
+@pytest.mark.parametrize("email", ["", "something", "something@", "@something"])
+def test_create_order_with_invalid_email(client, email):
     """
     An order is created with an invalid email, so a validation error is returned
     """
@@ -179,7 +180,7 @@ def test_create_order_with_invalid_email(client):
         reverse("b2b-checkout"),
         {
             "num_seats": 5,
-            "email": "invalid-email",
+            "email": email,
             "product_version_id": product_version.id,
             "discount_code": coupon.coupon_code,
             "contract_number": "",

--- a/b2b_ecommerce/views_test.py
+++ b/b2b_ecommerce/views_test.py
@@ -168,6 +168,27 @@ def test_create_order_with_invalid_code(client):
     assert resp.json() == {"errors": ["Invalid coupon code"]}
 
 
+def test_create_order_with_invalid_email(client):
+    """
+    An order is created with an invalid email, so a validation error is returned
+    """
+
+    product_version = ProductVersionFactory.create()
+    coupon = B2BCouponFactory.create(product=product_version.product)
+    resp = client.post(
+        reverse("b2b-checkout"),
+        {
+            "num_seats": 5,
+            "email": "invalid-email",
+            "product_version_id": product_version.id,
+            "discount_code": coupon.coupon_code,
+            "contract_number": "",
+        },
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json() == {"errors": {"email": "Invalid email"}}
+
+
 @pytest.mark.parametrize("key", ["num_seats", "email", "product_version_id"])
 def test_create_order_missing_parameters(key, client):
     """

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -225,7 +225,9 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: List[int]) -> List[str]:
             validate_email(order.email)
         except ValidationError as exc:
             log.error(
-                f"Validation error for B2BOrder id {order.id} in Hubspot sync task: {exc}"
+                "Validation error for B2BOrder id %s in Hubspot sync task: %s",
+                order.id,
+                exc,
             )
         else:
             results.append(api.sync_b2b_deal_with_hubspot(order.id).id)

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -223,10 +223,13 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: List[int]) -> List[str]:
     for order in B2BOrder.objects.filter(id__in=ids):
         try:
             validate_email(order.email)
-        except ValidationError:  # pylint: disable=try-except-raise
-            raise
-        results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
-        time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+        except ValidationError as exc:
+            log.error(
+                f"Validation error for B2BOrder id {order.id} in Hubspot sync task: {exc}"
+            )
+        else:
+            results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
+            time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
     return results
 
 

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -9,8 +9,6 @@ from typing import List, Tuple
 import celery
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
 from hubspot.crm.objects import BatchInputSimplePublicObjectInput
 from mitol.common.decorators import single_task

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -221,17 +221,8 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: List[int]) -> List[str]:
     """
     results = []
     for order in B2BOrder.objects.filter(id__in=ids):
-        try:
-            validate_email(order.email)
-        except ValidationError as exc:
-            log.error(
-                "Validation error for B2BOrder id %s in Hubspot sync task: %s",
-                order.id,
-                exc,
-            )
-        else:
-            results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
-            time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+        results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
+        time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
     return results
 
 

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -38,8 +38,12 @@ export const validate = (values: Object) => {
     errors.num_seats = "Number of Seats is required"
   }
 
+  const emailRegex = new RegExp(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/)
+
   if (!values.email.includes("@")) {
     errors.email = "Email is required"
+  } else if (!emailRegex.test(values.email)) {
+    errors.email = "Invalid email address"
   }
 
   if (!values.product.productId) {

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -5,7 +5,6 @@ import { ErrorMessage, Field, Formik, Form } from "formik"
 import Decimal from "decimal.js-light"
 import { curry } from "ramda"
 import { EmailInput } from "./elements/inputs"
-import FormError from "./elements/FormError"
 import { emailFieldValidation } from "../../lib/validation"
 
 import B2BPurchaseSummary from "../B2BPurchaseSummary"

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -38,7 +38,7 @@ export const validate = (values: Object) => {
     errors.num_seats = "Number of Seats is required"
   }
 
-  const emailRegex = new RegExp(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/)
+  const emailRegex = new RegExp(/^\w+([.\-+]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/)
 
   if (!values.email.includes("@")) {
     errors.email = "Email is required"

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -31,7 +31,7 @@ type Props = {
   seats: ?string
 }
 
-const emailValidation = yup.object().shape({
+export const emailValidation = yup.object().shape({
   email: emailFieldValidation
 })
 
@@ -43,10 +43,6 @@ export const validate = (values: Object) => {
   const numSeats = parseInt(values.num_seats)
   if (isNaN(numSeats) || numSeats <= 0) {
     errors.num_seats = "Number of Seats is required"
-  }
-
-  if (!values.email.includes("@")) {
-    errors.email = "Email is required"
   }
 
   if (!values.product.productId) {

--- a/static/js/components/forms/B2BPurchaseForm.js
+++ b/static/js/components/forms/B2BPurchaseForm.js
@@ -1,8 +1,12 @@
 // @flow
 import React from "react"
+import * as yup from "yup"
 import { ErrorMessage, Field, Formik, Form } from "formik"
 import Decimal from "decimal.js-light"
 import { curry } from "ramda"
+import { EmailInput } from "./elements/inputs"
+import FormError from "./elements/FormError"
+import { emailFieldValidation } from "../../lib/validation"
 
 import B2BPurchaseSummary from "../B2BPurchaseSummary"
 import ProductSelector from "../input/ProductSelector"
@@ -28,6 +32,10 @@ type Props = {
   seats: ?string
 }
 
+const emailValidation = yup.object().shape({
+  email: emailFieldValidation
+})
+
 const errorMessageRenderer = msg => <span className="error">{msg}</span>
 
 export const validate = (values: Object) => {
@@ -38,12 +46,8 @@ export const validate = (values: Object) => {
     errors.num_seats = "Number of Seats is required"
   }
 
-  const emailRegex = new RegExp(/^\w+([.\-+]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/)
-
   if (!values.email.includes("@")) {
     errors.email = "Email is required"
-  } else if (!emailRegex.test(values.email)) {
-    errors.email = "Invalid email address"
   }
 
   if (!values.product.productId) {
@@ -180,7 +184,7 @@ class B2BPurchaseForm extends React.Component<Props> {
 
             <label htmlFor="email">
               <span className="description">*Your email address:</span>
-              <Field type="text" name="email" />
+              <Field type="email" name="email" autoComplete="email" component={EmailInput} />
               <span className="explanation">
                 * We will email the enrollment codes to this address.
               </span>
@@ -265,6 +269,7 @@ class B2BPurchaseForm extends React.Component<Props> {
           coupon:          this.props.discountCode || "",
           contract_number: this.props.contractNumber || ""
         }}
+        validationSchema={emailValidation}
         validate={validate}
         render={this.renderForm}
         ref={this.formikRef}

--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -122,25 +122,23 @@ describe("B2BPurchaseForm", () => {
         "Number of Seats is required"
       )
     })
-
-    it("should validate email field", async () => {
-      const testCases = [
-        { input: "", expectedError: "Email is a required field" },
-        { input: "something", expectedError: "Invalid email" },
-        { input: "something@", expectedError: "Invalid email" },
-        { input: "@something", expectedError: "Invalid email" },
-      ]
-
-      for (const { input, expectedError } of testCases) {
-        const values = { email: input }
-
+    ;[
+      ["", "Email is a required field"],
+      ["something", "Invalid email"],
+      ["something@", "Invalid email"],
+      ["@something", "Invalid email"],
+      ["abc@example.com", null]
+    ].forEach(([email, expectedError]) => {
+      it("should validate email field", async () => {
+        const values = { email: email }
         try {
-          await emailValidation.validate(values)
-          assert.fail("Email validation should have thrown an error")
+          const result = await emailValidation.validate(values)
+          assert.strictEqual(result["email"], "abc@example.com")
+          assert.strictEqual(null, expectedError)
         } catch (error) {
           assert.strictEqual(error.message, expectedError)
         }
-      }
+      })
     })
 
     it("passes validation", () => {

--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -124,22 +124,22 @@ describe("B2BPurchaseForm", () => {
     })
 
     it("should validate email field", async () => {
-      const values = { email: "" }
-      try {
-        await emailValidation.validate(values)
-        assert.fail("Email validation should have thrown an error")
-      } catch (error) {
-        assert.strictEqual(error.message, "Email is a required field")
-      }
-    })
-
-    it("should validate email field is invalid", async () => {
-      const values = { email: "invalid-email" }
-      try {
-        await emailValidation.validate(values)
-        assert.fail("Email validation should have thrown an error")
-      } catch (error) {
-        assert.strictEqual(error.message, "Invalid email")
+      const testCases = [
+        { input: "", expectedError: "Email is a required field" },
+        { input: "something", expectedError: "Invalid email" },
+        { input: "something@", expectedError: "Invalid email" },
+        { input: "@something", expectedError: "Invalid email" },
+      ];
+    
+      for (const { input, expectedError } of testCases) {
+        const values = { email: input };
+    
+        try {
+          await emailValidation.validate(values);
+          assert.fail("Email validation should have thrown an error");
+        } catch (error) {
+          assert.strictEqual(error.message, expectedError);
+        }
       }
     })
 

--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -6,7 +6,7 @@ import { assert } from "chai"
 
 import { Field, Formik } from "formik"
 
-import B2BPurchaseForm, { validate } from "./B2BPurchaseForm"
+import B2BPurchaseForm, { validate, emailValidation } from "./B2BPurchaseForm"
 import ProductSelector from "../input/ProductSelector"
 import configureStoreMain from "../../store/configureStore"
 
@@ -103,11 +103,9 @@ describe("B2BPurchaseForm", () => {
       assert.deepEqual(
         validate({
           num_seats: "",
-          email:     "",
           product:   { productId: null, programId: null }
         }),
         {
-          email:     "Email is required",
           num_seats: "Number of Seats is required",
           product:   "No product selected"
         }
@@ -123,6 +121,26 @@ describe("B2BPurchaseForm", () => {
         }).num_seats,
         "Number of Seats is required"
       )
+    })
+
+    it("should validate email field", async () => {
+      const values = { email: "" }
+      try {
+        await emailValidation.validate(values)
+        assert.fail("Email validation should have thrown an error")
+      } catch (error) {
+        assert.strictEqual(error.message, "Email is a required field")
+      }
+    })
+
+    it("should validate email field is invalid", async () => {
+      const values = { email: "invalid-email" }
+      try {
+        await emailValidation.validate(values)
+        assert.fail("Email validation should have thrown an error")
+      } catch (error) {
+        assert.strictEqual(error.message, "Invalid email")
+      }
     })
 
     it("passes validation", () => {

--- a/static/js/components/forms/B2BPurchaseForm_test.js
+++ b/static/js/components/forms/B2BPurchaseForm_test.js
@@ -129,16 +129,16 @@ describe("B2BPurchaseForm", () => {
         { input: "something", expectedError: "Invalid email" },
         { input: "something@", expectedError: "Invalid email" },
         { input: "@something", expectedError: "Invalid email" },
-      ];
-    
+      ]
+
       for (const { input, expectedError } of testCases) {
-        const values = { email: input };
-    
+        const values = { email: input }
+
         try {
-          await emailValidation.validate(values);
-          assert.fail("Email validation should have thrown an error");
+          await emailValidation.validate(values)
+          assert.fail("Email validation should have thrown an error")
         } catch (error) {
-          assert.strictEqual(error.message, expectedError);
+          assert.strictEqual(error.message, expectedError)
         }
       }
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2555 

#### What's this PR do?
fixes the issue `Some B2BOrder email values have trailing spaces, carriage returns, and other invalid values that get rejected by Hubspot`

#### How should this be manually tested?
- Open `/ecommerce/bulk/`
- Enter the email with spaces
- Validate it should display an error message
- and you'll not be able to submit the form

#### Screenshots (if appropriate)
Before:
<img width="733" alt="Screenshot 2023-04-14 at 5 13 25 PM" src="https://user-images.githubusercontent.com/77275478/232040522-e37b7678-2956-4d30-a345-c3fd42e23cd9.png">

After:
<img width="733" alt="Screenshot 2023-04-14 at 5 12 56 PM" src="https://user-images.githubusercontent.com/77275478/232040556-e77b9938-d6c1-4107-977b-e04d3e7b7f40.png">

