### PR TITLE
hotfix: hide the Webinars link from top app bar

### DIFF
--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -67,7 +67,7 @@ const TopAppBar = ({ currentUser, location, errorPageHeader, courseTopics }: Pro
             className="collapse navbar-collapse px-0 justify-content-end"
           >
             <li>
-              <a href={routes.webinars} className="" aria-label="webinars">
+              <a href={routes.webinars} className="" aria-label="webinars" style = {{display: "None" }}>
                 Webinars
               </a>
             </li>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
None, Hot fix

#### What's this PR do?
- Hides the `Webinars` link from the Top App bar

#### How should this be manually tested?
- Just check that there is no `Webinars` link in the app bar and the design stays intact 

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
This PR is based on master which has some other functionalities e.g. Courses drop-down but it won't be there in production.
<img width="1789" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/bb3b95a9-341b-4913-ad83-8a0be439213d">

#### What GIF best describes this PR or how it makes you feel?
(Optional)
