### PR TITLE
feat: display tax rate on checkout, receipt and email

### DIFF
--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -31,7 +31,7 @@
                 <strong style="font-weight: 700;">Unit Price:</strong> ${{ line.price }}<br>
                 <strong style="font-weight: 700;">Discount:</strong> ${{ line.discount }}<br>
                 {% if enable_taxes_display %}
-                    <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat:2 }}):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
+                    <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat }}%):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
                 {% endif %}
                 <strong style="font-weight: 700;">Total Paid:</strong> ${{ line.total_paid|floatformat:2 }}
             </p>

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -31,7 +31,7 @@
                 <strong style="font-weight: 700;">Unit Price:</strong> ${{ line.price }}<br>
                 <strong style="font-weight: 700;">Discount:</strong> ${{ line.discount }}<br>
                 {% if enable_taxes_display %}
-                    <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat }}%):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
+                    <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat:"-2" }}%):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
                 {% endif %}
                 <strong style="font-weight: 700;">Total Paid:</strong> ${{ line.total_paid|floatformat:2 }}
             </p>

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -31,7 +31,7 @@
                 <strong style="font-weight: 700;">Unit Price:</strong> ${{ line.price }}<br>
                 <strong style="font-weight: 700;">Discount:</strong> ${{ line.discount }}<br>
                 {% if enable_taxes_display %}
-                    <strong style="font-weight: 700;">Tax:</strong> ${{ line.tax_paid|floatformat:2 }}<br>
+                    <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat:2 }}):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
                 {% endif %}
                 <strong style="font-weight: 700;">Total Paid:</strong> ${{ line.total_paid|floatformat:2 }}
             </p>

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -353,7 +353,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                       <span>{formatPrice(calculatePrice(item, coupon))}</span>
                     </div>
                     <div className="flex-row tax-row">
-                      <span>Tax:</span>
+                      <span>Tax ({basket.tax_info.tax_rate}%):</span>
                       <span>{formatPrice(calculateTax(item, coupon, basket.tax_info.tax_rate))}</span>
                     </div>
                   </div>

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -15,6 +15,7 @@ import {
   calculateTax,
   calculateTotalAfterTax,
   formatPrice,
+  formatNumber,
   formatRunTitle
 } from "../../lib/ecommerce"
 
@@ -353,7 +354,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                       <span>{formatPrice(calculatePrice(item, coupon))}</span>
                     </div>
                     <div className="flex-row tax-row">
-                      <span>Tax ({basket.tax_info.tax_rate}%):</span>
+                      <span>Tax ({formatNumber(basket.tax_info.tax_rate)}%):</span>
                       <span>{formatPrice(calculateTax(item, coupon, basket.tax_info.tax_rate))}</span>
                     </div>
                   </div>

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -254,7 +254,7 @@ export class ReceiptPage extends React.Component<Props> {
                         <th>Quantity</th>
                         <th>Unit Price</th>
                         <th>Discount</th>
-                        {SETTINGS.enable_taxes_display ? <th>Tax</th> : null}
+                        {SETTINGS.enable_taxes_display ? <th>Tax ({orderReceipt.order.tax_rate}%)</th> : null}
                         <th>Total Paid</th>
                       </tr>
                     </thead>

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -12,7 +12,7 @@ import { pathOr } from "ramda"
 
 import queries from "../../lib/queries"
 import { formatPrettyDate, parseDateString } from "../../lib/util"
-
+import { formatNumber } from "../../lib/ecommerce"
 import type Moment from "moment"
 import type { Match } from "react-router"
 import type { OrderReceiptResponse } from "../../flow/ecommerceTypes"
@@ -254,7 +254,7 @@ export class ReceiptPage extends React.Component<Props> {
                         <th>Quantity</th>
                         <th>Unit Price</th>
                         <th>Discount</th>
-                        {SETTINGS.enable_taxes_display ? <th>Tax ({orderReceipt.order.tax_rate}%)</th> : null}
+                        {SETTINGS.enable_taxes_display ? <th>Tax ({formatNumber(orderReceipt.order.tax_rate)}%)</th> : null}
                         <th>Total Paid</th>
                       </tr>
                     </thead>

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -135,7 +135,8 @@ export type OrderLine = {
 export type OrderSummary = {
   id: string,
   created_on: string,
-  reference_number: string
+  reference_number: string,
+  tax_rate: string
 }
 
 export type CybersourceReceiptSummary = {

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -117,19 +117,27 @@ export const calcSelectedRunIds = (
     : {}
 }
 
-export const formatPrice = (price: ?string | number | Decimal): string => {
-  if (price === null || price === undefined) {
+export const formatNumber = (number: ?string | number | Decimal): string => {
+  if (number === null || number === undefined) {
     return ""
   } else {
-    let formattedPrice: Decimal = Decimal(price)
+    let formattedNumber: Decimal = Decimal(number)
 
-    if (formattedPrice.isInteger()) {
-      formattedPrice = formattedPrice.toFixed(0)
+    if (formattedNumber.isInteger()) {
+      formattedNumber = formattedNumber.toFixed(0)
     } else {
-      formattedPrice = formattedPrice.toFixed(2, Decimal.ROUND_HALF_UP)
+      formattedNumber = formattedNumber.toFixed(2, Decimal.ROUND_HALF_UP)
     }
-    return `$${formattedPrice}`
+    return formattedNumber
   }
+}
+
+export const formatPrice = (price: ?string | number | Decimal): string => {
+  let formattedPrice = formatNumber(price)
+  if (formattedPrice) {
+    formattedPrice = `$${formattedPrice}`
+  }
+  return formattedPrice
 }
 
 export const formatCoursewareDate = (dateString: ?string) =>

--- a/static/js/lib/ecommerce_test.js
+++ b/static/js/lib/ecommerce_test.js
@@ -11,6 +11,7 @@ import {
   calculateTax,
   calculateTotalAfterTax,
   formatPrice,
+  formatNumber,
   formatRunTitle
 } from "./ecommerce"
 import { makeCourseRun } from "../factories/course"
@@ -95,6 +96,22 @@ describe("ecommerce", () => {
     it("returns an empty string if null or undefined", () => {
       assert.equal(formatPrice(null), "")
       assert.equal(formatPrice(undefined), "")
+    })
+  })
+
+  describe("formatNumber", () => {
+    it("format a number", () => {
+      assert.equal(formatNumber(20), "20")
+      assert.equal(formatNumber(20.005), "20.01")
+      assert.equal(formatNumber(20.1), "20.10")
+      assert.equal(formatNumber(20.6059), "20.61")
+      assert.equal(formatNumber(20.6959), "20.70")
+      assert.equal(formatNumber(20.1234567), "20.12")
+    })
+
+    it("returns an empty string if null or undefined", () => {
+      assert.equal(formatNumber(null), "")
+      assert.equal(formatNumber(undefined), "")
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,9 +3727,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001280":
-  version: 1.0.30001546
-  resolution: "caniuse-lite@npm:1.0.30001546"
-  checksum: d3ef82f5ee94743002c5b2dd61c84342debcc94b2d5907b64ade3514ecfc4f20bbe86a6bc453fd6436d5fbcf6582e07405d7c2077565675a71c83adc238a11fa
+  version: 1.0.30001547
+  resolution: "caniuse-lite@npm:1.0.30001547"
+  checksum: ec0fc2b46721887f6f4aca1f3902f03d9a1a07416d16a86b7cd4bfba60e7b6b03ab3969659d3ea0158cc2f298972c80215c06c9457eb15c649d7780e8f5e91a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2788

#### What's this PR do?
- Adds tax rate display on Checkout 
- Adds tax rate display on In-app Receipt 
- Adds tax rate display on Email Receipt 
- Fixes some failing tests
- Adds some missing tests for frontend in for CheckoutForm
- Upgrades `caniuse-lite` to fix frontend/JS tests

#### How should this be manually tested?
- Start setting up things for taxes as per https://github.com/mitodl/mitxpro/pull/2772 If you have not worked with taxes in xPRO before
- Add/Enable `FEATURE_ENABLE_TAXES_DISPLAY=True` so that taxes can be displayed on the frontend
- Make sure you have added an entry for `TaxRate` in Django Admin for your country
- Since your IP would be from a docker network, it would not be related to a country, An easy solution is to get your actual IP address and hardcode it in https://github.com/mitodl/mitxpro/blob/master/ecommerce/api.py#L115

Test the below things once you've done the basic setup: (Crossmatch from the screenshots below)
1. Add an item in checkout and make sure you can see the applied tax rate as well (Check this with and without discount)
2. Once your order is complete, Go to the dashboard and click the `View Receipt` link. A receipt will be opened and you can check that the applied tax rate also shows there as well. (Check this with and without a discount)
3. Check your email for both of your orders (With and without discount). Make sure you see the applied tax rate there as well.
4. Test this after disabling `FEATURE_ENABLE_TAXES_DISPLAY=False`. You should not see any tax-related things anywhere.


#### Where should the reviewer start?
Setting up Tax configurations locally

#### Any background context you want to provide?
You can have some background context by reading through the Original feat PR https://github.com/mitodl/mitxpro/pull/2772, and some other visible changes were made in https://github.com/mitodl/mitxpro/pull/2783

#### Screenshots (if appropriate)
## Checkout

**Without Discount**
<img width="1165" alt="checkout with tax 18" src="https://github.com/mitodl/mitxpro/assets/34372316/4db20b5a-32bd-4fbd-80bf-2338b7758bd2">


**With Discount**
<img width="1023" alt="Checkout with discount 100" src="https://github.com/mitodl/mitxpro/assets/34372316/18773437-7b5b-4ad3-8440-f67db7d2ac8d">

**With Decimal Tax**
<img width="994" alt="checkout with decimals tax" src="https://github.com/mitodl/mitxpro/assets/34372316/929b2fca-c2b7-48fe-af3e-64d67a690819">


## In App Receipt

**Without Discount**
<img width="1111" alt="Receipt With Tax" src="https://github.com/mitodl/mitxpro/assets/34372316/90f7aa70-744e-4982-8ef8-31063bafbe9c">


**With Discount**
<img width="1082" alt="Receipt with 100 discount" src="https://github.com/mitodl/mitxpro/assets/34372316/f7422ab0-d2cb-47a7-8a80-10b39591af4a">

**With Decimal Tax**
<img width="1069" alt="receipt with decimal tex" src="https://github.com/mitodl/mitxpro/assets/34372316/b869c0c8-f9f5-46c0-8aca-509c90d8b6ad">


## Email Receipt

**Without Discount**
<img width="421" alt="Receipt Email With tax" src="https://github.com/mitodl/mitxpro/assets/34372316/0cbaaa2b-3a39-444f-a774-6591e4b12671">


**With Discount**
<img width="443" alt="receipt email with discount" src="https://github.com/mitodl/mitxpro/assets/34372316/a20a8b95-f650-4fa1-80ae-349b7655510d">

**With Decimal Tax**
<img width="318" alt="email with decimal tax" src="https://github.com/mitodl/mitxpro/assets/34372316/49b6453b-e7eb-467f-a7e3-f8c7d5647545">

