### PR TITLE
fix: use raw id for voucher admin to avoid timeout

### DIFF
--- a/voucher/admin.py
+++ b/voucher/admin.py
@@ -26,3 +26,4 @@ class VoucherAdmin(admin.ModelAdmin):
         "course_title_input",
     )
     readonly_fields = ("coupon", "product", "enrollment")
+    raw_id_fields = ("user",)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/3795

### Description (What does it do?)
<!--- Describe your changes in detail -->
Uses raw_id_fields for the `user` FK field in the voucher admin.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
<img width="1739" alt="Screenshot 2024-03-19 at 10 06 54 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/35d7c925-3a4d-48ca-8793-3e3dc5bf5e94">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Timeout cannot be replicated without creating a lot of users.
2. We need to verify the Voucher admin at `/admin/voucher/voucher/`. The user should be a raw id field.

