### PR TITLE
fix: more dates links for external courseware

### DIFF
--- a/cms/templates/partials/metadata-tiles.html
+++ b/cms/templates/partials/metadata-tiles.html
@@ -16,11 +16,17 @@
                       <p>Click below to enroll in one of these dates</p>
                     </div>
                     {% for course_run in course_runs %}
+                    {% if course_run.course.page.external_marketing_url %}
+                      <div>
+                        <a class='date-link' href={{ course_run.course.page.external_marketing_url }}>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
+                      </div>
+                    {% else %}
                       <div>
                         <a class='date-link' href='{% url 'checkout-page' %}?product={{ course_run.products.first.id }}'>Start Date {{ course_run.start_date|date:'F j, Y' }}</a>
                       </div>
+                    {% endif %}
                     {% endfor %}">
-                  More Dates
+                    More Dates
                 </a>
               </span>
             {% endwith %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/2035

#### What's this PR do?
- Fixes a bug with external course links from within More dates
- Clicking any date from more dates should behave like `Learn More` button and should take the user to the external website instead of the checkout page.

#### How should this be manually tested?
- Setup some external courses, Programs
- Setup multiple enrollable runs
- Check that you see the `More Dates` link in the Course details page's tiles
- Now click on any date from the more dates, and they should all resolve to the external marketing site URL defined in the CMS page of the course or program instead of the checkout page.

#### Where should the reviewer start?
- Setup external courseware


#### Screenshots (if appropriate)
<img width="1788" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/54782c91-e10f-4845-b47a-476c8b04ceb0">


