### PR TITLE
Fixing formatting errors on receipt page, should not charge tax if TaxRate

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -859,7 +859,9 @@ def create_unfulfilled_order(validated_basket, affiliate_id=None, **kwargs):
         )
 
         try:
-            tax_rate_info = TaxRate.objects.get(country_code=country_code)
+            tax_rate_info = TaxRate.objects.filter(active=True).get(
+                country_code=country_code
+            )
         except (TaxRate.DoesNotExist, TaxRate.MultipleObjectsReturned):
             # not using get_or_create here because we don't want the rate to stick around
             tax_rate_info = TaxRate()

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -262,7 +262,7 @@ def test_send_ecommerce_order_receipt(mocker, receipt_data):
                 {
                     "quantity": 1,
                     "total_paid": "100.00",
-                    "tax_paid": 0,
+                    "tax_paid": "0.00",
                     "discount": "0.00",
                     "price": "100.00",
                     "readable_id": get_readable_id(

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -372,7 +372,11 @@ class BasketSerializer(serializers.ModelSerializer):
             if request and hasattr(request, "user"):
                 country_code = determine_visitor_country(request)
                 if country_code is not None:
-                    return TaxRate.objects.get(country_code=country_code).to_dict()
+                    return (
+                        TaxRate.objects.filter(active=True)
+                        .get(country_code=country_code)
+                        .to_dict()
+                    )
             else:
                 log.error("No request object in get_tax_info")
         except TaxRate.DoesNotExist:

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -1,6 +1,7 @@
 """ ecommerce serializers """
 # pylint: disable=too-many-lines
 import logging
+from decimal import Decimal
 
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -975,9 +976,11 @@ class OrderReceiptSerializer(serializers.ModelSerializer):
                 product_version=line.product_version,
                 tax_rate=instance.tax_rate,
             )
-            tax_paid = product_price_and_tax["tax_assessed"] * line.quantity
+            tax_paid = Decimal(
+                product_price_and_tax["tax_assessed"] * line.quantity
+            ).quantize(Decimal(".01"))
             total_price = product_price_and_tax["price"] * line.quantity
-            total_paid = total_price + tax_paid
+            total_paid = Decimal(total_price + tax_paid).quantize(Decimal(".01"))
             discount = (line.product_version.price * line.quantity) - total_price
 
             dates = CourseRunEnrollment.objects.filter(
@@ -1016,7 +1019,7 @@ class OrderReceiptSerializer(serializers.ModelSerializer):
                 dict(
                     quantity=line.quantity,
                     total_paid=str(total_paid),
-                    tax_paid=tax_paid,
+                    tax_paid=str(tax_paid),
                     discount=str(discount),
                     CEUs=str(CEUs) if CEUs else None,
                     **BaseProductVersionSerializer(line.product_version).data,

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -459,7 +459,7 @@ def test_serialize_order_receipt(receipt_data):
                 "end_date": None,
                 "price": str(product_version.price),
                 "total_paid": str(line.quantity * product_version.price),
-                "tax_paid": 0,
+                "tax_paid": "0.00",
                 "quantity": line.quantity,
                 "CEUs": product_version.product.content_object.course.page.certificate_page.CEUs,
             }


### PR DESCRIPTION

#### Pre-Flight checklist

- [X] Screenshots and design review for any changes that affect layout or styling
  - [X] Desktop screenshots
  - [X] Mobile width screenshots
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

mitodl/hq#2575

#### What's this PR do?

Updates the receipt serializer to format tax paid and total paid for two decimal places.

Updates the `create_unfulfilled_order` call to only look at active TaxRate objects.

#### How should this be manually tested?

1. Create an inactive tax rate for your country, then attempt to check out. You should not be charged tax.
2. View the receipt for an order that has had tax assessed. The Tax and Total Paid should be formatted with two decimal places.


#### Screenshots (if appropriate)

![image](https://github.com/mitodl/mitxpro/assets/945611/534032f2-58b9-4b09-9fc3-dff407e0fbb7)

Tax here is 17% so the actual tax charged is $21.675.