### PR TITLE
fix: return topics with more than zero courses

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -586,7 +586,10 @@ class CatalogPage(Page):
             hubspot_new_courses_form_guid=settings.HUBSPOT_CONFIG.get(
                 "HUBSPOT_NEW_COURSES_FORM_GUID"
             ),
-            topics=[ALL_TOPICS] + CourseTopic.objects.parent_topic_names(),
+            topics=[
+                ALL_TOPICS,
+                *[topic.name for topic in CourseTopic.parent_topics_with_courses()],
+            ],
             selected_topic=topic_filter,
             active_tab=request.GET.get("active-tab", ALL_TAB),
         )

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -442,16 +442,21 @@ def test_catalog_page_topics_ordering(client, wagtail_basics):
     catalog_page = CatalogPageFactory.create(parent=homepage)
     catalog_page.save_revision().publish()
 
-    topic_name_list = ["Analog", "Computer", "Business", "Technology", "Engineering"]
+    topic_name_without_courses_list = ["Analog", "Computer", "Business"]
+    topic_name_with_courses_list = ["Technology", "Engineering"]
 
-    parent_topics = CourseTopicFactory.create_batch(
-        5, name=factory.Iterator(topic_name_list)
+    CourseTopicFactory.create_batch(
+        3, name=factory.Iterator(topic_name_without_courses_list)
     )
+    parent_topics_with_courses = CourseTopicFactory.create_batch(
+        2, name=factory.Iterator(topic_name_with_courses_list)
+    )
+    CourseRunFactory.create(course__page__topics=parent_topics_with_courses)
 
     resp = client.get(catalog_page.get_url())
     assert resp.status_code == status.HTTP_200_OK
     assert resp.context_data["topics"] == sorted(
-        [ALL_TOPICS] + [topic.name for topic in parent_topics]
+        [ALL_TOPICS, *topic_name_with_courses_list]
     )
 
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -424,6 +424,17 @@ class CourseTopic(TimestampedModel):
             ]
         )
 
+    @classmethod
+    def parent_topics_with_courses(cls):
+        """
+        Returns parent topics with count > 0
+        """
+        return [
+            topic
+            for topic in cls.objects.parent_topics_with_annotated_course_counts()
+            if topic.course_count > 0
+        ]
+
 
 class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
     """Model for a course"""

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -201,8 +201,4 @@ class CourseTopicViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Returns parent topics with course count > 0.
         """
-        return [
-            topic
-            for topic in CourseTopic.objects.parent_topics_with_annotated_course_counts()
-            if topic.course_count > 0
-        ]
+        return CourseTopic.parent_topics_with_courses()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
A small enhancement for https://github.com/mitodl/mitxpro/issues/2614

#### What's this PR do?
Shows topics having more than zero courses on the course catalog page.

#### How should this be manually tested?

- Create a few parent topics with / without courses.
- Verify that only topics with Catalog Visible courses are visible.

#### Any background context you want to provide?
We somehow missed adding an extra filter for the catalog page topics and I noticed it. This PR adds it.

#### Screenshots (if appropriate)
<img width="1344" alt="Screen Shot 2023-12-05 at 12 04 12 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/b009ba4e-167c-48b3-b51d-6b26c836282f">


