### PR TITLE
feat: update catalog ordering

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -1,7 +1,7 @@
 """API for the CMS app"""
 import itertools
 import logging
-from datetime import MINYEAR, datetime
+from datetime import MAXYEAR, datetime
 
 import pytz
 from django.contrib.contenttypes.models import ContentType
@@ -46,7 +46,7 @@ def filter_and_sort_catalog_pages(
 
     page_run_dates = {
         page: page.product.next_run_date
-        or datetime(year=MINYEAR, month=1, day=1, tzinfo=pytz.UTC)
+        or datetime(year=MAXYEAR, month=1, day=1, tzinfo=pytz.UTC)
         for page in itertools.chain(
             valid_program_pages,
             valid_course_pages,

--- a/cms/api_test.py
+++ b/cms/api_test.py
@@ -99,18 +99,18 @@ def test_filter_and_sort_catalog_pages():  # pylint:disable=too-many-locals
 
     # Pages should be sorted by next run date
     assert [page.program for page in program_pages] == [
-        earlier_external_program_page.program,
         first_program_run.course.program,
         second_program_run.course.program,
         later_external_program_page.program,
+        earlier_external_program_page.program,
     ]
     expected_course_run_sort = [
-        future_enrollment_end_run,
-        earlier_external_course_page,
         non_program_run,
         first_program_run,
         second_program_run,
         later_external_course_page,
+        future_enrollment_end_run,
+        earlier_external_course_page,
     ]
 
     # The sort should also include external course pages as expected


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/2037

#### What's this PR do?
Updates the catalog course ordering. Moves the courses with no start date to the end.

#### How should this be manually tested?

- Create some external courses.
- Create some internal courses with the start date in the past but the end date should be in the future.
- Create some courses with start dates in the future.
- Catalog will display the start date for only future start dates. Verify that courses without a start date are at the end of the catalog.

#### Screenshots (if appropriate)
<img width="877" alt="Screen Shot 2023-08-03 at 10 43 19 AM" src="https://github.com/mitodl/mitxpro/assets/52656433/b2fb07df-3da6-48f2-8b2f-9085a194498a">

