### PR TITLE
fix: display discount amount as negative

### DIFF
--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -1,4 +1,5 @@
 {% extends "email_base.html" %}
+{% load format_discount %}
 
 {% block content %}
 <tr class="receipt-new-wrapper" style="font: 14px/22px 'Arial', sans-serif; margin: 0 auto; padding: 0 20px">
@@ -29,7 +30,7 @@
             <p>
                 <strong style="font-weight: 700;">Quantity:</strong>  {{ line.quantity }}<br>
                 <strong style="font-weight: 700;">Unit Price:</strong> ${{ line.price }}<br>
-                <strong style="font-weight: 700;">Discount:</strong> ${{ line.discount }}<br>
+                <strong style="font-weight: 700;">Discount:</strong> {{ line.discount|format_discount }}<br>
                 {% if enable_taxes_display %}
                     <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat:"-2" }}%):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
                 {% endif %}

--- a/mail/templatetags/format_discount.py
+++ b/mail/templatetags/format_discount.py
@@ -1,0 +1,21 @@
+"""Custom template tags for email"""
+from decimal import Decimal
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def format_discount(discount_amount):
+    """
+    Formats the discount amount to be displayed in $
+
+    Args:
+        discount_amount (Decimal): Discount amount
+
+    Returns:
+        str: Formatted discount amount, Would return "$0" and "-${discount}" for all others
+    """
+    discount_amount = abs(Decimal(discount_amount))
+    return f"{'' if discount_amount == 0 else '-'}${abs(discount_amount.quantize(Decimal('.01')))}"

--- a/mail/templatetags/format_discount_test.py
+++ b/mail/templatetags/format_discount_test.py
@@ -1,0 +1,16 @@
+"""Tests for custom mail templatetags"""
+
+from mail.templatetags.format_discount import format_discount
+
+
+def test_format_discount():
+    """format_discount should return a proper string with "-" sign"""
+
+    assert format_discount(0) == "$0.00"
+    assert format_discount(1) == "-$1.00"
+    assert format_discount(-1) == "-$1.00"
+    assert format_discount(1.00) == "-$1.00"
+    assert format_discount(100.12) == "-$100.12"
+    assert format_discount(-100.12) == "-$100.12"
+    assert format_discount(100.577) == "-$100.58"
+    assert format_discount(-100.577) == "-$100.58"

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -344,7 +344,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                 {coupon ? (
                   <div className="flex-row discount-row">
                     <span>Discount:</span>
-                    <span>{formatDiscount(formatNumber(calculateDiscount(item, coupon)))}</span>
+                    <span>{formatDiscount(calculateDiscount(item, coupon))}</span>
                   </div>
                 ) : null}
                 {SETTINGS.enable_taxes_display ? (

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -14,6 +14,7 @@ import {
   calculatePrice,
   calculateTax,
   calculateTotalAfterTax,
+  formatDiscount,
   formatPrice,
   formatNumber,
   formatRunTitle
@@ -343,7 +344,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                 {coupon ? (
                   <div className="flex-row discount-row">
                     <span>Discount:</span>
-                    <span>{formatPrice(calculateDiscount(item, coupon))}</span>
+                    <span>{formatDiscount(formatNumber(calculateDiscount(item, coupon)))}</span>
                   </div>
                 ) : null}
                 {SETTINGS.enable_taxes_display ? (

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -95,7 +95,7 @@ describe("CheckoutForm", () => {
       if (hasCoupon) {
         assert.equal(
           inner.find(".discount-row").text(),
-          `Discount:${formatPrice(calculateDiscount(basketItem, coupon))}`
+          `Discount:-${formatPrice(calculateDiscount(basketItem, coupon))}`
         )
       } else {
         assert.isFalse(inner.find(".discount-row").exists())

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -12,7 +12,7 @@ import { pathOr } from "ramda"
 
 import queries from "../../lib/queries"
 import { formatPrettyDate, parseDateString } from "../../lib/util"
-import { formatNumber } from "../../lib/ecommerce"
+import { formatNumber, formatDiscount } from "../../lib/ecommerce"
 import type Moment from "moment"
 import type { Match } from "react-router"
 import type { OrderReceiptResponse } from "../../flow/ecommerceTypes"
@@ -284,7 +284,7 @@ export class ReceiptPage extends React.Component<Props> {
                               <div>${line.price}</div>
                             </td>
                             <td>
-                              <div>${line.discount}</div>
+                              <div>{formatDiscount(line.discount, true)}</div>
                             </td>
                             {SETTINGS.enable_taxes_display ? (
                               <td>

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -140,6 +140,26 @@ export const formatPrice = (price: ?string | number | Decimal): string => {
   return formattedPrice
 }
 
+export const formatDiscount = (discount: ?string | number | Decimal, forcePrecision: boolean = false): string => {
+  if (discount === null || discount === undefined) {
+    return "$0"
+  }
+
+  let formattedDiscount = new Decimal(formatNumber(discount))
+
+  formattedDiscount = Math.abs(formattedDiscount)
+  if (forcePrecision) {
+    formattedDiscount = formattedDiscount.toFixed(2)
+  }
+
+  // $FlowFixMe: formatted_discount is a Decimal here
+  if (formattedDiscount == 0) {  // eslint-disable-line eqeqeq
+    return `$${formattedDiscount}`
+  } else {
+    return `-$${formattedDiscount}`
+  }
+}
+
 export const formatCoursewareDate = (dateString: ?string) =>
   dateString ? moment(dateString).format("ll") : "?"
 

--- a/static/js/lib/ecommerce_test.js
+++ b/static/js/lib/ecommerce_test.js
@@ -12,6 +12,7 @@ import {
   calculateTotalAfterTax,
   formatPrice,
   formatNumber,
+  formatDiscount,
   formatRunTitle
 } from "./ecommerce"
 import { makeCourseRun } from "../factories/course"
@@ -107,11 +108,35 @@ describe("ecommerce", () => {
       assert.equal(formatNumber(20.6059), "20.61")
       assert.equal(formatNumber(20.6959), "20.70")
       assert.equal(formatNumber(20.1234567), "20.12")
+      assert.equal(formatNumber(0), "0")
     })
 
     it("returns an empty string if null or undefined", () => {
       assert.equal(formatNumber(null), "")
       assert.equal(formatNumber(undefined), "")
+    })
+  })
+
+  describe("formatDiscount", () => {
+    it("format a discount", () => {
+      assert.equal(formatDiscount(20), "-$20")
+      assert.equal(formatDiscount(-20), "-$20")
+      assert.equal(formatDiscount(20, true), "-$20.00")
+      assert.equal(formatDiscount(20.00), "-$20")
+      assert.equal(formatDiscount(20.00, true), "-$20.00")
+      assert.equal(formatDiscount(-20.00, true), "-$20.00")
+      assert.equal(formatDiscount(20.1), "-$20.1")
+      assert.equal(formatDiscount(20.1, true), "-$20.10")
+      assert.equal(formatDiscount(20.6959), "-$20.7")
+      assert.equal(formatDiscount(-20.6959), "-$20.7")
+      assert.equal(formatDiscount(20.6959, true), "-$20.70")
+      assert.equal(formatDiscount(0.00), "$0")
+      assert.equal(formatDiscount(0.00, true), "$0.00")
+    })
+
+    it("returns $0 string if null or undefined", () => {
+      assert.equal(formatDiscount(null), "$0")
+      assert.equal(formatDiscount(undefined), "$0")
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2787

#### What's this PR do?
- Displays the discount amount as negative in CheckoutPage, ReceiptPage, and receipt email
- Adds a new template tag to mimic discount behavior in other templates as well
- Refactors `ecommerce.js` to have the functionality to show discounts in a specific format

#### How should this be manually tested?
- Create a couple of Courses, Programs, and products with enrollable runs
- Create a couple of discounts using `/ecommerce/admin` (e.g. 0%, 50%, 100%)
- Add a product in the basket (e.g. by clicking `Enroll Now` on course page)
- Apply different discounts to your basket and make sure you see a `-` sign e.g. `-$50` for the discount amount in the checkout. (Please Note: For $0 there will be no `-` sign)
- Now, Perform the checkout and view your receipt through `/dashboard` and check that the discount is displayed there with a `-` sign.
- Now, Check your receipt email and verify the same as above.
- You can perform these steps with different discount amounts that can be whole numbers or decimals.


#### Where should the reviewer start?
Creating a discount using `/ecommerce/admin`


#### Screenshots (if appropriate)
**Email**
<img width="421" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/90ff63a2-906d-4754-932a-63858baf95ac">
<img width="231" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/b3dd381d-2952-4f62-9992-993d4374b268">

---

**Receipt Page**
<img width="1185" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/fa2c9bbb-e2f7-4190-8943-14675d65e9c5">
<img width="1101" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/f40193ac-8f81-4ba3-9959-379e26b344dc">

--

**Checkout**

<img width="416" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/7b390b04-813b-4606-baf4-ea17f12b60a3">
<img width="393" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/6316bf98-15df-4685-b42e-9278e71bbcc8">
