### PR TITLE
feat: remove legacy zendesk snippets

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -30,17 +30,6 @@
   {% render_bundle 'header' %}
 {% endblock %}
 
-{% block scripts %}
-  {{ block.super }}
-  <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
-      if (SETTINGS.zendesk_config.help_widget_enabled) {
-        zE('webWidget', 'helpCenter:setSuggestions', { search: '{{page.product.title}}'});
-      }
-    });
-  </script>
-{% endblock %}
-
 {% block content %}
 <div>
   {% include "partials/hero.html" %}

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -78,21 +78,5 @@
         });
         </script>
     {% endblock %}
-    {% if zendesk_config.help_widget_enabled and not request.path|startswith:'/certificate/' %}
-    <script type="text/javascript">
-      document.addEventListener('DOMContentLoaded', function() {
-        if (typeof zE !== 'undefined') {
-          zE('webWidget', 'prefill', {
-            name: {
-                value: '{{user.name}}',
-            },
-            email: {
-                value: '{{user.email}}',
-            }
-          });
-        }
-      });
-    </script>
-    {% endif %}
   </body>
 </html>

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -249,12 +249,6 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
     }
 
     const dataConsent = basket.data_consents[0]
-    if (SETTINGS.zendesk_config.help_widget_enabled) {
-      ZendeskAPI("webWidget", "helpCenter:setSuggestions", {
-        search: item.content_title
-      })
-    }
-
     return (
       <React.Fragment>
         <Form className="checkout-page container">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3366 & https://github.com/mitodl/mitxpro/issues/2910

### Description (What does it do?)
<!--- Describe your changes in detail -->
Thie PR removes the legacy Help Widget snippets that we added. CS team wants to use the new widget and we don't need these snippets now.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Set `ZENDESK_HELP_WIDGET_KEY=4bde85d7-9202-4a71-9a35-d9295e7a5b3d` in .env locally
- Verify the new help widget is visible
- Smoke test all pages i.e. home page, product pages, catalog page, webinar page, enterprise page, blog page, checkout, user profile, and user account.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
https://github.com/mitodl/hq/issues/3366#issuecomment-1994497120
