### PR TITLE
fix: course not found errros on sentry

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -3,14 +3,31 @@
 import itertools
 import logging
 from collections import namedtuple
+from datetime import timedelta
 from traceback import format_exc
 
 from django.core.exceptions import ValidationError
+from django.conf import settings
+from django.db.models import Q
 from requests.exceptions import ConnectionError as RequestsConnectionError, HTTPError
 
 from courses.constants import ENROLL_CHANGE_STATUS_DEFERRED
-from courses.models import CourseRun, CourseRunEnrollment, ProgramEnrollment
-from courseware.api import enroll_in_edx_course_runs, unenroll_edx_course_run
+from courses.models import (
+    CourseRun,
+    CourseRunCertificate,
+    CourseRunEnrollment,
+    ProgramEnrollment,
+)
+from courses.utils import (
+    ensure_course_run_grade,
+    process_course_run_grade_certificate,
+    sync_course_runs,
+)
+from courseware.api import (
+    enroll_in_edx_course_runs,
+    unenroll_edx_course_run,
+    get_edx_grades_with_users,
+)
 from courseware.exceptions import (
     EdxApiEnrollErrorException,
     EdxEnrollmentCreateError,
@@ -19,7 +36,7 @@ from courseware.exceptions import (
     UnknownEdxApiEnrollException,
 )
 from ecommerce import mail_api
-from mitxpro.utils import first_or_none, partition
+from mitxpro.utils import first_or_none, partition, now_in_utc
 
 
 log = logging.getLogger(__name__)
@@ -352,3 +369,82 @@ def defer_enrollment(
     except EdxEnrollmentCreateError:  # pylint: disable=try-except-raise
         raise
     return from_enrollment, first_or_none(to_enrollments)
+
+
+def generate_course_run_certificates():
+    """Task to generate certificates for course runs"""
+    now = now_in_utc()
+    course_runs = (
+        CourseRun.objects.live()
+        .filter(
+            end_date__lt=now
+            - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
+        )
+        .exclude(
+            id__in=CourseRunCertificate.objects.values_list("course_run__id", flat=True)
+        )
+    )
+
+    for run in course_runs:
+        edx_grade_user_iter = exception_logging_generator(
+            get_edx_grades_with_users(run)
+        )
+        created_grades_count, updated_grades_count, generated_certificates_count = (
+            0,
+            0,
+            0,
+        )
+        for edx_grade, user in edx_grade_user_iter:
+            course_run_grade, created, updated = ensure_course_run_grade(
+                user=user, course_run=run, edx_grade=edx_grade, should_update=True
+            )
+
+            if created:
+                created_grades_count += 1
+            elif updated:
+                updated_grades_count += 1
+
+            _, created, deleted = process_course_run_grade_certificate(
+                course_run_grade=course_run_grade
+            )
+
+            if deleted:
+                log.warning(
+                    "Certificate deleted for user %s and course_run %s", user, run
+                )
+            elif created:
+                generated_certificates_count += 1
+
+        log.info(
+            "Finished processing course run %s: created grades for %d users, "
+            "updated grades for %d users, generated certificates for %d users",
+            run,
+            created_grades_count,
+            updated_grades_count,
+            generated_certificates_count,
+        )
+
+
+def exception_logging_generator(generator):
+    """Returns a new generator that logs exceptions from the given generator and continues with iteration"""
+    while True:
+        try:
+            yield next(generator)
+        except StopIteration:
+            return
+        except HTTPError as exc:
+            log.exception("EdX API error for fetching user grades %s:", exc)
+        except Exception as exp:  # pylint: disable=broad-except
+            log.exception("Error fetching user grades from edX %s:", exp)
+
+
+def sync_course_runs_data():
+    """Sync titles and dates for course runs from edX."""
+    now = now_in_utc()
+    runs = CourseRun.objects.live().filter(
+        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now),
+        course__is_external=False,
+    )
+
+    # `sync_course_runs` logs internally so no need to capture/output the returned values
+    sync_course_runs(runs)

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -12,6 +12,7 @@ from courses.models import CourseRun, CourseRunCertificate
 from courses.utils import (
     ensure_course_run_grade,
     process_course_run_grade_certificate,
+    sync_course_runs
 )
 from courseware.api import get_edx_grades_with_users
 from mitxpro.celery import app
@@ -104,6 +105,4 @@ def sync_courseruns_data():
     )
 
     # `sync_course_runs` logs internally so no need to capture/output the returned values
-    from courses.utils import sync_course_runs
-
     sync_course_runs(runs)

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -94,7 +94,7 @@ def exception_logging_generator(generator):
 @app.task
 def sync_courseruns_data():
     """
-    Task to sync only internal course runs data
+    Task to sync titles and dates for course runs from edX. (Only internal courses)
     """
     now = now_in_utc()
     runs = list(

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -12,7 +12,7 @@ from courses.models import CourseRun, CourseRunCertificate
 from courses.utils import (
     ensure_course_run_grade,
     process_course_run_grade_certificate,
-    sync_course_runs
+    sync_course_runs,
 )
 from courseware.api import get_edx_grades_with_users
 from mitxpro.celery import app

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -99,8 +99,8 @@ def sync_courseruns_data():
     """
     now = now_in_utc()
     runs = CourseRun.objects.live().filter(
-        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now), 
-        course__is_external=False
+        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now),
+        course__is_external=False,
     )
 
     # `sync_course_runs` logs internally so no need to capture/output the returned values

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -2,9 +2,20 @@
 Tasks for the courses app
 """
 import logging
+from datetime import timedelta
 
+from django.conf import settings
+from django.db.models import Q
+from requests.exceptions import HTTPError
+
+from courses.models import CourseRun, CourseRunCertificate
+from courses.utils import (
+    ensure_course_run_grade,
+    process_course_run_grade_certificate,
+)
+from courseware.api import get_edx_grades_with_users
 from mitxpro.celery import app
-
+from mitxpro.utils import now_in_utc
 
 log = logging.getLogger(__name__)
 
@@ -14,16 +25,85 @@ def generate_course_certificates():
     """
     Task to generate certificates for courses.
     """
-    from courses.api import generate_course_run_certificates
+    now = now_in_utc()
+    course_runs = (
+        CourseRun.objects.live()
+        .filter(
+            end_date__lt=now
+            - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
+        )
+        .exclude(
+            id__in=CourseRunCertificate.objects.values_list("course_run__id", flat=True)
+        )
+    )
 
-    generate_course_run_certificates()
+    for run in course_runs:
+        edx_grade_user_iter = exception_logging_generator(
+            get_edx_grades_with_users(run)
+        )
+        created_grades_count, updated_grades_count, generated_certificates_count = (
+            0,
+            0,
+            0,
+        )
+        for edx_grade, user in edx_grade_user_iter:
+            course_run_grade, created, updated = ensure_course_run_grade(
+                user=user, course_run=run, edx_grade=edx_grade, should_update=True
+            )
+
+            if created:
+                created_grades_count += 1
+            elif updated:
+                updated_grades_count += 1
+
+            _, created, deleted = process_course_run_grade_certificate(
+                course_run_grade=course_run_grade
+            )
+
+            if deleted:
+                log.warning(
+                    "Certificate deleted for user %s and course_run %s", user, run
+                )
+            elif created:
+                generated_certificates_count += 1
+
+        log.info(
+            "Finished processing course run %s: created grades for %d users, "
+            "updated grades for %d users, generated certificates for %d users",
+            run,
+            created_grades_count,
+            updated_grades_count,
+            generated_certificates_count,
+        )
+
+
+def exception_logging_generator(generator):
+    """Returns a new generator that logs exceptions from the given generator and continues with iteration"""
+    while True:
+        try:
+            yield next(generator)
+        except StopIteration:
+            return
+        except HTTPError as exc:
+            log.exception("EdX API error for fetching user grades %s:", exc)
+        except Exception as exp:  # pylint: disable=broad-except
+            log.exception("Error fetching user grades from edX %s:", exp)
 
 
 @app.task
 def sync_courseruns_data():
     """
-    Task to sync course runs data
+    Task to sync only internal course runs data
     """
-    from courses.api import sync_course_runs_data
+    now = now_in_utc()
+    runs = list(
+        CourseRun.objects.live().filter(
+            Q(expiration_date__isnull=True) | Q(expiration_date__gt=now),
+            course__is_external=False,
+        )
+    )
 
-    sync_course_runs_data()
+    # `sync_course_runs` logs internally so no need to capture/output the returned values
+    from courses.utils import sync_course_runs
+
+    sync_course_runs(runs)

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -2,21 +2,8 @@
 Tasks for the courses app
 """
 import logging
-from datetime import timedelta
 
-from django.conf import settings
-from django.db.models import Q
-from requests.exceptions import HTTPError
-
-from courses.models import CourseRun, CourseRunCertificate
-from courses.utils import (
-    ensure_course_run_grade,
-    process_course_run_grade_certificate,
-    sync_course_runs,
-)
-from courseware.api import get_edx_grades_with_users
 from mitxpro.celery import app
-from mitxpro.utils import now_in_utc
 
 
 log = logging.getLogger(__name__)
@@ -27,81 +14,16 @@ def generate_course_certificates():
     """
     Task to generate certificates for courses.
     """
-    now = now_in_utc()
-    course_runs = (
-        CourseRun.objects.live()
-        .filter(
-            end_date__lt=now
-            - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
-        )
-        .exclude(
-            id__in=CourseRunCertificate.objects.values_list("course_run__id", flat=True)
-        )
-    )
+    from courses.api import generate_course_run_certificates
 
-    for run in course_runs:
-        edx_grade_user_iter = exception_logging_generator(
-            get_edx_grades_with_users(run)
-        )
-        created_grades_count, updated_grades_count, generated_certificates_count = (
-            0,
-            0,
-            0,
-        )
-        for edx_grade, user in edx_grade_user_iter:
-            course_run_grade, created, updated = ensure_course_run_grade(
-                user=user, course_run=run, edx_grade=edx_grade, should_update=True
-            )
-
-            if created:
-                created_grades_count += 1
-            elif updated:
-                updated_grades_count += 1
-
-            _, created, deleted = process_course_run_grade_certificate(
-                course_run_grade=course_run_grade
-            )
-
-            if deleted:
-                log.warning(
-                    "Certificate deleted for user %s and course_run %s", user, run
-                )
-            elif created:
-                generated_certificates_count += 1
-
-        log.info(
-            "Finished processing course run %s: created grades for %d users, "
-            "updated grades for %d users, generated certificates for %d users",
-            run,
-            created_grades_count,
-            updated_grades_count,
-            generated_certificates_count,
-        )
-
-
-def exception_logging_generator(generator):
-    """Returns a new generator that logs exceptions from the given generator and continues with iteration"""
-    while True:
-        try:
-            yield next(generator)
-        except StopIteration:
-            return
-        except HTTPError as exc:
-            log.exception("EdX API error for fetching user grades %s:", exc)
-        except Exception as exp:  # pylint: disable=broad-except
-            log.exception("Error fetching user grades from edX %s:", exp)
+    generate_course_run_certificates()
 
 
 @app.task
 def sync_courseruns_data():
     """
-    Task to sync titles and dates for course runs from edX.
+    Task to sync course runs data
     """
-    now = now_in_utc()
-    runs = CourseRun.objects.live().filter(
-        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now),
-        course__is_external=False,
-    )
+    from courses.api import sync_course_runs_data
 
-    # `sync_course_runs` logs internally so no need to capture/output the returned values
-    sync_course_runs(runs)
+    sync_course_runs_data()

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -99,7 +99,8 @@ def sync_courseruns_data():
     """
     now = now_in_utc()
     runs = CourseRun.objects.live().filter(
-        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now)
+        Q(expiration_date__isnull=True) | Q(expiration_date__gt=now), 
+        course__is_external=False
     )
 
     # `sync_course_runs` logs internally so no need to capture/output the returned values

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -13,9 +13,7 @@ def test_sync_courseruns_data(mocker):
     sync_course_runs = mocker.patch("courses.utils.sync_course_runs")
 
     course_runs = CourseRunFactory.create_batch(size=3)
-    _ = CourseRunFactory.create_batch(
-        size=3, course__is_external=True
-    )
+    _ = CourseRunFactory.create_batch(size=3, course__is_external=True)
 
     sync_courseruns_data.delay()
     sync_course_runs.assert_called_once_with(course_runs)

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -1,1 +1,23 @@
-"""Course tasks tests"""
+"""Tests for Course related tasks"""
+
+import pytest
+
+from courses.tasks import generate_course_certificates, sync_courseruns_data
+
+pytestmark = pytest.mark.django_db
+
+
+def test_generate_course_certificates_task(mocker):
+    """Test generate_course_certificates calls the right api functionality from courses"""
+    generate_course_run_certificates = mocker.patch(
+        "courses.api.generate_course_run_certificates"
+    )
+    generate_course_certificates.delay()
+    generate_course_run_certificates.assert_called_once()
+
+
+def test_sync_courseruns_data(mocker):
+    """Test sync_courseruns_data calls the right api functionality from courses"""
+    sync_course_runs_data_task = mocker.patch("courses.api.sync_course_runs_data")
+    sync_courseruns_data.delay()
+    sync_course_runs_data_task.assert_called_once()

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -3,7 +3,7 @@
 import pytest
 
 from courses.tasks import sync_courseruns_data
-from courses.factories import CourseFactory, CourseRunFactory
+from courses.factories import CourseRunFactory
 
 pytestmark = [pytest.mark.django_db]
 
@@ -13,7 +13,7 @@ def test_sync_courseruns_data(mocker):
     sync_course_runs = mocker.patch("courses.utils.sync_course_runs")
 
     course_runs = CourseRunFactory.create_batch(size=3)
-    external_course_runs = CourseRunFactory.create_batch(
+    _ = CourseRunFactory.create_batch(
         size=3, course__is_external=True
     )
 

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -10,10 +10,10 @@ pytestmark = [pytest.mark.django_db]
 
 def test_sync_courseruns_data(mocker):
     """Test sync_courseruns_data calls the right api functionality from courses"""
-    sync_course_runs = mocker.patch("courses.utils.sync_course_runs")
+    sync_course_runs = mocker.patch("courses.tasks.sync_course_runs")
 
     course_runs = CourseRunFactory.create_batch(size=3)
-    _ = CourseRunFactory.create_batch(size=3, course__is_external=True)
+    CourseRunFactory.create_batch(size=3, course__is_external=True)
 
     sync_courseruns_data.delay()
     sync_course_runs.assert_called_once_with(course_runs)

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -2,22 +2,20 @@
 
 import pytest
 
-from courses.tasks import generate_course_certificates, sync_courseruns_data
+from courses.tasks import sync_courseruns_data
+from courses.factories import CourseFactory, CourseRunFactory
 
-pytestmark = pytest.mark.django_db
-
-
-def test_generate_course_certificates_task(mocker):
-    """Test generate_course_certificates calls the right api functionality from courses"""
-    generate_course_run_certificates = mocker.patch(
-        "courses.api.generate_course_run_certificates"
-    )
-    generate_course_certificates.delay()
-    generate_course_run_certificates.assert_called_once()
+pytestmark = [pytest.mark.django_db]
 
 
 def test_sync_courseruns_data(mocker):
     """Test sync_courseruns_data calls the right api functionality from courses"""
-    sync_course_runs_data_task = mocker.patch("courses.api.sync_course_runs_data")
+    sync_course_runs = mocker.patch("courses.utils.sync_course_runs")
+
+    course_runs = CourseRunFactory.create_batch(size=3)
+    external_course_runs = CourseRunFactory.create_batch(
+        size=3, course__is_external=True
+    )
+
     sync_courseruns_data.delay()
-    sync_course_runs_data_task.assert_called_once()
+    sync_course_runs.assert_called_once_with(course_runs)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #2671

#### What's this PR do?
This PR resolves the errors logged in sentry regarding missing courses in edx

#### How should this be manually tested?
1. Mark some courses external locally via local admin
2. Execute the python shell in mirxpro-web docker container, `docker exec -it mitxpro-web-1 ./manage.py shell`
3. Fetch the courses via new queryset and either compare the lengths of objects returned or the is_external propertry of the objects
