### PR TITLE
fix: fix static image path for enterprise page

### DIFF
--- a/static/scss/detail/enterprise/learning-journey.scss
+++ b/static/scss/detail/enterprise/learning-journey.scss
@@ -2,7 +2,7 @@
 
 .learning-journey-block {
   padding-top: 70px;
-  background: url('#{$static-path}/images/enterprise-page-dots-bg.png') repeat-x 0% 100% $alice-blue;
+  background: url('#{$static-path}/images/enterprise/enterprise-page-dots-bg.png') repeat-x 0% 100% $alice-blue;
   position: relative;
 
   @include media-breakpoint-down (sm) {

--- a/static/scss/detail/enterprise/learning-strategy-form.scss
+++ b/static/scss/detail/enterprise/learning-strategy-form.scss
@@ -3,7 +3,7 @@
 .learning-strategy-block {
   width: 100%;
   padding: 75px 0 0;
-  background: url('#{$static-path}/images/enterprise-page-dots-bg.png') repeat-x 0% 60% $alice-blue;
+  background: url('#{$static-path}/images/enterprise/enterprise-page-dots-bg.png') repeat-x 0% 60% $alice-blue;
   background-size: contain;
 
   @include media-breakpoint-down (sm) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes issue with the path of an enterprise banner background. Image exists at `/images/enterprise/` but `enterprise/` was missing and resulted in 404.

#### How should this be manually tested?

- Setup enterprise page
- Verify the dotted banner for the learning journey and the learning strategy form.

#### Screenshots (if appropriate)
Failing request on RC
<img width="1738" alt="Screenshot 2024-01-24 at 6 41 05 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/af5e8d2a-d760-4a96-8b78-e84589bea4e8">

After fix:
<img width="1738" alt="Screenshot 2024-01-24 at 6 48 49 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/27c68ae8-feb1-4153-a53e-1f1495e060f5">
Before Fix:
<img width="1738" alt="Screenshot 2024-01-24 at 6 49 16 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/f61c36af-8055-4d3c-bf42-588c118bae9d">


