### PR TITLE
feat: enable header links and disable new and events on homepage

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -778,6 +778,12 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
         """
         Gets the news and events section subpage
         """
+        webinar_or_blog_enabled = settings.FEATURES.get(
+            "WEBINARS", False
+        ) or settings.FEATURES.get("ENABLE_BLOG", False)
+        if webinar_or_blog_enabled:
+            return None
+
         return self._get_child_page_of_type(NewsAndEventsPage)
 
     @property

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -66,15 +66,6 @@ const TopAppBar = ({ currentUser, location, errorPageHeader, courseTopics }: Pro
             id="nav"
             className="collapse navbar-collapse px-0 justify-content-end"
           >
-            {
-              SETTINGS.webinars ? (
-                <li>
-                  <a href={routes.webinars} className="" aria-label="webinars">
-                    Webinars
-                  </a>
-                </li>
-              ) : null
-            }
             <li>
               {
                 SETTINGS.course_dropdown ? (
@@ -87,9 +78,18 @@ const TopAppBar = ({ currentUser, location, errorPageHeader, courseTopics }: Pro
               }
             </li>
             {
+              SETTINGS.webinars ? (
+                <li>
+                  <a href={routes.webinars} className="webinar-link" aria-label="webinars">
+                    Webinars
+                  </a>
+                </li>
+              ) : null
+            }
+            {
               SETTINGS.enable_blog ? (
                 <li>
-                  <a href={routes.blog} className="" aria-label="blog">
+                  <a href={routes.blog} className="blog-link" aria-label="blog">
                     Blog
                   </a>
                 </li>

--- a/static/scss/top-app-bar.scss
+++ b/static/scss/top-app-bar.scss
@@ -54,6 +54,10 @@
       text-decoration: none;
       display: block;
 
+      &.blog-link {
+        margin-right: 10px;
+      }
+
       &:hover {
         color: $primary;
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
(Required)
Fixes https://github.com/mitodl/hq/issues/3080

#### What's this PR do?
(Required)
Disables new and events section on the Home Page if Blog or Webinars feature is enabled.
Makes a few design adjustments.

#### How should this be manually tested?
(Required)

- Enable Blog and Webinar features by turning on FEATURE_WEBINARS and FEATURE_ENABLE_BLOG in .env
- Enable FEATURE_COURSE_DROPDOWN in .env
- Verify that you can see the updated header links for blog, webinar and courses dropdown and they are working fine.
- Verify that new and events is not visible on homepage.

#### Screenshots (if appropriate)
<img width="1344" alt="Screen Shot 2023-11-30 at 1 53 21 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/7a21daaa-e419-4263-b959-20bd7bf433bc">
<img width="1344" alt="Screen Shot 2023-11-30 at 2 56 54 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/197cef97-2280-4001-b314-9fa129ead887">
