### PR TITLE
fix: Add vat id in hubspot properties sync

### DIFF
--- a/hubspot_xpro/management/commands/configure_hubspot_properties.py
+++ b/hubspot_xpro/management/commands/configure_hubspot_properties.py
@@ -206,7 +206,6 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                 "type": "string",
                 "fieldType": "text",
             },
-
         ],
     },
     "line_items": {

--- a/hubspot_xpro/management/commands/configure_hubspot_properties.py
+++ b/hubspot_xpro/management/commands/configure_hubspot_properties.py
@@ -68,13 +68,13 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                     {
                         "value": models.Order.CREATED,
                         "label": models.Order.CREATED,
-                        "displayOrder": 0,
+                        "displayOrder": 2,
                         "hidden": False,
                     },
                     {
                         "value": models.Order.REFUNDED,
                         "label": models.Order.REFUNDED,
-                        "displayOrder": 1,
+                        "displayOrder": 3,
                         "hidden": False,
                     },
                 ],
@@ -234,13 +234,13 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                     {
                         "value": models.Order.CREATED,
                         "label": models.Order.CREATED,
-                        "displayOrder": 0,
+                        "displayOrder": 2,
                         "hidden": False,
                     },
                     {
                         "value": models.Order.REFUNDED,
                         "label": models.Order.REFUNDED,
-                        "displayOrder": 1,
+                        "displayOrder": 3,
                         "hidden": False,
                     },
                 ],

--- a/hubspot_xpro/management/commands/configure_hubspot_properties.py
+++ b/hubspot_xpro/management/commands/configure_hubspot_properties.py
@@ -198,6 +198,15 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                 "type": "string",
                 "fieldType": "text",
             },
+            {
+                "name": "vat_id",
+                "label": "VAT ID",
+                "description": "Customer VAT ID",
+                "groupName": "contactinformation",
+                "type": "string",
+                "fieldType": "text",
+            },
+
         ],
     },
     "line_items": {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2847

#### What's this PR do?
- Adds the VAT ID property in HubSpot properties sync command
- Fixes sync issues with choice group order

#### How should this be manually tested?
- Setup a test account on HubSpot
- Add a private app in integrations (`settings->Integrations->Private Apps`)
- Copy the access token secret and place it as a value for `MITOL_HUBSPOT_API_PRIVATE_TOKEN`
- Copy the client secret and place it as a value for HUBSPOT_PIPELINE_ID
- I would suggest reproducing this issue on `master` first:
    - Run `./manage.py configure_hubspot_properties` once above configs are done
    - Notice error about duplicate orders in field choices of deal
    - Create a new user and also notice that you see 400 errors from `sync_contact_with_hubspot`
-  Shift to this branch, And run `./manage.py configure_hubspot_properties` again an this should succeed now
- Now manually trigger `sync_contact_with_hubspot(<user_id>)` and this should succeed 
- Check that you see this user in `Contacts` on HubSpot
- Check that the user represents the VAT ID correctly on Hubspot contact properties 

If you have any confusion, Please ping me.

#### Where should the reviewer start?
Setup a test HubSpot account - We can use xpro-dev account too but I would recommend setting up your own.

#### Any background context you want to provide?
We recently added VAT Id feat https://github.com/mitodl/mitxpro/pull/2764 but this wasn't synced with hubspot

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
