### PR TITLE
fix: postgres startup error without password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ x-extra-hosts:
 services:
   db:
     image: postgres:11.16
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: 'trust'
     ports:
       - "5432"
 


### PR DESCRIPTION
#### Pre-Flight checklist

#### What are the relevant tickets?
None. Started seeing this error after postgres version upgrade `11.6->11.16`. Done by Renovate through https://github.com/mitodl/mitxpro/pull/2815 

```db_1      | Error: Database is uninitialized and superuser password is not specified.
db_1      |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db_1      |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db_1      | 
db_1      |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db_1      |        connections without a password. This is *not* recommended.
db_1      | 
db_1      |        See PostgreSQL documentation about "trust":
db_1      |        https://www.postgresql.org/docs/current/auth-trust.html
```

#### What's this PR do?
- Disables the password locally, allows `trust`

#### How should this be manually tested?
- Once you do a fresh install of xPRO you will start noticing the issue I mentioned above. To start fresh you would need to run `docker-compose down` followed by `docker-compose build --no-cache`
- Your db container should be built and run successful
- Your web app container should be able to connect to db/postgress and do operations normally
- Other places that touch the database should work like usual




#### Reviewer Note:
Before https://github.com/mitodl/mitxpro/pull/2815 , the postgres would by default run in `trust` mode. And this PR actually explicitly adds that for postgres db container environment.

