### PR TITLE
fix: receipt email typo

### DIFF
--- a/mail/templates/b2b_receipt/body.html
+++ b/mail/templates/b2b_receipt/body.html
@@ -12,7 +12,7 @@
               {% endif %}
               <p style="color: #000000;" >Thank you! You have purchased one or more seats for your team.</p>
               <p><a href="{{ download_url }}">Download enrollment codes and view receipt</a></p>
-              <p style="color: #000000;" >Below you will find a copy of you receipt:</p>
+              <p style="color: #000000;" >Below you will find a copy of your receipt:</p>
               <h1 style="margin: 20px 0 10px; font-size: 30px; line-height: 50px; color: #03152d; font-weight: bold;">Receipt</h1>
             </td>
           </tr>

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -9,7 +9,7 @@
         <p style="font-weight: normal; margin: 0 0 20px;">You have been enrolled {% if content_title %} in {{ content_title }}{% endif %}.
             The course should now appear on your MIT xPRO <a href="{{ base_url }}{% url 'user-dashboard' %}" style="color: #0070DA">dashboard</a>. You can also access your receipt by <a style="color: #0070DA" href="{{ base_url }}/receipt/{{order.id }}">clicking here</a>.
         </p>
-        <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of you receipt:</p>
+        <p style="font-weight: normal; margin: 0 0 20px;">Below you will find a copy of your receipt:</p>
     </td>
     <tr>
         <td>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None, There was a typo in the receipt email. 

#### What's this PR do?
It used to say `Below you will find a copy of you receipt:` instead of `Below you will find a copy of your receipt:`


#### How should this be manually tested?
- Do a single checkout and check that the email typo is fixed
- Do a B2B Checkout and check that the email typo is fixed

#### Screenshots (if appropriate)
**Regular checkout:**

<img width="749" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/a44d2d22-19eb-422f-b0f4-7e0088c2c04a">

--- 

**B2B Checkout**
<img width="752" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/2186341b-5796-4443-8df0-cca69871c348">

