### PR TITLE
fix: Two accounts with the same email

### DIFF
--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import requests
-from mitol.common.utils import dict_without_keys
 from social_core.backends.email import EmailAuth
 from social_core.exceptions import AuthException, InvalidEmail
 from social_core.pipeline.partial import partial
@@ -109,7 +108,9 @@ def create_user_via_email(
             errors=["Full name must be at least 2 characters long."],
         )
 
-    data["email"] = kwargs.get("email", kwargs.get("details", {}).get("email")).strip().lower()
+    data["email"] = (
+        kwargs.get("email", kwargs.get("details", {}).get("email")).strip().lower()
+    )
     username = usernameify(data["name"], email=data["email"])
 
     affiliate_id = get_affiliate_id_from_request(strategy.request)

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -3,7 +3,7 @@ import json
 import logging
 import requests
 from social_core.backends.email import EmailAuth
-from social_core.exceptions import AuthAlreadyAssociated, AuthException, InvalidEmail
+from social_core.exceptions import AuthAlreadyAssociated, AuthException
 from social_core.pipeline.partial import partial
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -108,9 +108,7 @@ def create_user_via_email(
             errors=["Full name must be at least 2 characters long."],
         )
 
-    data["email"] = (
-        kwargs.get("email", kwargs.get("details", {}).get("email"))
-    )
+    data["email"] = kwargs.get("email", kwargs.get("details", {}).get("email"))
 
     if User.objects.filter(email__iexact=data["email"]).exists():
         raise InvalidEmail(backend)

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -109,7 +109,7 @@ def create_user_via_email(
         )
 
     data["email"] = (
-        kwargs.get("email", kwargs.get("details", {}).get("email")).strip().lower()
+        kwargs.get("email", kwargs.get("details", {}).get("email"))
     )
 
     if User.objects.filter(email__iexact=data["email"]).exists():

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -3,7 +3,7 @@ import json
 import logging
 import requests
 from social_core.backends.email import EmailAuth
-from social_core.exceptions import AuthException, InvalidEmail
+from social_core.exceptions import AuthAlreadyAssociated, AuthException, InvalidEmail
 from social_core.pipeline.partial import partial
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -111,7 +111,7 @@ def create_user_via_email(
     data["email"] = kwargs.get("email", kwargs.get("details", {}).get("email"))
 
     if User.objects.filter(email__iexact=data["email"]).exists():
-        raise InvalidEmail(backend)
+        raise AuthAlreadyAssociated(backend)
 
     username = usernameify(data["name"], email=data["email"])
     data["username"] = username

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -118,11 +118,12 @@ def create_user_via_email(
         context["affiliate_id"] = affiliate_id
 
     try:
-        user = User.objects.get(email=data["email"])
-        raise InvalidEmail(backend)
+        user = User.objects.get(email__iexact=data["email"])
     except User.DoesNotExist:
         data["username"] = username
         serializer = UserSerializer(data=data, context=context)
+    else:
+        raise InvalidEmail(backend)
 
     if not serializer.is_valid():
         raise RequirePasswordAndPersonalInfoException(

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -4,6 +4,7 @@
 from django.contrib.sessions.middleware import SessionMiddleware
 import pytest
 from social_core.backends.email import EmailAuth
+from social_core.exceptions import InvalidEmail
 from social_django.utils import load_strategy, load_backend
 
 from affiliate.factories import AffiliateFactory
@@ -350,6 +351,23 @@ def test_create_user_via_email_existing_user_raises(
             mock_create_user_strategy,
             mock_email_backend,
             user=user,
+            pipeline_index=0,
+            flow=SocialAuthState.FLOW_REGISTER,
+        )
+
+
+@pytest.mark.django_db
+def test_create_user_via_email_existing_email_case_insensitive_user_raises(
+    mock_email_backend, mock_create_user_strategy
+):
+    """Tests that create_user_via_email raises an error if a user already exists in the pipeline"""
+    email = "user@example.com"
+    UserFactory.create(email=email.upper())
+    with pytest.raises(InvalidEmail):
+        user_actions.create_user_via_email(
+            mock_create_user_strategy,
+            mock_email_backend,
+            details=dict(email=email),
             pipeline_index=0,
             flow=SocialAuthState.FLOW_REGISTER,
         )

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -361,7 +361,7 @@ def test_create_user_via_email_with_email_case_insensitive_existing_user(
     mock_email_backend, mock_create_user_strategy
 ):
     """
-    Tests that create_user_via_email raises InvalidEmail exception
+    Tests that create_user_via_email raises AuthAlreadyAssociated exception
     if a user already exists with different case email
     """
     email = "user@example.com"

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -4,7 +4,7 @@
 from django.contrib.sessions.middleware import SessionMiddleware
 import pytest
 from social_core.backends.email import EmailAuth
-from social_core.exceptions import InvalidEmail
+from social_core.exceptions import AuthAlreadyAssociated
 from social_django.utils import load_strategy, load_backend
 
 from affiliate.factories import AffiliateFactory
@@ -366,7 +366,7 @@ def test_create_user_via_email_with_email_case_insensitive_existing_user(
     """
     email = "user@example.com"
     UserFactory.create(email=email.upper())
-    with pytest.raises(InvalidEmail):
+    with pytest.raises(AuthAlreadyAssociated):
         user_actions.create_user_via_email(
             mock_create_user_strategy,
             mock_email_backend,

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -357,19 +357,22 @@ def test_create_user_via_email_existing_user_raises(
 
 
 @pytest.mark.django_db
-def test_create_user_via_email_existing_email_case_insensitive_user_raises(
+def test_create_user_via_email_with_email_case_insensitive_existing_user(
     mock_email_backend, mock_create_user_strategy
 ):
-    """Tests that create_user_via_email raises an error if a user already exists in the pipeline"""
+    """
+    Tests that create_user_via_email raises InvalidEmail exception
+    if a user already exists with different case email
+    """
     email = "user@example.com"
     UserFactory.create(email=email.upper())
     with pytest.raises(InvalidEmail):
         user_actions.create_user_via_email(
             mock_create_user_strategy,
             mock_email_backend,
-            details=dict(email=email),
             pipeline_index=0,
             flow=SocialAuthState.FLOW_REGISTER,
+            details=dict(email=email),
         )
 
 

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -95,11 +95,7 @@ class SocialAuthSerializer(serializers.Serializer):
                     authentication_flow
                     and authentication_flow == SocialAuthState.FLOW_REGISTER
                 ):
-                    email = (
-                        partial.data.get("kwargs")
-                        .get("details")
-                        .get("email")
-                    )
+                    email = partial.data.get("kwargs").get("details").get("email")
                     user_exists = User.objects.filter(email__iexact=email).exists()
 
                     if user_exists:

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.http import HttpResponseRedirect
 from social_django.views import _do_login as login
 from social_core.backends.email import EmailAuth
-from social_core.exceptions import InvalidEmail, AuthException
+from social_core.exceptions import InvalidEmail, AuthException, AuthAlreadyAssociated
 from social_core.utils import (
     user_is_authenticated,
     user_is_active,
@@ -102,6 +102,8 @@ class SocialAuthSerializer(serializers.Serializer):
                         return SocialAuthState(SocialAuthState.STATE_EXISTING_ACCOUNT)
                     return SocialAuthState(SocialAuthState.STATE_INVALID_LINK)
                 return SocialAuthState(SocialAuthState.STATE_INVALID_EMAIL)
+            except AuthAlreadyAssociated:
+                return SocialAuthState(SocialAuthState.STATE_EXISTING_ACCOUNT)
             # clean partial data after usage
             strategy.clean_partial_pipeline(partial.token)
         else:

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -95,7 +95,13 @@ class SocialAuthSerializer(serializers.Serializer):
                     authentication_flow
                     and authentication_flow == SocialAuthState.FLOW_REGISTER
                 ):
-                    email = partial.data.get("kwargs").get("details").get("email").strip().lower()
+                    email = (
+                        partial.data.get("kwargs")
+                        .get("details")
+                        .get("email")
+                        .strip()
+                        .lower()
+                    )
                     user_exists = User.objects.filter(email=email).exists()
 
                     if user_exists:

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -99,10 +99,8 @@ class SocialAuthSerializer(serializers.Serializer):
                         partial.data.get("kwargs")
                         .get("details")
                         .get("email")
-                        .strip()
-                        .lower()
                     )
-                    user_exists = User.objects.filter(email=email).exists()
+                    user_exists = User.objects.filter(email__iexact=email).exists()
 
                     if user_exists:
                         return SocialAuthState(SocialAuthState.STATE_EXISTING_ACCOUNT)

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -95,7 +95,7 @@ class SocialAuthSerializer(serializers.Serializer):
                     authentication_flow
                     and authentication_flow == SocialAuthState.FLOW_REGISTER
                 ):
-                    email = partial.data.get("kwargs").get("details").get("email")
+                    email = partial.data.get("kwargs").get("details").get("email").strip().lower()
                     user_exists = User.objects.filter(email=email).exists()
 
                     if user_exists:

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -108,7 +108,6 @@ export const HIGHEST_EDUCATION_CHOICES = [
 ]
 
 export const ALERT_TYPE_TEXT = "text"
-export const ALERT_TYPE_DANGER = "danger"
 export const ALERT_TYPE_UNUSED_COUPON = "unused-coupon"
 export const ALTER_TYPE_B2B_ORDER_STATUS = "b2b-order-status"
 

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -108,6 +108,7 @@ export const HIGHEST_EDUCATION_CHOICES = [
 ]
 
 export const ALERT_TYPE_TEXT = "text"
+export const ALERT_TYPE_DANGER = "danger"
 export const ALERT_TYPE_UNUSED_COUPON = "unused-coupon"
 export const ALTER_TYPE_B2B_ORDER_STATUS = "b2b-order-status"
 

--- a/static/js/containers/pages/register/RegisterConfirmPage.js
+++ b/static/js/containers/pages/register/RegisterConfirmPage.js
@@ -5,7 +5,6 @@ import DocumentTitle from "react-document-title"
 import { REGISTER_CONFIRM_PAGE_TITLE } from "../../../constants"
 import { compose } from "redux"
 import { connect } from "react-redux"
-import { Link } from "react-router-dom"
 import { mutateAsync, connectRequest } from "redux-query"
 import { path } from "ramda"
 import { createStructuredSelector } from "reselect"
@@ -13,14 +12,11 @@ import { createStructuredSelector } from "reselect"
 import { addUserNotification } from "../../../actions"
 import { ALERT_TYPE_TEXT } from "../../../constants"
 import queries from "../../../lib/queries"
-import { routes } from "../../../lib/urls"
+import { getAppropriateInformationFragment } from "../../../lib/util"
 import {
   STATE_REGISTER_DETAILS,
-  STATE_INVALID_EMAIL,
   handleAuthResponse,
-  INFORMATIVE_STATES,
-  STATE_INVALID_LINK,
-  STATE_EXISTING_ACCOUNT
+  INFORMATIVE_STATES
 } from "../../../lib/auth"
 
 import { authSelector } from "../../../lib/queries/auth"
@@ -73,7 +69,7 @@ export class RegisterConfirmPage extends React.Component<Props> {
           <div className="row">
             <div className="col">
               {auth && INFORMATIVE_STATES.indexOf(auth.state) > -1 ? (
-                this.getAppropriateInformationFragment(auth.state)
+                getAppropriateInformationFragment(auth.state)
               ) : (
                 <p>Confirming...</p>
               )}
@@ -81,36 +77,6 @@ export class RegisterConfirmPage extends React.Component<Props> {
           </div>
         </div>
       </DocumentTitle>
-    )
-  }
-
-  getAppropriateInformationFragment(state: string) {
-    let preLinkText = ""
-    let postLinkText = ""
-    let linkRoute = null
-    if (state === STATE_INVALID_LINK) {
-      preLinkText = "This invitation is invalid or has expired. Please"
-      postLinkText = "to register again"
-      linkRoute = routes.register.begin
-    } else if (state === STATE_EXISTING_ACCOUNT) {
-      preLinkText = "You already have an xPRO account. Please"
-      postLinkText = "to sign in"
-      linkRoute = routes.login.begin
-    } else if (state === STATE_INVALID_EMAIL) {
-      preLinkText = "No confirmation code was provided or it has expired."
-      postLinkText = "to register again"
-      linkRoute = routes.register.begin
-    }
-    return (
-      <React.Fragment>
-        <span className={"confirmation-message"}>
-          {preLinkText}{" "}
-          <Link class={"action-link"} to={linkRoute}>
-            click here {postLinkText}
-          </Link>
-          .
-        </span>
-      </React.Fragment>
     )
   }
 }

--- a/static/js/containers/pages/register/RegisterDetailsPage.js
+++ b/static/js/containers/pages/register/RegisterDetailsPage.js
@@ -54,7 +54,7 @@ type Props = {|
 |}
 
 type State = {
-  state: string | null | undefined
+  state: string | null
 }
 
 export class RegisterDetailsPage extends React.Component<Props, State> {
@@ -80,9 +80,8 @@ export class RegisterDetailsPage extends React.Component<Props, State> {
         // eslint-disable-next-line camelcase
         [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
           setErrors(field_errors),
-        [STATE_EXISTING_ACCOUNT]: ({state}: AuthResponse) => {
+        [STATE_EXISTING_ACCOUNT]: ({state}: AuthResponse) =>
           this.setState({ state })
-        }
       })
     } finally {
       setSubmitting(false)

--- a/static/js/containers/pages/register/RegisterDetailsPage.js
+++ b/static/js/containers/pages/register/RegisterDetailsPage.js
@@ -12,7 +12,7 @@ import { createStructuredSelector } from "reselect"
 import auth from "../../../lib/queries/auth"
 import users from "../../../lib/queries/users"
 import { routes } from "../../../lib/urls"
-import { STATE_ERROR, handleAuthResponse } from "../../../lib/auth"
+import { STATE_ERROR, STATE_EXISTING_ACCOUNT, handleAuthResponse } from "../../../lib/auth"
 import queries from "../../../lib/queries"
 import { qsPartialTokenSelector } from "../../../lib/selectors"
 
@@ -53,7 +53,14 @@ type Props = {|
   ...DispatchProps
 |}
 
-export class RegisterDetailsPage extends React.Component<Props> {
+type State = {
+  state: string | null | undefined
+}
+
+export class RegisterDetailsPage extends React.Component<Props, State> {
+  state = {
+    state: null
+  }
   async onSubmit(detailsData: any, { setSubmitting, setErrors }: any) {
     const {
       history,
@@ -72,7 +79,10 @@ export class RegisterDetailsPage extends React.Component<Props> {
       handleAuthResponse(history, body, {
         // eslint-disable-next-line camelcase
         [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
-          setErrors(field_errors)
+          setErrors(field_errors),
+        [STATE_EXISTING_ACCOUNT]: ({state}: AuthResponse) => {
+          this.setState({ state })
+        }
       })
     } finally {
       setSubmitting(false)
@@ -81,39 +91,57 @@ export class RegisterDetailsPage extends React.Component<Props> {
 
   render() {
     const { countries } = this.props
+    const { state } = this.state
 
     return (
       <DocumentTitle
         title={`${SETTINGS.site_name} | ${REGISTER_DETAILS_PAGE_TITLE}`}
       >
-        <div className="container auth-page registration-page">
-          <div className="auth-header row d-flex flex-row align-items-center justify-content-between flex-nowrap">
-            <div className="col-auto flex-shrink-1">
-              <h1>Create an Account</h1>
-            </div>
-            <div className="col-auto align-text-right gray-text">
-              <h4>Step 1 of 2</h4>
-            </div>
-          </div>
-          <div className="auth-card card-shadow row">
-            <div className="container">
-              <div className="row">
-                <div className="col-12 form-group">
-                  {`Already have an ${SETTINGS.site_name} account? `}
-                  <Link to={routes.login.begin}>Click here</Link>
-                </div>
-              </div>
-              <div className="row">
-                <div className="col-12 auth-form">
-                  <RegisterDetailsForm
-                    onSubmit={this.onSubmit.bind(this)}
-                    countries={countries}
-                  />
-                </div>
+        {state && state !== undefined ? (
+          <div className="container auth-page">
+            <div className="row">
+              <div className="col">
+                <React.Fragment>
+                  <span className={"confirmation-message"}>
+                    {"You already have an xPRO account. Please"}{" "}
+                    <Link className={"action-link"} to={routes.login.begin}>
+                      click here {"to sign in"}
+                    </Link>
+                  </span>
+                </React.Fragment>
               </div>
             </div>
           </div>
-        </div>
+        ) : (
+          <div className="container auth-page registration-page">
+            <div className="auth-header row d-flex flex-row align-items-center justify-content-between flex-nowrap">
+              <div className="col-auto flex-shrink-1">
+                <h1>Create an Account</h1>
+              </div>
+              <div className="col-auto align-text-right gray-text">
+                <h4>Step 1 of 2</h4>
+              </div>
+            </div>
+            <div className="auth-card card-shadow row">
+              <div className="container">
+                <div className="row">
+                  <div className="col-12 form-group">
+                    {`Already have an ${SETTINGS.site_name} account? `}
+                    <Link to={routes.login.begin}>Click here</Link>
+                  </div>
+                </div>
+                <div className="row">
+                  <div className="col-12 auth-form">
+                    <RegisterDetailsForm
+                      onSubmit={this.onSubmit.bind(this)}
+                      countries={countries}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </DocumentTitle>
     )
   }

--- a/static/js/containers/pages/register/RegisterDetailsPage_test.js
+++ b/static/js/containers/pages/register/RegisterDetailsPage_test.js
@@ -11,7 +11,8 @@ import {
   STATE_USER_BLOCKED,
   STATE_ERROR,
   STATE_ERROR_TEMPORARY,
-  FLOW_REGISTER
+  FLOW_REGISTER,
+  STATE_EXISTING_ACCOUNT
 } from "../../../lib/auth"
 import { routes } from "../../../lib/urls"
 import { makeRegisterAuthResponse } from "../../../factories/auth"
@@ -148,5 +149,24 @@ describe("RegisterDetailsPage", () => {
       }
       sinon.assert.calledWith(setSubmittingStub, false)
     })
+  })
+
+  it("displays a message with a login link for existing account", async () => {
+    helper.handleRequestStub.returns({})
+    const { inner } = await renderPage({
+      entities: {
+        auth: {
+          state:         STATE_EXISTING_ACCOUNT,
+          partial_token: partialToken,
+          extra_data:    {}
+        }
+      }
+    })
+    const confirmationMessage = inner.find(".confirmation-message")
+    assert.isNotNull(confirmationMessage)
+    assert.equal(
+      confirmationMessage.text().replace("<Link />", ""),
+      "You already have an xPRO account. Please ."
+    )
   })
 })

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -5,6 +5,7 @@ export type AuthStates =
   | "success"
   | "inactive"
   | "invalid-email"
+  | "existing-account"
   | "user-blocked"
   | "error"
   | "error-temporary"

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -1,5 +1,6 @@
 // @flow
 /* global SETTINGS:false */
+import React from "react"
 import {
   all,
   complement,
@@ -17,6 +18,7 @@ import _truncate from "lodash/truncate"
 import qs from "query-string"
 import * as R from "ramda"
 import moment from "moment"
+import { Link } from "react-router-dom"
 
 import type Moment from "moment"
 import type {
@@ -29,6 +31,12 @@ import type { Product } from "../flow/ecommerceTypes"
 
 import { PRODUCT_TYPE_COURSERUN } from "../constants"
 import type { HttpRespErrorMessage, HttpResponse } from "../flow/httpTypes"
+import { routes } from "./urls"
+import {
+  STATE_INVALID_EMAIL,
+  STATE_INVALID_LINK,
+  STATE_EXISTING_ACCOUNT
+} from "./auth"
 
 /**
  * Returns a promise which resolves after a number of milliseconds have elapsed
@@ -234,4 +242,34 @@ export const getErrorMessages = (
     return null
   }
   return response.body.errors
+}
+
+export const getAppropriateInformationFragment = (state: string) => {
+  let preLinkText = ""
+  let postLinkText = ""
+  let linkRoute = null
+  if (state === STATE_INVALID_LINK) {
+    preLinkText = "This invitation is invalid or has expired. Please"
+    postLinkText = "to register again"
+    linkRoute = routes.register.begin
+  } else if (state === STATE_EXISTING_ACCOUNT) {
+    preLinkText = "You already have an xPRO account. Please"
+    postLinkText = "to sign in"
+    linkRoute = routes.login.begin
+  } else if (state === STATE_INVALID_EMAIL) {
+    preLinkText = "No confirmation code was provided or it has expired."
+    postLinkText = "to register again"
+    linkRoute = routes.register.begin
+  }
+  return (
+    <React.Fragment>
+      <span className={"confirmation-message"}>
+        {preLinkText}{" "}
+        <Link className={"action-link"} to={linkRoute}>
+          click here {postLinkText}
+        </Link>
+        .
+      </span>
+    </React.Fragment>
+  )
 }

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -231,7 +231,6 @@ class PublicUserSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "username", "name", "created_on", "updated_on")
 
-
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for users"""
 
@@ -245,7 +244,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     def validate_email(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""
-        return {"email": value}
+        return {"email": value.strip().lower()}
 
     def validate_username(self, value):
         """Empty validation function, but this is required for WriteableSerializerMethodField"""

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -231,6 +231,7 @@ class PublicUserSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "username", "name", "created_on", "updated_on")
 
+
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for users"""
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2633 

#### What's this PR do?
Fixes the two account issue with one email #2633 

#### How should this be manually tested?
1. Checkout to this branch and run xpro locally
2. Open `Create Account` on local `xpro`
3. Enter an email, with lowercase letters in the address
4. In another tab, open `Create Account` again and enter the same email, but all uppercase 
5. You should get two verification emails, with different links. 
6. Follow one of the links and complete the first screen of the account creation process
7. In a private window or another browser open the 2nd verification link and complete the first screen of the account creation process
8. You should see an error screen as the screenshot below on submit that a user already exists

#### Screenshots (if appropriate)
<img width="1172" alt="Screenshot 2023-05-05 at 4 57 47 PM" src="https://user-images.githubusercontent.com/77275478/236823928-2144a6ff-7015-48f6-9ce5-66b4838bfb74.png">
