### PR TITLE
feat: add enterprise page link in header

### DIFF
--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -598,4 +598,5 @@ def get_js_settings(request: HttpRequest):
         "webinars": settings.FEATURES.get("WEBINARS", False),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
         "enable_taxes_display": settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False),
+        "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
     }

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -472,6 +472,7 @@ def test_get_js_settings(settings, rf):
     settings.FEATURES["WEBINARS"] = False
     settings.FEATURES["ENABLE_TAXES_DISPLAY"] = False
     settings.FEATURES["ENABLE_BLOG"] = False
+    settings.FEATURES["ENABLE_ENTERPRISE"] = False
 
     request = rf.get("/")
 
@@ -492,4 +493,5 @@ def test_get_js_settings(settings, rf):
         "webinars": settings.FEATURES.get("WEBINARS", False),
         "enable_taxes_display": settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
+        "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
     }

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -78,6 +78,15 @@ const TopAppBar = ({ currentUser, location, errorPageHeader, courseTopics }: Pro
               }
             </li>
             {
+              SETTINGS.enable_enterprise ? (
+                <li>
+                  <a href={routes.enterprise} className="enterprise-link" aria-label="enterprise">
+                    Enterprise
+                  </a>
+                </li>
+              ) : null
+            }
+            {
               SETTINGS.webinars ? (
                 <li>
                   <a href={routes.webinars} className="webinar-link" aria-label="webinars">

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -22,6 +22,7 @@ declare type Settings = {
   webinars: boolean,
   enable_blog: boolean,
   enable_taxes_display: boolean,
+  enable_enterprise: boolean,
 }
 declare var SETTINGS: Settings
 

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -11,6 +11,7 @@ export const routes = {
   root:            "/",
   catalog:         "/catalog/",
   webinars:         "/webinars/",
+  enterprise:         "/enterprise/",
   blog:            "/blog/",
   dashboard:       "/dashboard/",
   accountSettings: "/account-settings/",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New configs have been added to the relevant repos i.e. ol-infrastructure, salt-ops 

#### What are the relevant tickets?
A followup of https://github.com/mitodl/hq/issues/1370

#### What's this PR do?
Adds a feature flag-based header link for the enterprise page.

#### How should this be manually tested?

- Enable ENABLE_ENTERPRISE by adding FEATURE_ENABLE_ENTERPRISE=True in .env
- Verify that a header link for enterprise page is added per https://projects.invisionapp.com/share/KH135O9R5XWP#/screens
- Header link should not be visible when FEATURE_ENABLE_ENTERPRISE=False
