### PR TITLE
Django bypasses validation when using one form field to upload multiple files

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ celery==5.2.2
 celery-redbeat==2.0.0
 boto3==1.26.18
 dj-database-url==0.5.0
-django==3.2.18
+django==3.2.19
 django-anymail[mailgun]==8.4
 django-filter==2.4.0
 django-hijack==2.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ defusedxml==0.7.1
     #   zeep
 dj-database-url==0.5.0
     # via -r requirements.in
-django==3.2.18
+django==3.2.19
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backward-compatible with the current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
fixes https://github.com/mitodl/mitxpro/security/dependabot/91

#### What's this PR do?
This fix is related to uploading multiple files using one form field and has never been supported by [forms.FileField](https://docs.djangoproject.com/en/4.2/ref/forms/fields/#django.forms.FileField) or [forms.ImageField](https://docs.djangoproject.com/en/4.2/ref/forms/fields/#django.forms.ImageField) as only the last uploaded file was validated.

#### How should this be manually tested?
- This is a minor upgrade from `3.2.18` to `3.2.19`
- We currently do not have a form supporting multiple files or image uploads
- Smoke tests would be enough
