### PR TITLE
Use new hubspot_api version and try to sync contacts individually if a batched sync chunk fails

### DIFF
--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -240,6 +240,30 @@ def test_batch_update_hubspot_objects_chunked(mocker, id_count):
     )
 
 
+@pytest.mark.parametrize(
+    "status, expected_error", [[429, TooManyRequestsException], [500, ApiException]]
+)
+def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_error):
+    """batch_update_hubspot_objects_chunked raise expected exception"""
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.update.side_effect = (
+        ApiException(status=status)
+    )
+    mock_sync_contacts = mocker.patch(
+        "hubspot_xpro.tasks.api.sync_contact_with_hubspot",
+        side_effect=(ApiException(status=status)),
+    )
+    chunk = [(user.id, "123") for user in UserFactory.create_batch(3)]
+    with pytest.raises(expected_error):
+        tasks.batch_update_hubspot_objects_chunked(
+            HubspotObjectType.CONTACTS.value,
+            "user",
+            chunk,
+        )
+    for item in chunk:
+        mock_sync_contacts.assert_any_call(item[0])
+
+
 @pytest.mark.parametrize("id_count", [5, 15])
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
@@ -268,6 +292,30 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
             ]
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "status, expected_error", [[429, TooManyRequestsException], [500, ApiException]]
+)
+def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_error):
+    """batch_create_hubspot_objects_chunked raise expected exception"""
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.side_effect = (
+        ApiException(status=status)
+    )
+    mock_sync_contact = mocker.patch(
+        "hubspot_xpro.tasks.api.sync_contact_with_hubspot",
+        side_effect=(ApiException(status=status)),
+    )
+    chunk = sorted([user.id for user in UserFactory.create_batch(3)])
+    with pytest.raises(expected_error):
+        tasks.batch_create_hubspot_objects_chunked(
+            HubspotObjectType.CONTACTS.value,
+            "user",
+            chunk,
+        )
+    for item in chunk:
+        mock_sync_contact.assert_any_call(item)
 
 
 def test_batch_upsert_associations(
@@ -366,3 +414,47 @@ def test_batch_upsert_associations_chunked(mocker):
 def test_task_obj_lock(func_name, args, kwargs, result):
     """task_obj_lock should return expected result string"""
     assert task_obj_lock(func_name, args, kwargs) == result
+
+
+def test_sync_failed_contacts(mocker):
+    """sync_failed_contacts should try to sync each contact and return a list of failed contact ids"""
+    user_ids = sorted(user.id for user in UserFactory.create_batch(4))
+    mock_sync = mocker.patch(
+        "hubspot_xpro.tasks.api.sync_contact_with_hubspot",
+        side_effect=[
+            mocker.Mock(),
+            ApiException(status=500, reason="err"),
+            mocker.Mock(),
+            ApiException(status=429, reason="tmr"),
+        ],
+    )
+    result = tasks.sync_failed_contacts(user_ids)
+    assert mock_sync.call_count == 4
+    assert result == [user_ids[1], user_ids[3]]
+
+
+@pytest.mark.parametrize("for_contacts", [True, False])
+@pytest.mark.parametrize("has_errors", [True, False])
+def test_handle_failed_batch_chunk(mocker, for_contacts, has_errors):
+    """handle_failed_batch_chunk should retry contacts only and log exceptions as appropriate"""
+    object_ids = [1, 2, 3, 4]
+    expected_sync_result = object_ids if has_errors or not for_contacts else []
+    hubspot_type = (
+        HubspotObjectType.CONTACTS.value
+        if for_contacts
+        else HubspotObjectType.DEALS.value
+    )
+    mock_sync_contacts = mocker.patch(
+        "hubspot_xpro.tasks.sync_failed_contacts", return_value=expected_sync_result
+    )
+    mock_log = mocker.patch("hubspot_xpro.tasks.log.exception")
+    tasks.handle_failed_batch_chunk(object_ids, hubspot_type)
+    assert mock_sync_contacts.call_count == (
+        1 if hubspot_type == HubspotObjectType.CONTACTS.value else 0
+    )
+    if has_errors or not for_contacts:
+        mock_log.assert_called_once_with(
+            "Exception when batch syncing Hubspot ids %s of type %s",
+            f"{expected_sync_result}",
+            hubspot_type,
+        )

--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ hubspot-api-client
 ipython
 mitol-django-common==2.7.0
 mitol-django-digital-credentials==3.3.0
-mitol-django-hubspot-api==1.1.0
+mitol-django-hubspot-api~=2023.5.22
 mitol-django-mail==3.3.0
 mitol-django-oauth-toolkit-extensions==1.3.0
 mitol-django-authentication==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -267,7 +267,7 @@ mitol-django-common==2.7.0
     #   mitol-django-oauth-toolkit-extensions
 mitol-django-digital-credentials==3.3.0
     # via -r requirements.in
-mitol-django-hubspot-api==1.1.0
+mitol-django-hubspot-api==2023.5.22
     # via -r requirements.in
 mitol-django-mail==3.3.0
     # via
@@ -376,6 +376,7 @@ requests==2.27.1
     #   edx-api-client
     #   mitol-django-common
     #   mitol-django-digital-credentials
+    #   mitol-django-hubspot-api
     #   mitol-django-oauth-toolkit-extensions
     #   premailer
     #   requests-oauthlib


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What's this PR do?
- Uses the new version of mitol.hubspot_api which can handle conflicts caused by a Hubspot contact having 2 emails associated with different bootcamps users
- Modifies the batch create/update tasks to try syncing contacts individually (to hit code above) if any API exceptions occur when running batch sync operations.

#### How should this be manually tested?
- Ask for access to the xprodev sandbox account for hubspot if you don't already have it.
- Copy the `HUBSPOT_*` settings values from RC to your .env file

Part 1:
- Create a new user in xpro, something like `fake_user+1@gmail.com`
- Find the contact in hubspot (may take a minute or so to show up) and add a secondary email to that contact: `fake_user+2@gmail.com`

<img width="542" alt="Screenshot 2023-05-11 at 10 30 32 AM" src="https://github.com/mitodl/mitxonline/assets/187676/fa1cea9a-4900-4707-89e0-98ec1a301e84">

- Register another new user with that same email - `fake_user+2@gmail.com`
- Check back on hubspot, that secondary email should be gone from the contact, and there should be a new contact with email `fake_user+2@gmail.com`

Part 2:
- Comment out your hubspot .env settings and restart your containers
- Create another new user, `fake_user+3@gmail.com`
- In hubspot, add that email to one of the existing contacts as a secondary email
- Uncomment your hubspot .env settings and restart your containers
- Run `manage.py sync_db_to_hubspot --users create`.  It should complete successfully
- Check hubspot again, the secondary email from the contact should be gone and assigned to a new contact.


