### PR TITLE
Add usedforsecurity flag

### DIFF
--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -69,7 +69,7 @@ def load_drf_strategy(request=None):
 
 def get_md5_hash(value):
     """Returns the md5 hash object for the given value"""
-    return hashlib.md5(value.lower().encode("utf-8"))
+    return hashlib.md5(value.lower().encode("utf-8"), usedforsecurity=False)
 
 
 def is_user_email_blocked(email):

--- a/users/management/tests/block_users_test.py
+++ b/users/management/tests/block_users_test.py
@@ -28,7 +28,9 @@ class TestblockUsers(TestCase):
 
         user = UserFactory.create(email=test_email, is_active=True)
         email = user.email
-        hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
+        hashed_email = hashlib.md5(
+            email.lower().encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
         assert BlockList.objects.all().count() == 0
 
         COMMAND.handle("block_users", users=[test_email], block_users=True)

--- a/users/management/tests/block_users_test.py
+++ b/users/management/tests/block_users_test.py
@@ -28,7 +28,7 @@ class TestblockUsers(TestCase):
 
         user = UserFactory.create(email=test_email, is_active=True)
         email = user.email
-        hashed_email = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+        hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
         assert BlockList.objects.all().count() == 0
 
         COMMAND.handle("block_users", users=[test_email], block_users=True)

--- a/users/management/tests/retire_users_test.py
+++ b/users/management/tests/retire_users_test.py
@@ -83,7 +83,7 @@ def test_retire_user_blocking_with_email():
     user = UserFactory.create(email=test_email, is_active=True)
     UserSocialAuthFactory.create(user=user, provider="edX")
     email = user.email
-    hashed_email = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+    hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
     assert user.is_active is True
     assert "retired_email" not in user.email
     assert UserSocialAuth.objects.filter(user=user).count() == 1
@@ -132,7 +132,7 @@ def test_user_blocking_if_not_requested():
     user = UserFactory.create(email=test_email, is_active=True)
     UserSocialAuthFactory.create(user=user, provider="edX")
     email = user.email
-    hashed_email = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+    hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
     assert user.is_active is True
     assert "retired_email" not in user.email
     assert UserSocialAuth.objects.filter(user=user).count() == 1

--- a/users/management/tests/retire_users_test.py
+++ b/users/management/tests/retire_users_test.py
@@ -83,7 +83,9 @@ def test_retire_user_blocking_with_email():
     user = UserFactory.create(email=test_email, is_active=True)
     UserSocialAuthFactory.create(user=user, provider="edX")
     email = user.email
-    hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
+    hashed_email = hashlib.md5(
+        email.lower().encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
     assert user.is_active is True
     assert "retired_email" not in user.email
     assert UserSocialAuth.objects.filter(user=user).count() == 1
@@ -132,7 +134,9 @@ def test_user_blocking_if_not_requested():
     user = UserFactory.create(email=test_email, is_active=True)
     UserSocialAuthFactory.create(user=user, provider="edX")
     email = user.email
-    hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
+    hashed_email = hashlib.md5(
+        email.lower().encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
     assert user.is_active is True
     assert "retired_email" not in user.email
     assert UserSocialAuth.objects.filter(user=user).count() == 1

--- a/users/management/tests/unblock_users_test.py
+++ b/users/management/tests/unblock_users_test.py
@@ -31,7 +31,9 @@ class TestUnblockUsers(TestCase):
         user = UserFactory.create(email=test_email, is_active=True)
         UserSocialAuthFactory.create(user=user, provider="edX")
         email = user.email
-        hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
+        hashed_email = hashlib.md5(
+            email.lower().encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
         assert user.is_active is True
         assert "retired_email" not in user.email
         assert UserSocialAuth.objects.filter(user=user).count() == 1

--- a/users/management/tests/unblock_users_test.py
+++ b/users/management/tests/unblock_users_test.py
@@ -31,7 +31,7 @@ class TestUnblockUsers(TestCase):
         user = UserFactory.create(email=test_email, is_active=True)
         UserSocialAuthFactory.create(user=user, provider="edX")
         email = user.email
-        hashed_email = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+        hashed_email = hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()
         assert user.is_active is True
         assert "retired_email" not in user.email
         assert UserSocialAuth.objects.filter(user=user).count() == 1


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Ran `bandit` for static code analysis and our use of md5 was flagged based on the following [test plugin](https://bandit.readthedocs.io/en/latest/plugins/b324_hashlib.html). Checking our use of md5 in this case doesn't appear to be a sec issue, thus added the recommended flag `usedforsecurity`.