### PR TITLE
fix: Unify decimal places for price and discount

### DIFF
--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -284,7 +284,7 @@ export class ReceiptPage extends React.Component<Props> {
                               <div>${line.price}</div>
                             </td>
                             <td>
-                              <div>{formatDiscount(line.discount, true)}</div>
+                              <div>{formatDiscount(line.discount)}</div>
                             </td>
                             {SETTINGS.enable_taxes_display ? (
                               <td>

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -117,13 +117,13 @@ export const calcSelectedRunIds = (
     : {}
 }
 
-export const formatNumber = (number: ?string | number | Decimal): string => {
+export const formatNumber = (number: ?string | number | Decimal, trimTrailingZeros: boolean = true): Decimal => {
   if (number === null || number === undefined) {
     return ""
   } else {
     let formattedNumber: Decimal = Decimal(number)
 
-    if (formattedNumber.isInteger()) {
+    if (formattedNumber.isInteger() && trimTrailingZeros) {
       formattedNumber = formattedNumber.toFixed(0)
     } else {
       formattedNumber = formattedNumber.toFixed(2, Decimal.ROUND_HALF_UP)
@@ -132,32 +132,29 @@ export const formatNumber = (number: ?string | number | Decimal): string => {
   }
 }
 
-export const formatPrice = (price: ?string | number | Decimal): string => {
-  let formattedPrice = formatNumber(price)
+export const formatPrice = (price: ?string | number | Decimal, trimTrailingZeros: boolean = false): string => {
+  let formattedPrice = formatNumber(price, trimTrailingZeros)
   if (formattedPrice) {
     formattedPrice = `$${formattedPrice}`
   }
   return formattedPrice
 }
 
-export const formatDiscount = (discount: ?string | number | Decimal, forcePrecision: boolean = false): string => {
+export const formatDiscount = (discount: ?string | number | Decimal, trimTrailingZeros: boolean = false): string => {
   if (discount === null || discount === undefined) {
-    return "$0"
+    return "$0.00"
   }
 
-  let formattedDiscount = new Decimal(formatNumber(discount))
+  let formattedDiscount = formatNumber(discount, trimTrailingZeros)
 
-  formattedDiscount = Math.abs(formattedDiscount)
-  if (forcePrecision) {
-    formattedDiscount = formattedDiscount.toFixed(2)
-  }
-
-  // $FlowFixMe: formatted_discount is a Decimal here
   if (formattedDiscount == 0) {  // eslint-disable-line eqeqeq
     return `$${formattedDiscount}`
-  } else {
-    return `-$${formattedDiscount}`
   }
+  else if (formattedDiscount < 0) {
+    formattedDiscount = (formattedDiscount * -1).toFixed(2)
+  }
+  // $FlowFixMe: formatted_discount is a Decimal here
+    return `-$${formattedDiscount}`
 }
 
 export const formatCoursewareDate = (dateString: ?string) =>

--- a/static/js/lib/ecommerce.js
+++ b/static/js/lib/ecommerce.js
@@ -149,12 +149,11 @@ export const formatDiscount = (discount: ?string | number | Decimal, trimTrailin
 
   if (formattedDiscount == 0) {  // eslint-disable-line eqeqeq
     return `$${formattedDiscount}`
-  }
-  else if (formattedDiscount < 0) {
+  } else if (formattedDiscount < 0) {
     formattedDiscount = (formattedDiscount * -1).toFixed(2)
   }
   // $FlowFixMe: formatted_discount is a Decimal here
-    return `-$${formattedDiscount}`
+  return `-$${formattedDiscount}`
 }
 
 export const formatCoursewareDate = (dateString: ?string) =>

--- a/static/js/lib/ecommerce_test.js
+++ b/static/js/lib/ecommerce_test.js
@@ -120,11 +120,11 @@ describe("ecommerce", () => {
   describe("formatDiscount", () => {
     it("format a discount", () => {
       assert.equal(formatDiscount(20), "-$20.00")
-      // assert.equal(formatDiscount(-20), "-$20.00")
+      assert.equal(formatDiscount(-20), "-$20.00")
       assert.equal(formatDiscount(20), "-$20.00")
       assert.equal(formatDiscount(20.00), "-$20.00")
       assert.equal(formatDiscount(20.00), "-$20.00")
-      // assert.equal(formatDiscount(-20.00), "-$20.00")
+      assert.equal(formatDiscount(-20.00), "-$20.00")
       assert.equal(formatDiscount(20.1), "-$20.10")
       assert.equal(formatDiscount(20.1), "-$20.10")
       assert.equal(formatDiscount(20.6959), "-$20.70")

--- a/static/js/lib/ecommerce_test.js
+++ b/static/js/lib/ecommerce_test.js
@@ -86,7 +86,7 @@ describe("ecommerce", () => {
 
   describe("formatPrice", () => {
     it("format price", () => {
-      assert.equal(formatPrice(20), "$20")
+      assert.equal(formatPrice(20), "$20.00")
       assert.equal(formatPrice(20.005), "$20.01")
       assert.equal(formatPrice(20.1), "$20.10")
       assert.equal(formatPrice(20.6059), "$20.61")
@@ -119,24 +119,24 @@ describe("ecommerce", () => {
 
   describe("formatDiscount", () => {
     it("format a discount", () => {
-      assert.equal(formatDiscount(20), "-$20")
-      assert.equal(formatDiscount(-20), "-$20")
-      assert.equal(formatDiscount(20, true), "-$20.00")
-      assert.equal(formatDiscount(20.00), "-$20")
-      assert.equal(formatDiscount(20.00, true), "-$20.00")
-      assert.equal(formatDiscount(-20.00, true), "-$20.00")
-      assert.equal(formatDiscount(20.1), "-$20.1")
-      assert.equal(formatDiscount(20.1, true), "-$20.10")
-      assert.equal(formatDiscount(20.6959), "-$20.7")
-      assert.equal(formatDiscount(-20.6959), "-$20.7")
-      assert.equal(formatDiscount(20.6959, true), "-$20.70")
-      assert.equal(formatDiscount(0.00), "$0")
-      assert.equal(formatDiscount(0.00, true), "$0.00")
+      assert.equal(formatDiscount(20), "-$20.00")
+      // assert.equal(formatDiscount(-20), "-$20.00")
+      assert.equal(formatDiscount(20), "-$20.00")
+      assert.equal(formatDiscount(20.00), "-$20.00")
+      assert.equal(formatDiscount(20.00), "-$20.00")
+      // assert.equal(formatDiscount(-20.00), "-$20.00")
+      assert.equal(formatDiscount(20.1), "-$20.10")
+      assert.equal(formatDiscount(20.1), "-$20.10")
+      assert.equal(formatDiscount(20.6959), "-$20.70")
+      assert.equal(formatDiscount(-20.6959), "-$20.70")
+      assert.equal(formatDiscount(20.6959), "-$20.70")
+      assert.equal(formatDiscount(0.00), "$0.00")
+      assert.equal(formatDiscount(0.00), "$0.00")
     })
 
     it("returns $0 string if null or undefined", () => {
-      assert.equal(formatDiscount(null), "$0")
-      assert.equal(formatDiscount(undefined), "$0")
+      assert.equal(formatDiscount(null), "$0.00")
+      assert.equal(formatDiscount(undefined), "$0.00")
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/2605

#### What's this PR do?
- Unifies the decimal places for amount-related fields i.e. price, discount etc.

#### How should this be manually tested?
- Add any course or program to the cart and visit the checkout page
- Check that all the prices and discounts are in two decimal places even when the remainder part is zero or something else
- Below are some of the examples to test this so that we don't leave any unintended display with unexpected data

**Scenarios you might want to create**
- Order amount 0, discount 100%, tax None
- Order amount any, discount 0%, tax None
- Order amount any, discount 50%, tax any
- Order amount any, discount 0%, tax any



#### Screenshots (if appropriate)
**Checkout**

<img width="1074" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/6ded851d-3723-4f0e-8b7d-07f5ae2ec583">


**Receipt**
<img width="1100" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/db9ddfd2-920e-438b-b498-6538277ee7d4">


**Email Receipt**
<img width="545" alt="image" src="https://github.com/mitodl/mitxpro/assets/34372316/03aebbfe-0362-4703-a17f-844328b2fa21">


