### PR TITLE
fix: Certificates creation does not halt entire process

### DIFF
--- a/courses/management/commands/sync_grades_and_certificates.py
+++ b/courses/management/commands/sync_grades_and_certificates.py
@@ -90,27 +90,31 @@ class Command(BaseCommand):
 
         results = []
         for edx_grade, user in edx_grade_user_iter:
-            course_run_grade, created_grade, updated_grade = ensure_course_run_grade(
-                user=user,
-                course_run=run,
-                edx_grade=edx_grade,
-                should_update=should_update,
-            )
+            try:
+                (
+                    course_run_grade,
+                    created_grade,
+                    updated_grade,
+                ) = ensure_course_run_grade(
+                    user=user,
+                    course_run=run,
+                    edx_grade=edx_grade,
+                    should_update=should_update,
+                )
 
-            if override_grade is not None:
-                course_run_grade.grade = override_grade
-                course_run_grade.passed = bool(override_grade)
-                course_run_grade.letter_grade = None
-                course_run_grade.set_by_admin = True
-                try:
+                if override_grade is not None:
+                    course_run_grade.grade = override_grade
+                    course_run_grade.passed = bool(override_grade)
+                    course_run_grade.letter_grade = None
+                    course_run_grade.set_by_admin = True
                     course_run_grade.save_and_log(None)
-                except Exception as e:
-                    self.stdout.write(
-                        self.style.ERROR(
-                            f"Course certificate creation failed for {user.email} due to following reason(s),\n{e}"
-                        )
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Course certificate creation failed for {user.email} due to following reason(s),\n{e}"
                     )
-                    continue
+                )
+                continue
 
             _, created_cert, deleted_cert = process_course_run_grade_certificate(
                 course_run_grade=course_run_grade

--- a/courses/management/commands/sync_grades_and_certificates.py
+++ b/courses/management/commands/sync_grades_and_certificates.py
@@ -102,7 +102,15 @@ class Command(BaseCommand):
                 course_run_grade.passed = bool(override_grade)
                 course_run_grade.letter_grade = None
                 course_run_grade.set_by_admin = True
-                course_run_grade.save_and_log(None)
+                try:
+                    course_run_grade.save_and_log(None)
+                except Exception as e:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Course certificate creation failed for {user.email} due to following reason(s),\n{e}"
+                        )
+                    )
+                    continue
 
             _, created_cert, deleted_cert = process_course_run_grade_certificate(
                 course_run_grade=course_run_grade

--- a/courses/management/commands/sync_grades_and_certificates.py
+++ b/courses/management/commands/sync_grades_and_certificates.py
@@ -108,17 +108,17 @@ class Command(BaseCommand):
                     course_run_grade.letter_grade = None
                     course_run_grade.set_by_admin = True
                     course_run_grade.save_and_log(None)
+
+                _, created_cert, deleted_cert = process_course_run_grade_certificate(
+                    course_run_grade=course_run_grade
+                )
             except Exception as e:
                 self.stdout.write(
                     self.style.ERROR(
-                        f"Course certificate creation failed for {user.email} due to following reason(s),\n{e}"
+                        f"Course certificate creation failed for {user} due to following reason(s),\n{e}"
                     )
                 )
                 continue
-
-            _, created_cert, deleted_cert = process_course_run_grade_certificate(
-                course_run_grade=course_run_grade
-            )
 
             if created_grade:
                 grade_status = "created"
@@ -147,9 +147,7 @@ class Command(BaseCommand):
             )
 
             results.append(
-                "Processed user {} ({}) in course run {}. Result - {}".format(
-                    user.username, user.email, run.courseware_id, result_summary
-                )
+                f"Processed {user} in course run {run.courseware_id}. Result - {result_summary}"
             )
 
         for result in results:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#2675

#### What's this PR do?
This PR adds a try except block ensuring the certificate creation process continues despite some failed entries too

#### How should this be manually tested?
1. Enroll some users in a course
2. Explicitly set `override_grade` in `sync_grades_and_certificates` to value `> 1.0`
3. Run the command `sync_grades_and_certificates --run="course-run" --force`
4. You should see multiple errors for all enrolled courses
5. (Optional) Randomly tweak `override_grade` values for users
6. (Optional) Run the command again, and you will see successful message for the ones which had correct values and errors for the others

#### Screenshots (if appropriate)
<img width="1379" alt="Screenshot 2023-06-14 at 4 35 02 PM" src="https://github.com/mitodl/mitxpro/assets/68846543/10952ff8-575c-4fcd-821d-21f95eb6a1fe">
