### PR TITLE
Update the tax calculation rules to charge more aggressively

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -93,11 +93,7 @@ def determine_visitor_country(request: HttpRequest or None) -> str or None:
         The resolved country, or None
     """
 
-    if (
-        not request
-        or not request.user.is_authenticated
-        or request.user.legal_address.country is None
-    ):
+    if not request or not request.user.is_authenticated:
         return None
 
     profile_country_code = (
@@ -110,14 +106,9 @@ def determine_visitor_country(request: HttpRequest or None) -> str or None:
     try:
         client_ip, _ = get_client_ip(request)
     except TypeError:
-        return None
+        return profile_country_code
 
-    ip_country_code = ip_to_country_code(client_ip)
-
-    if ip_country_code == profile_country_code:
-        return ip_country_code
-
-    return None
+    return ip_to_country_code(client_ip) or profile_country_code
 
 
 def calculate_tax(


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/3582

### Description (What does it do?)

Changes the tax assessment algorithm to be more aggressive in assessing tax for regions that require it. 

Before, the behavior was to charge tax if _both_ the user's IP address was geolocated to a country that required tax, _and_ if the user's profile indicated that they were in that same country. We now want to charge the tax if _either_ of these conditions are true, and this update allows for that. 

In the case where the user is in a country that charges tax, but their IP is in a _different_ country that charges _different_ tax, then we prefer the IP-based location. (So, if tax is set up for assessment for both CA and US, for instance, at different rates, a US-based learner in CA will be charged CA tax.) 

### How can this be tested?

Automated tests should work. Testing locally will require that you have xPRO running as well as the MaxMind GeoLite2 data imported. 

Testing the IP-based rate assessment also requires that you set up a netblock for the private IP range that your Docker setup uses. This is most likely 172.16.0.0/12; in this case, you should set up a netblock as follows (in Django Admin):
```
Decimal ip start: 				2886729728
Decimal ip end: 				2887778303
Ip start: 					172.16.0.0
Ip end: 					172.31.255.255
Network: 					172.16.0.0/12
Geoname id: 					6252001
Registered country geoname id: 			6252001
Represented country geoname id: 		6252001
```
This will get you a netblock for your Docker IPs that is for the US. Change as necessary. There's an IP-to-decimal conversion tool [here](https://www.ipaddressguide.com/ip) if you need it. You'll want to update the geoname ID fields to represent the country that you're testing in. (i.e. if your tax rate is set up for US, use `6252001` for a netblock that's in the US, or a different one for one that's outside.) 

Attempt to navigate to the checkout page in each of the following scenarios:

| Scenario | Tax Assessed? |
|---|---|
| Learner account profile set to a country that **does not** assess tax using an IP that **is not** configured or is not in a country that assesses tax | No |
| Learner account profile set to a country that **does** assess tax, using an IP that **is not** configured/set to a country that assesses tax | **Yes**, country that the learner profile is set to |
| Learner account profile set to a country that **does not** assess tax, using an IP that **is** configured to a country that assesses tax | **Yes**, country that the IP is set to |
| Learner account profile set to a country that **does** assess tax, using an IP that **is** configured to **the same country** that assesses tax | **Yes**, the shared country between these two |
| Learner account profile set to a country that **does** assess tax, using an IP that **is** configured to **a different country** that assesses tax | **Yes**, the country that the **IP** is set to |

You'll have to modify your tax rates and netblock to test all of these scenarios. 