### PR TITLE
Manage Program Certificates Command

### DIFF
--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             if _ and not is_created:
                 status = (self.style.SUCCESS, "already exists")
             elif not is_created:
-                status = (self.style.ERROR, "failed")
+                status = (self.style.ERROR, "creation failed")
             else:
                 status = (self.style.SUCCESS, "successfully created")
 

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -52,11 +52,13 @@ class Command(BaseCommand):
             else Q(run__course__program__readable_id=program, active=True)
         )
 
-        enrollments = CourseRunEnrollment.objects.filter(base_query).distinct('user__email', 'run__course__program')
+        enrollments = CourseRunEnrollment.objects.filter(base_query).distinct(
+            "user__email", "run__course__program"
+        )
         if not enrollments:
             raise CommandError(
                 f"Could not find course enrollment(s) with provided program readable_id={program}"
-            ) 
+            )
 
         results = []
         for enrollment in enrollments:

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -80,9 +80,7 @@ class Command(BaseCommand):
                 status = (self.style.SUCCESS, "successfully created")
 
             results.append(
-                status[0](
-                    f"Certificate {status[1]} for {user} in program {program}"
-                )
+                status[0](f"Certificate {status[1]} for {user} in program {program}")
             )
 
         for result in results:

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -1,0 +1,75 @@
+"""
+Management command to sync grades and certificates for a course run
+"""
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from courses.models import ProgramEnrollment
+from courses.utils import generate_program_certificate
+from users.api import fetch_user
+
+
+class Command(BaseCommand):
+    """
+    Command to create program certificates for users.
+    """
+
+    help = "Create program certifificates, specific or all, for user(s)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="The id, email or username of the enrolled User",
+            required=False,
+        )
+        parser.add_argument(
+            "--readable_id",
+            type=str,
+            help="The 'readable_id' value for a Program",
+            required=True,
+        )
+        super().add_arguments(parser)
+
+    def handle(
+        self, *args, **options
+    ):  # pylint: disable=too-many-locals,too-many-branches
+        """Handle command execution"""
+        program = options["readable_id"]
+        user = options["user"] and fetch_user(options["user"])
+        base_query = (
+            Q(program__readable_id=program, user=user)
+            if user
+            else Q(program__readable_id=program)
+        )
+
+        try:
+            enrollments = ProgramEnrollment.objects.filter(base_query)
+        except ProgramEnrollment.DoesNotExist:
+            raise CommandError(
+                "Could not find program enrollment with readable_id={}".format(
+                    options["readable_id"]
+                )
+            )
+
+        results = []
+        for enrollment in enrollments:
+            user = enrollment.user
+            cert, is_created = generate_program_certificate(user, enrollment.program)
+
+            if not cert and not is_created:
+                results.append(
+                    self.style.ERROR(
+                        f"Certificate creation failed for {user.username} ({user.email}) in program {enrollment.program} due to incomplete courses"
+                    )
+                )
+                continue
+
+            results.append(
+                self.style.SUCCESS(
+                    f"Certificate successfully created for {user.username} ({user.email}) in program {enrollment.program}"
+                )
+            )
+
+        for result in results:
+            self.stdout.write(result)

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         program = options.get("readable_id")
         if not program:
             raise CommandError("Please provide a valid program readable_id.")
-        
+
         user = options.get("user") and fetch_user(options["user"])
         base_query = (
             Q(program__readable_id=program, user=user)
@@ -58,9 +58,11 @@ class Command(BaseCommand):
             cert, is_created = generate_program_certificate(user, enrollment.program)
 
             if not cert and not is_created:
-                self.stdout.write(self.style.ERROR(
-                    f"Certificate creation failed for {user.username} ({user.email}) in program {enrollment.program} due to incomplete courses"
-                ))
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Certificate creation failed for {user.username} ({user.email}) in program {enrollment.program} due to incomplete courses"
+                    )
+                )
                 continue
 
             results.append(

--- a/courses/management/commands/manage_program_certificates.py
+++ b/courses/management/commands/manage_program_certificates.py
@@ -72,14 +72,16 @@ class Command(BaseCommand):
             user = enrollment.user
             _, is_created = generate_program_certificate(user, program)
 
-            if not is_created:
-                status = "failed"
+            if _ and not is_created:
+                status = (self.style.SUCCESS, "already exists")
+            elif not is_created:
+                status = (self.style.ERROR, "failed")
             else:
-                status = "successful"
+                status = (self.style.SUCCESS, "successfully created")
 
             results.append(
-                self.style.SUCCESS(
-                    f"Certificate creation {status} for {user} in program {program}"
+                status[0](
+                    f"Certificate {status[1]} for {user} in program {program}"
                 )
             )
 

--- a/courses/management/commands/test_manage_program_certificates.py
+++ b/courses/management/commands/test_manage_program_certificates.py
@@ -1,6 +1,7 @@
 """Tests for Program Certificates management command"""
 
 import pytest
+from itertools import product
 from courses.management.commands import manage_program_certificates
 from courses.models import ProgramCertificate
 from django.core.management.base import CommandError
@@ -12,33 +13,76 @@ from courses.factories import (
     CourseRunEnrollmentFactory,
     ProgramFactory,
 )
+from users.factories import UserFactory
 
 pytestmark = [pytest.mark.django_db]
 
 
 def test_program_certificate_management_no_argument():
-    """Test that command throws error when no input is provided"""
-
+    """Test that command throws error when no arguments are provided"""
     with pytest.raises(CommandError) as command_error:
         manage_program_certificates.Command().handle()
     assert str(command_error.value) == "Please provide a valid program readable_id."
 
 
-def test_program_certificate_management_invalid_program():
-    """
-    Test that program certificate management command throws proper error when
-    no valid program is supplied
-    """
-
+def test_program_certificate_management_no_user_argument():
+    """Test that command generates error when user is not passed"""
+    program = ProgramFactory.create()
     with pytest.raises(CommandError) as command_error:
-        manage_program_certificates.Command().handle(program="test")
+        manage_program_certificates.Command().handle(program=program.readable_id)
     assert (
         str(command_error.value)
-        == "Could not find course enrollment(s) with provided program readable_id=test"
+        == f"Could not find course enrollment(s) with provided program readable_id={program.readable_id}"
     )
 
 
-def test_program_certificate_creation(user):
+def test_program_certificate_management_no_program_argument(user):
+    """Test that command generates error when the program is not passed"""
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle(user=user)
+    assert str(command_error.value) == f"Please provide a valid program readable_id."
+
+
+def test_program_certificate_creation_multiple_users():
+    """
+    Test that program certificate management command creates program certificates
+    when no user and a valid program is supplied
+    """
+
+    def create_course_certificates(args):
+        run, user = args
+        CourseRunEnrollmentFactory.create(user=user, run=run),
+        CourseRunGradeFactory.create(course_run=run, user=user, passed=True, grade=1),
+        CourseRunCertificateFactory.create(course_run=run, user=user),
+
+    program = ProgramFactory.create(readable_id="test")
+    users = UserFactory.create_batch(size=3)
+    courses = CourseFactory.create_batch(size=2, program=program)
+    course_runs = [CourseRunFactory.create(course=course) for course in courses]
+
+    courses_users = product(course_runs, users)
+    list(map(create_course_certificates, courses_users))
+
+    manage_program_certificates.Command().handle(program="test")
+    generated_certificates = ProgramCertificate.objects.filter(program=program)
+
+    assert generated_certificates.count() == len(users)
+
+
+def test_program_not_present():
+    """
+    Test that program certificate management command throws proper error when
+    the provided program is not found
+    """
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle(program="no-program")
+    assert (
+        str(command_error.value)
+        == "Could not find any program with provided readable_id=no-program"
+    )
+
+
+def test_program_certificate_creation_single_user(user):
     """
     Test that create operation for program certificate management command
     creates the program certificate for a user
@@ -67,25 +111,16 @@ def test_incomplete_course_program_certificate(user):
     Test that create operation for program certificate management command
     Testing program certificate creation for incomplete courses
     """
+
+    def create_course_grades(run):
+        CourseRunEnrollmentFactory.create(user=user, run=run)
+        CourseRunGradeFactory.create(course_run=run, user=user, passed=True, grade=1)
+
     program = ProgramFactory.create()
     courses = CourseFactory.create_batch(size=2, program=program)
     course_runs = [CourseRunFactory.create(course=course) for course in courses]
 
-    list(
-        map(
-            lambda run: CourseRunEnrollmentFactory.create(user=user, run=run),
-            course_runs,
-        )
-    )
-    list(
-        map(
-            lambda run: CourseRunGradeFactory.create(
-                course_run=run, user=user, passed=True, grade=1
-            ),
-            course_runs,
-        )
-    )
-
+    list(map(create_course_grades, course_runs))
     # Generating certificate only for a single course
     CourseRunCertificateFactory.create(user=user, course_run=course_runs[0])
     manage_program_certificates.Command().handle(

--- a/courses/management/commands/test_manage_program_certificates.py
+++ b/courses/management/commands/test_manage_program_certificates.py
@@ -11,7 +11,6 @@ from courses.factories import (
     CourseRunCertificateFactory,
     CourseRunEnrollmentFactory,
     ProgramFactory,
-    ProgramEnrollmentFactory,
 )
 
 pytestmark = [pytest.mark.django_db]

--- a/courses/management/commands/test_manage_program_certificates.py
+++ b/courses/management/commands/test_manage_program_certificates.py
@@ -53,7 +53,7 @@ def test_program_certificate_creation(user):
     CourseRunCertificateFactory.create(user=user, course_run=course_run)
 
     manage_program_certificates.Command().handle(
-        readable_id=program.readable_id, user=user.username
+        program=program.readable_id, user=user.username
     )
 
     generated_certificates = ProgramCertificate.objects.filter(
@@ -63,7 +63,7 @@ def test_program_certificate_creation(user):
     assert generated_certificates.count() == 1
 
 
-def test_program_certificate_creation(user):
+def test_incomplete_course_program_certificate(user):
     """
     Test that create operation for program certificate management command
     Testing program certificate creation for incomplete courses

--- a/courses/management/commands/test_manage_program_certificates.py
+++ b/courses/management/commands/test_manage_program_certificates.py
@@ -1,0 +1,60 @@
+"""Tests for Program Certificates management command"""
+
+import pytest
+from courses.management.commands import manage_program_certificates
+from courses.models import ProgramCertificate
+from django.core.management.base import CommandError
+from courses.factories import (
+    CourseFactory,
+    CourseRunFactory,
+    CourseRunGradeFactory,
+    CourseRunCertificateFactory,
+    ProgramFactory,
+    ProgramEnrollmentFactory,
+)
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_program_certificate_management_no_argument():
+    """Test that command throws error when no input is provided"""
+
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle()
+    assert str(command_error.value) == "Please provide a valid program readable_id."
+
+
+def test_program_certificate_management_invalid_program():
+    """
+    Test that program certificate management command throws proper error when
+    no valid program is supplied
+    """
+
+    with pytest.raises(CommandError) as command_error:
+        manage_program_certificates.Command().handle(readable_id="test")
+    assert (
+        str(command_error.value)
+        == "Could not find program enrollment(s) with readable_id=test"
+    )
+
+
+def test_program_certificate_creation(user):
+    """
+    Test that create operation for program certificate management command
+    creates the program certificate for a user
+    """
+    program = ProgramFactory.create()
+    ProgramEnrollmentFactory.create(user=user, program=program)
+    course = CourseFactory.create(program=program)
+    course_run = CourseRunFactory.create(course=course)
+    CourseRunGradeFactory.create(course_run=course_run, user=user, passed=True, grade=1)
+    CourseRunCertificateFactory.create(user=user, course_run=course_run)
+    manage_program_certificates.Command().handle(
+        readable_id=program.readable_id, user=user.username
+    )
+
+    generated_certificates = ProgramCertificate.objects.filter(
+        user=user, program=program
+    )
+
+    assert generated_certificates.count() == 1

--- a/courses/management/commands/test_manage_program_certificates.py
+++ b/courses/management/commands/test_manage_program_certificates.py
@@ -108,8 +108,7 @@ def test_program_certificate_creation_single_user(user):
 
 def test_incomplete_course_program_certificate(user):
     """
-    Test that create operation for program certificate management command
-    Testing program certificate creation for incomplete courses
+    Test that create operation for program certificate management command doesn't create a certificate for incomplete courses
     """
 
     def create_course_grades(run):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2676

#### What's this PR do?
This PR introduces a new management command which helps making program certificates for user(s) on the fly.

#### How should this be manually tested?
1. En-roll a user in a program
2. Complete courses for that program (directly from the admin panel)
3. Once courses are updated, run `docker-compose run --rm web ./manage.py sync_grades_and_certificates --user=user_email --run=<course_run>`
4. Run the following command,  
5.  `docker-compose run --rm web ./manage.py manage_program_certificates --readable_id=<program_id>`
6. You should see message in console, indicating success of certificate creation