### PR TITLE
fix: platform name search in Django Admin Courses/Programs

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -33,7 +33,7 @@ class ProgramAdmin(admin.ModelAdmin):
     """Admin for Program"""
 
     model = Program
-    search_fields = ["title", "readable_id", "platform"]
+    search_fields = ["title", "readable_id", "platform__name"]
     list_display = ("id", "title", "readable_id", "platform")
     list_filter = ["live", "platform"]
 
@@ -50,7 +50,7 @@ class CourseAdmin(admin.ModelAdmin):
     """Admin for Course"""
 
     model = Course
-    search_fields = ["title", "readable_id", "platform"]
+    search_fields = ["title", "readable_id", "platform__name"]
     list_display = ("id", "title", "get_program", "position_in_program", "platform")
     list_filter = ["live", "program", "platform"]
     formfield_overrides = {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes [This Sentry error](https://mit-office-of-digital-learning.sentry.io/issues/4545153479/?project=1413655&query=is%3Aunresolved&referrer=issue-stream&stream_index=0).

#### What's this PR do?
Fixes a bug when searching courses or programs with platform names.

#### How should this be manually tested?
- Check that you can search courses and programs through Django Admin based on the platform name. 


#### Screenshots (if appropriate)
<img width="1150" alt="platfrom name search" src="https://github.com/mitodl/mitxpro/assets/34372316/82194fac-d27f-45c0-b920-64b1ccbea2d1">

