### PR TITLE
feat: add xpro catalog link when no courseware is associated

### DIFF
--- a/cms/templates/webinar_page.html
+++ b/cms/templates/webinar_page.html
@@ -45,7 +45,7 @@
           Learn more about this courseware or enroll
         </a>
       {% else %}
-        <a href="/catalog" class="read-more">
+        <a href="/catalog/" class="read-more">
           Explore MITx PRO Catalog
         </a>
       {% endif %}

--- a/cms/templates/webinar_page.html
+++ b/cms/templates/webinar_page.html
@@ -44,6 +44,10 @@
         <a href="{{ courseware_url }}" class="read-more">
           Learn more about this courseware or enroll
         </a>
+      {% else %}
+        <a href="/catalog" class="read-more">
+          Explore MITx PRO Catalog
+        </a>
       {% endif %}
       <a href="{% pageurl page.get_parent %}" class="back-to-top">Back to webinars</a>
     </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
fixes https://github.com/mitodl/hq/issues/2762

#### What's this PR do?
Add a link to the catalog page in Webinar page when there is no course/program link.

#### How should this be manually tested?

- Create an on-demand webinar.
- Associate a course/program.
- Verify that the courseware link is visible.
- Now remove the course/program from the already created webinar or create a new webinar without courseware.
- Verify that a link to the catalog page is there in place of the courseware link.


#### Screenshots (if appropriate)
<img width="1740" alt="Screen Shot 2023-10-25 at 11 57 37 AM" src="https://github.com/mitodl/mitxpro/assets/52656433/b6baa594-6f14-4c1d-9cc3-a690c890b7ba">



