### PR TITLE
Manually bump cryptography from 38.0.3 to 40.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ coreapi==2.3.3
     # via djoser
 coreschema==0.0.4
     # via coreapi
-cryptography==38.0.3
+cryptography==40.0.2
     # via social-auth-core
 cssselect==1.1.0
     # via premailer


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/security/dependabot/78

#### What's this PR do?
Fixes the issue https://github.com/mitodl/mitxpro/security/dependabot/78. Also, rebase was not working on this PR https://github.com/mitodl/mitxpro/pull/2567 So created a manual PR with the latest version

#### How should this be manually tested?
All tests should be passed, Register, Login, Enrollment, and Cubersource testing would be enough.
