### PR TITLE
feat: Update management command for user deferrals to include courses with closed enrollments

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -87,8 +87,13 @@ def get_user_enrollments(user):
 
 
 def create_run_enrollments(
-    user, runs, keep_failed_enrollments=False, order=None, company=None
-):
+    user,
+    runs,
+    keep_failed_enrollments=False,
+    order=None,
+    company=None,
+    force_enrollment=False,
+):  # pylint: disable=too-many-arguments
     """
     Creates local records of a user's enrollment in course runs, and attempts to enroll them
     in edX via API
@@ -109,7 +114,7 @@ def create_run_enrollments(
     """
     successful_enrollments = []
     try:
-        enroll_in_edx_course_runs(user, runs)
+        enroll_in_edx_course_runs(user, runs, force_enrollment=force_enrollment)
     except (
         EdxApiEnrollErrorException,
         UnknownEdxApiEnrollException,
@@ -314,7 +319,7 @@ def defer_enrollment(
         raise ValidationError(
             "Cannot defer to the same course run (run: {})".format(to_run.courseware_id)
         )
-    if not to_run.is_not_beyond_enrollment:
+    if not force and not to_run.is_not_beyond_enrollment:
         raise ValidationError(
             "Cannot defer to a course run that is outside of its enrollment period (run: {}).".format(
                 to_run.courseware_id
@@ -334,6 +339,7 @@ def defer_enrollment(
             order=from_enrollment.order,
             company=from_enrollment.company,
             keep_failed_enrollments=keep_failed_enrollments,
+            force_enrollment=force,
         )
         if to_enrollments:
             from_enrollment = deactivate_run_enrollment(

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -161,16 +161,10 @@ def test_create_run_enrollments(mocker, user, force_enrollment):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "exception_cls, force_enrollment",
-    [
-        (NoEdxApiAuthError, True),
-        (HTTPError, True),
-        (RequestsConnectionError, True),
-        (NoEdxApiAuthError, False),
-        (HTTPError, False),
-        (RequestsConnectionError, False),
-    ],
+    "exception_cls",
+    [NoEdxApiAuthError, HTTPError, RequestsConnectionError],
 )
+@pytest.mark.parametrize("force_enrollment", [True, False])
 def test_create_run_enrollments_api_fail(mocker, user, exception_cls, force_enrollment):
     """
     create_run_enrollments should log a message and still create local enrollment records when certain exceptions

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -218,7 +218,7 @@ def test_create_run_enrollments_enroll_api_fail(
     force_enrollment,
     exception_cls,
     inner_exception,
-):
+):  # pylint: disable=too-many-arguments
     """
     create_run_enrollments should log a message and still create local enrollment records when an enrollment exception
     is raised if a flag is set to true

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -141,9 +141,9 @@ def test_create_run_enrollments(mocker, user):
     )
 
     successful_enrollments, edx_request_success = create_run_enrollments(
-        user, runs, order=order, company=company
+        user, runs, order=order, company=company, force_enrollment=False
     )
-    patched_edx_enroll.assert_called_once_with(user, runs)
+    patched_edx_enroll.assert_called_once_with(user, runs, force_enrollment=False)
     assert patched_send_enrollment_email.call_count == num_runs
     assert edx_request_success is True
     assert len(successful_enrollments) == num_runs
@@ -174,9 +174,14 @@ def test_create_run_enrollments_api_fail(mocker, user, exception_cls):
     )
     run = CourseRunFactory.create()
     successful_enrollments, edx_request_success = create_run_enrollments(
-        user, [run], order=None, company=None, keep_failed_enrollments=True
+        user,
+        [run],
+        order=None,
+        company=None,
+        keep_failed_enrollments=True,
+        force_enrollment=False,
     )
-    patched_edx_enroll.assert_called_once_with(user, [run])
+    patched_edx_enroll.assert_called_once_with(user, [run], force_enrollment=False)
     patched_log_exception.assert_called_once()
     patched_send_enrollment_email.assert_not_called()
     assert len(successful_enrollments) == 1
@@ -221,8 +226,9 @@ def test_create_run_enrollments_enroll_api_fail(
             order=None,
             company=None,
             keep_failed_enrollments=keep_failed_enrollments,
+            force_enrollment=False,
         )
-    patched_edx_enroll.assert_called_once_with(user, runs)
+    patched_edx_enroll.assert_called_once_with(user, runs, force_enrollment=False)
     if keep_failed_enrollments:
         patched_log_exception.assert_called_once()
     else:
@@ -250,9 +256,9 @@ def test_create_run_enrollments_creation_fail(mocker, user):
     patched_mail_api = mocker.patch("courses.api.mail_api")
 
     successful_enrollments, edx_request_success = create_run_enrollments(
-        user, runs, order=None, company=None
+        user, runs, order=None, company=None, force_enrollment=False
     )
-    patched_edx_enroll.assert_called_once_with(user, runs)
+    patched_edx_enroll.assert_called_once_with(user, runs, force_enrollment=False)
     patched_log_exception.assert_called_once()
     patched_mail_api.send_course_run_enrollment_email.assert_not_called()
     patched_mail_api.send_enrollment_failure_message.assert_called_once()
@@ -452,6 +458,7 @@ def test_defer_enrollment(mocker, keep_failed_enrollments):
         order=order,
         company=company,
         keep_failed_enrollments=keep_failed_enrollments,
+        force_enrollment=False,
     )
     patched_deactivate_enrollments.assert_called_once_with(
         existing_enrollment,

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -417,27 +417,38 @@ def test_get_edx_api_client(mocker, settings, user):
     )
 
 
-def test_enroll_in_edx_course_runs(mocker, user):
+@pytest.mark.parametrize("force_enrollment", [True, False])
+def test_enroll_in_edx_course_runs(mocker, user, force_enrollment):
     """Tests that enroll_in_edx_course_runs uses the EdxApi client to enroll in course runs"""
     mock_client = mocker.MagicMock()
     enroll_return_values = ["result1", "result2"]
     mock_client.enrollments.create_student_enrollment = mocker.Mock(
         side_effect=enroll_return_values
     )
-    mocker.patch("courseware.api.get_edx_api_client", return_value=mock_client)
+    if force_enrollment:
+        mocker.patch(
+            "courseware.api.get_edx_api_service_client", return_value=mock_client
+        )
+    else:
+        mocker.patch("courseware.api.get_edx_api_client", return_value=mock_client)
     course_runs = CourseRunFactory.build_batch(2)
-    enroll_results = enroll_in_edx_course_runs(user, course_runs)
+    enroll_results = enroll_in_edx_course_runs(
+        user,
+        course_runs,
+        force_enrollment=force_enrollment,
+    )
+    expected_username = user.username if force_enrollment else None
     mock_client.enrollments.create_student_enrollment.assert_any_call(
         course_runs[0].courseware_id,
         mode=EDX_ENROLLMENT_PRO_MODE,
-        username=None,
-        force_enrollment=False,
+        username=expected_username,
+        force_enrollment=force_enrollment,
     )
     mock_client.enrollments.create_student_enrollment.assert_any_call(
         course_runs[1].courseware_id,
         mode=EDX_ENROLLMENT_PRO_MODE,
-        username=None,
-        force_enrollment=False,
+        username=expected_username,
+        force_enrollment=force_enrollment,
     )
     assert enroll_results == enroll_return_values
 

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -428,10 +428,16 @@ def test_enroll_in_edx_course_runs(mocker, user):
     course_runs = CourseRunFactory.build_batch(2)
     enroll_results = enroll_in_edx_course_runs(user, course_runs)
     mock_client.enrollments.create_student_enrollment.assert_any_call(
-        course_runs[0].courseware_id, mode=EDX_ENROLLMENT_PRO_MODE
+        course_runs[0].courseware_id,
+        mode=EDX_ENROLLMENT_PRO_MODE,
+        username=None,
+        force_enrollment=False,
     )
     mock_client.enrollments.create_student_enrollment.assert_any_call(
-        course_runs[1].courseware_id, mode=EDX_ENROLLMENT_PRO_MODE
+        course_runs[1].courseware_id,
+        mode=EDX_ENROLLMENT_PRO_MODE,
+        username=None,
+        force_enrollment=False,
     )
     assert enroll_results == enroll_return_values
 
@@ -452,10 +458,16 @@ def test_enroll_in_edx_course_runs_audit(mocker, user, error_text):
     results = enroll_in_edx_course_runs(user, [course_run])
     assert mock_client.enrollments.create_student_enrollment.call_count == 2
     mock_client.enrollments.create_student_enrollment.assert_any_call(
-        course_run.courseware_id, mode=EDX_ENROLLMENT_PRO_MODE
+        course_run.courseware_id,
+        mode=EDX_ENROLLMENT_PRO_MODE,
+        username=None,
+        force_enrollment=False,
     )
     mock_client.enrollments.create_student_enrollment.assert_any_call(
-        course_run.courseware_id, mode=EDX_ENROLLMENT_AUDIT_MODE
+        course_run.courseware_id,
+        mode=EDX_ENROLLMENT_AUDIT_MODE,
+        username=None,
+        force_enrollment=False,
     )
     assert results == [audit_result]
     patched_log_error.assert_called_once()

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ django-oauth-toolkit==1.4.0
 django-user-agents==0.4.0
 djangorestframework==3.12.4
 djoser==2.1.0
-edx-api-client==0.10.0
+edx-api-client==1.7.0
 django-storages==1.13.1
 drf-flex-fields==0.8.5
 google-api-python-client==1.7.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -399,7 +399,6 @@ six==1.16.0
     # via
     #   click-repl
     #   django-compat
-    #   edx-api-client
     #   google-api-python-client
     #   google-auth
     #   google-auth-httplib2

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,7 +181,7 @@ draftjs-exporter==2.1.7
     # via wagtail
 drf-flex-fields==0.8.5
     # via -r requirements.in
-edx-api-client==0.10.0
+edx-api-client==1.7.0
     # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
#2631 

#### What's this PR do?
A site admin can run the `defer_enrollment` management command to transfer a user to a course run even after the enrollment period ends

#### How should this be manually tested?
  - `edX` and `xpro` should be working on the local machine
  - Try to enroll a user in an enrollment-expired course run using the `defer_enrollment` command using `-f` argument
  - Validate the user is enrolled in the given course run on `xpro` and `edX` on your localhost