### PR TITLE
fix: checkout when there is a course without course page

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -154,10 +154,11 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_topics(self, instance):
         """List topics of a course"""
-        return sorted(
-            [{"name": topic.name} for topic in instance.page.topics.all()],
-            key=lambda topic: topic["name"],
-        )
+        if instance.page:
+            return sorted(
+                [{"name": topic.name} for topic in instance.page.topics.all()],
+                key=lambda topic: topic["name"],
+            )
 
     def get_time_commitment(self, instance):
         """Returns the time commitment for this course that's set in CMS page"""

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -159,6 +159,7 @@ class CourseSerializer(serializers.ModelSerializer):
                 [{"name": topic.name} for topic in instance.page.topics.all()],
                 key=lambda topic: topic["name"],
             )
+        return []
 
     def get_time_commitment(self, instance):
         """Returns the time commitment for this course that's set in CMS page"""

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -199,6 +199,7 @@ def test_serialize_course(
         mock_context["all_runs"] = True
     user = mock_context["request"].user
 
+    # Only create course page is required
     if course_page:
         course = CourseFactory.create(
             is_external=is_external,

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -258,7 +258,7 @@ def test_serialize_course(
             ],
             "thumbnail_url": f"http://localhost:8053{course.page.thumbnail_image.file.url if course_page else '/static/images/mit-dome.png'}",
             "next_run_id": course.first_unexpired_run.id,
-            "topics": [{"name": topic}] if course_page else None,
+            "topics": [{"name": topic}] if course_page else [],
             "time_commitment": time_commitment if course_page else None,
             "duration": duration if course_page else None,
             "video_url": video_url if course_page else None,

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -199,7 +199,7 @@ def test_serialize_course(
         mock_context["all_runs"] = True
     user = mock_context["request"].user
 
-    # Only create course page is required
+    # Only create course page if required
     if course_page:
         course = CourseFactory.create(
             is_external=is_external,
@@ -217,7 +217,6 @@ def test_serialize_course(
         course__no_program=True,
         live=True,
     )
-    # course = course_run.course
     topic = "a course topic"
     if course_page:
         course.page.topics.set([CourseTopic.objects.create(name=topic)])


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1418

#### What's this PR do?
- Adds a check to fetch course topics only when there is a course page

#### How should this be manually tested?
I'd recommend recreating this issue on Master before testing this PR. 
To recreate the issue, You need to create a Program in Django Admin, Also create a course in Django Admin. Create products for both. Note that you should not create any CMS pages for these.
Associate the course with the program in Django Admin. Now, Manually enter the URL `http://xpro.odl.local:8053/checkout/?product=<your_program_id>` and `http://xpro.odl.local:8053/checkout/?product=<your_course_id>` You should notice [this error](https://mit-office-of-digital-learning.sentry.io/issues/4120830727/?project=1413655).

- Now to test the fix, Move to this PR and run the checkout URL again, the page should work, and the course and program should be enrollable.


#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
