### PR TITLE
chore: set time fields for start/end date in Django with a default time

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -90,6 +90,19 @@ class CourseRunAdmin(TimestampedModelAdmin):
     }
 
     def get_changeform_initial_data(self, request):
+        """
+        Returns initial data for the change form.
+
+        Sets the initial values for start_date and end_date fields
+        to the current date with a time of 23:59:00 for start_date,
+        and the next day with a time of 23:59:00 for end_date.
+
+        Args:
+            request: The request object.
+
+        Returns:
+            dict: A dictionary containing initial data for the form.
+        """
         initial = super().get_changeform_initial_data(request)
         start_date = now_in_utc().replace(hour=23, minute=59, second=0, microsecond=0)
         initial["start_date"] = start_date

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -74,15 +74,19 @@ class CourseRunAdminForm(forms.ModelForm):
 
     class Meta:
         model = CourseRun
-        fields = '__all__'
+        fields = "__all__"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.instance.pk:
             start_date = now_in_utc()
             end_date = start_date + timedelta(days=1)
-            self.initial['start_date'] = start_date.replace(hour=23, minute=59, second=0, microsecond=0)
-            self.initial['end_date'] = end_date.replace(hour=23, minute=59, second=0, microsecond=0)
+            self.initial["start_date"] = start_date.replace(
+                hour=23, minute=59, second=0, microsecond=0
+            )
+            self.initial["end_date"] = end_date.replace(
+                hour=23, minute=59, second=0, microsecond=0
+            )
 
 
 @admin.register(CourseRun)

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -91,9 +91,7 @@ class CourseRunAdmin(TimestampedModelAdmin):
 
     def get_changeform_initial_data(self, request):
         initial = super().get_changeform_initial_data(request)
-        start_date = now_in_utc().replace(
-            hour=23, minute=59, second=0, microsecond=0
-        )
+        start_date = now_in_utc().replace(hour=23, minute=59, second=0, microsecond=0)
         initial["start_date"] = start_date
         initial["end_date"] = start_date + timedelta(days=1)
         return initial

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -4,7 +4,6 @@ Admin site bindings for profiles
 
 from datetime import timedelta
 
-from django import forms
 from django.contrib import admin
 from django.db import models
 from django.forms import TextInput
@@ -69,31 +68,11 @@ class CourseAdmin(admin.ModelAdmin):
         return obj.program.readable_id if obj.program is not None else None
 
 
-class CourseRunAdminForm(forms.ModelForm):
-    """Admin form for CourseRun"""
-
-    class Meta:
-        model = CourseRun
-        fields = "__all__"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not self.instance.pk:
-            start_date = now_in_utc()
-            end_date = start_date + timedelta(days=1)
-            self.initial["start_date"] = start_date.replace(
-                hour=23, minute=59, second=0, microsecond=0
-            )
-            self.initial["end_date"] = end_date.replace(
-                hour=23, minute=59, second=0, microsecond=0
-            )
-
-
 @admin.register(CourseRun)
 class CourseRunAdmin(TimestampedModelAdmin):
     """Admin for CourseRun"""
 
-    form = CourseRunAdminForm
+    model = CourseRun
     search_fields = ["title", "courseware_id"]
     list_display = (
         "id",
@@ -109,6 +88,15 @@ class CourseRunAdmin(TimestampedModelAdmin):
     formfield_overrides = {
         models.CharField: {"widget": TextInput(attrs={"size": "80"})}
     }
+
+    def get_changeform_initial_data(self, request):
+        initial = super().get_changeform_initial_data(request)
+        start_date = now_in_utc().replace(
+            hour=23, minute=59, second=0, microsecond=0
+        )
+        initial["start_date"] = start_date
+        initial["end_date"] = start_date + timedelta(days=1)
+        return initial
 
 
 @admin.register(ProgramEnrollment)


### PR DESCRIPTION
### What are the relevant tickets?
[#3734](https://github.com/mitodl/hq/issues/3734) 

### Description (What does it do?)
This PR autopopulates the datetime fields for start_date and end_date in the Django admin interface. It sets a default time of 23:59:00 and the default date to the current date for start_date, while end_date is autopopulated to the next day.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

1. Checkout to this branch, and log in to the Django admin interface.
2. Create or Edit CourseRun Instance:
    - Create a new CourseRun instance or edit an existing one.
    - Observe that if the instance is new (not yet saved to the database), the start_date field defaults to the current date with a time of 23:59:00, and the end_date field defaults to the next day with a time of 23:59:00.
    - If editing an existing instance, ensure that the default values are not applied to the start_date and end_date fields, unless explicitly set by the user.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
