### PR TITLE
Force enrollment when deferring enrollment

### DIFF
--- a/sheets/deferral_request_api.py
+++ b/sheets/deferral_request_api.py
@@ -172,7 +172,7 @@ class DeferralRequestHandler(EnrollmentChangeRequestHandler):
                 user,
                 from_courseware_id=deferral_req_row.from_courseware_id,
                 to_courseware_id=deferral_req_row.to_courseware_id,
-                force=True
+                force=True,
             )
             # When #1838 is completed, this logic can be removed
             if not from_enrollment and not to_enrollment:

--- a/sheets/deferral_request_api.py
+++ b/sheets/deferral_request_api.py
@@ -172,6 +172,7 @@ class DeferralRequestHandler(EnrollmentChangeRequestHandler):
                 user,
                 from_courseware_id=deferral_req_row.from_courseware_id,
                 to_courseware_id=deferral_req_row.to_courseware_id,
+                force=True
             )
             # When #1838 is completed, this logic can be removed
             if not from_enrollment and not to_enrollment:


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/1895

#### What's this PR do?
Set 'force' flag when processing deferral requests.

This would proceed with enrollment if:
1) from enrollment not active
2) if course run is outside of the enrollment window

#### How should this be manually tested?
Have google sheets set up locally, for setup follow [instructions](https://github.com/mitodl/mitxpro/blob/master/sheets/dev-setup.md).
Submit a request for a deferral where the "To Course" is not within enrollment window. The enrollment should succeed.