### PR TITLE
feat: order topics alphabetically on HomePage and CatalogPage

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -105,9 +105,7 @@ class CourseTopicQuerySet(models.QuerySet):
         """
         Returns a list of all parent topic names.
         """
-        return list(
-            self.parent_topics().values_list("name", flat=True)
-        )
+        return list(self.parent_topics().values_list("name", flat=True))
 
 
 class ActiveEnrollmentManager(models.Manager):

--- a/courses/models.py
+++ b/courses/models.py
@@ -99,13 +99,15 @@ class CourseTopicQuerySet(models.QuerySet):
         """
         Applies a filter for course topics with parent=None
         """
-        return self.filter(parent__isnull=True)
+        return self.filter(parent__isnull=True).order_by("name")
 
     def parent_topic_names(self):
         """
         Returns a list of all parent topic names.
         """
-        return list(self.parent_topics().values_list("name", flat=True))
+        return list(
+            self.parent_topics().order_by("name").values_list("name", flat=True)
+        )
 
 
 class ActiveEnrollmentManager(models.Manager):

--- a/courses/models.py
+++ b/courses/models.py
@@ -106,7 +106,7 @@ class CourseTopicQuerySet(models.QuerySet):
         Returns a list of all parent topic names.
         """
         return list(
-            self.parent_topics().order_by("name").values_list("name", flat=True)
+            self.parent_topics().values_list("name", flat=True)
         )
 
 


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
None

#### What's this PR do?
- Orders the topics list on HomePage and Catalog page alphabetically.

#### How should this be manually tested?
- Add some topics randomly, Visit the Catalog Page, they should be sorted alphabetically.
- Visit Home Page and check that the topics are sorted alphabetically as well.
- An additional thing you can do is to update topic name(s) and make sure that the ordering still works accordingly


#### Any background context you want to provide?
We added the topics filtering in https://github.com/mitodl/mitxpro/pull/2629, Afterward we decided to order them alphabetically.

#### Screenshots (if appropriate)
**Catalog After**
<img width="1586" alt="image" src="https://user-images.githubusercontent.com/34372316/234278370-34aabd54-85e7-4b09-bc18-076d1829d563.png">


**Catalog Before**
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/34372316/234278518-8574d99f-ec0f-442c-9f82-b0d5f2c83318.png">

**HomePage After**
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/34372316/234279956-71a01d3b-7745-4072-a321-8a0278b39a86.png">

**HomePage Before**
<img width="1752" alt="image" src="https://user-images.githubusercontent.com/34372316/234281600-f6c61806-76e9-4f86-bb10-62863366b126.png">

#### What GIF best describes this PR or how it makes you feel?
(Optional)
