### PR TITLE
fix: update hubspot settings default values

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1236,16 +1236,16 @@ HUBSPOT_TASK_DELAY = get_int(
 HUBSPOT_CONFIG = {
     "HUBSPOT_NEW_COURSES_FORM_GUID": get_string(
         name="HUBSPOT_NEW_COURSES_FORM_GUID",
-        default="b9220dc1-4e48-4097-8539-9f2907f18b1e",
+        default="",
         description="Form guid over hub spot for new courses email subscription form.",
     ),
     "HUBSPOT_FOOTER_FORM_GUID": get_string(
         name="HUBSPOT_FOOTER_FORM_GUID",
-        default="ff810010-c33c-4e99-9285-32d283fbc816",
+        default="",
         description="Form guid over hub spot for footer block.",
     ),
     "HUBSPOT_PORTAL_ID": get_string(
-        name="HUBSPOT_PORTAL_ID", default="5890463", description="Hub spot portal id."
+        name="HUBSPOT_PORTAL_ID", default="", description="Hub spot portal id."
     ),
     "HUBSPOT_CREATE_USER_FORM_ID": get_string(
         name="HUBSPOT_CREATE_USER_FORM_ID",
@@ -1253,7 +1253,6 @@ HUBSPOT_CONFIG = {
         description="Form ID for Hubspot Forms API",
     ),
 }
-
 
 # Sheets settings
 DRIVE_SERVICE_ACCOUNT_CREDS = get_string(


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #2453 

#### What's this PR do?
Remove certain default HubSpot values from `settings.py` file, and you can find these values in the [salt-ops](https://github.com/mitodl/salt-ops) repository [here](https://github.com/mitodl/salt-ops/blob/cafbf0fe6bca95c55a90e8d5cdcd14388483913f/pillar/heroku/xpro.sls).

#### How should this be manually tested?
To test this change locally, follow these steps:

- Access/open the Django shell.
- Import the settings.
- Attempt to fetch the `HUBSPOT_CONFIG` key.
- Initially, it should return with the empty strings (default).

Next, add the necessary configuration details related to `HUBSPOT_CONFIG` to the `.env` file, including:

- HUBSPOT_NEW_COURSES_FORM_GUID
- HUBSPOT_FOOTER_FORM_GUID
- HUBSPOT_PORTAL_ID

After adding the configuration details, run the test again. 

Verify that you can now successfully retrieve the `HUBSPOT_CONFIG` information and its contained keys (`HUBSPOT_NEW_COURSES_FORM_GUID, HUBSPOT_FOOTER_FORM_GUID, HUBSPOT_PORTAL_ID`) with correct values from the Django settings. This step confirms that the changes made in this pull request correctly access the configuration data from the `.env` file locally.
