### PR TITLE
fix: include todays webinars in upcoming webinars list

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -183,7 +183,7 @@ class WebinarIndexPage(Page, CanCreatePageMixin):
         """Populate the context with a dict of categories and live webinars"""
         webinars = (
             WebinarPage.objects.live()
-            .exclude(Q(category=UPCOMING_WEBINAR) & Q(date__lte=now_in_utc().date()))
+            .exclude(Q(category=UPCOMING_WEBINAR) & Q(date__lt=now_in_utc().date()))
             .order_by("-category", "date")
         )
         webinars_dict = defaultdict(lambda: [])


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
A small fix for https://github.com/mitodl/mitxpro/pull/2704

#### What's this PR do?
Includes upcoming webinars with a start date equal to the current date.

#### How should this be manually tested?
Create an upcoming webinar with the start date  = today's date and verify that it shows up on webinar list page at `/webinars`

