### PR TITLE
fix: create enrollments when token creation fails

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -6,15 +6,16 @@ from collections import namedtuple
 from traceback import format_exc
 
 from django.core.exceptions import ValidationError
-from requests.exceptions import HTTPError, ConnectionError as RequestsConnectionError
+from requests.exceptions import ConnectionError as RequestsConnectionError, HTTPError
 
 from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
 from courses.models import CourseRun, CourseRunEnrollment, ProgramEnrollment
 from courseware.api import enroll_in_edx_course_runs, unenroll_edx_course_run
 from courseware.exceptions import (
-    EdxEnrollmentCreateError,
     EdxApiEnrollErrorException,
+    EdxEnrollmentCreateError,
     NoEdxApiAuthError,
+    OpenEdXOAuth2Error,
     UnknownEdxApiEnrollException,
 )
 from ecommerce import mail_api
@@ -121,6 +122,7 @@ def create_run_enrollments(
         NoEdxApiAuthError,
         HTTPError,
         RequestsConnectionError,
+        OpenEdXOAuth2Error,
     ):
         error_message = (
             "edX enrollment failure for user: {}, runs: {} (order: {})".format(

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -27,6 +27,7 @@ from courses.factories import (
     ProgramEnrollmentFactory,
     ProgramFactory,
 )
+
 # pylint: disable=redefined-outer-name
 from courses.models import CourseRunEnrollment, ProgramEnrollment
 from courseware.exceptions import (

--- a/courses/api_test.py
+++ b/courses/api_test.py
@@ -1,42 +1,42 @@
 """Courses API tests"""
+import contextlib
 from datetime import timedelta
 from types import SimpleNamespace
 
-import contextlib
-import pytest
 import factory
+import pytest
 from django.core.exceptions import ValidationError
-from requests import HTTPError, ConnectionError as RequestsConnectionError
+from requests import ConnectionError as RequestsConnectionError, HTTPError
 
 from courses.api import (
-    get_user_enrollments,
-    deactivate_run_enrollment,
-    deactivate_program_enrollment,
-    create_run_enrollments,
     create_program_enrollments,
+    create_run_enrollments,
+    deactivate_program_enrollment,
+    deactivate_run_enrollment,
     defer_enrollment,
+    get_user_enrollments,
 )
 from courses.constants import (
-    ENROLL_CHANGE_STATUS_REFUNDED,
     ENROLL_CHANGE_STATUS_DEFERRED,
+    ENROLL_CHANGE_STATUS_REFUNDED,
 )
 from courses.factories import (
-    ProgramFactory,
-    CourseRunFactory,
-    CourseRunEnrollmentFactory,
-    ProgramEnrollmentFactory,
     CourseFactory,
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+    ProgramEnrollmentFactory,
+    ProgramFactory,
 )
-
 # pylint: disable=redefined-outer-name
 from courses.models import CourseRunEnrollment, ProgramEnrollment
 from courseware.exceptions import (
-    EdxEnrollmentCreateError,
-    UnknownEdxApiEnrollException,
     EdxApiEnrollErrorException,
+    EdxEnrollmentCreateError,
     NoEdxApiAuthError,
+    OpenEdXOAuth2Error,
+    UnknownEdxApiEnrollException,
 )
-from ecommerce.factories import OrderFactory, CompanyFactory
+from ecommerce.factories import CompanyFactory, OrderFactory
 from mitxpro.test_utils import MockHttpError
 from mitxpro.utils import now_in_utc
 
@@ -162,7 +162,7 @@ def test_create_run_enrollments(mocker, user, force_enrollment):
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "exception_cls",
-    [NoEdxApiAuthError, HTTPError, RequestsConnectionError],
+    [NoEdxApiAuthError, HTTPError, RequestsConnectionError, OpenEdXOAuth2Error],
 )
 @pytest.mark.parametrize("force_enrollment", [True, False])
 def test_create_run_enrollments_api_fail(mocker, user, exception_cls, force_enrollment):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1487

#### What's this PR do?
Creates enrollment in xPro if edX enrollment fails due to the missing user account on edX.

#### How should this be manually tested?
This issue exists when a user does not exist in edX but exists in xPro and we try to enroll.

On Master Branch:
- Create a new user in xPro that does not exist on edX. Maybe stop edX and create your user in xPro. OR Delete a user from edX.
- Enroll in a course. Complete Cybersource payment.
- You will get an exception OpenEdXOAuth2Error.
- Order is successfully created with Fulfilled State but course run enrollment is not created.

Now repeat the above steps with the changes in this PR. You won't get any exceptions and the course run enrollment is created with edx_enrolled=False.

NOTE: If you are not able to reproduce OpenEdXOAuth2Error on the master branch due to some other error. You can change these code lines and try to enroll a user.

- Comment out lines 263-265 in courseware/api.py
- Update line 455 to `auth = None`
- Update line 461 `auth = None or create_edx_auth_token(user)`

#### Where should the reviewer start?
By getting through the ticket and this comment https://github.com/mitodl/hq/issues/1487#issuecomment-1562614553.
