### PR TITLE
fix: ignore git guardian secret on local docker compsoe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   db:
     image: postgres:12.17
     environment:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
     ports:
       - "5432"
 


### PR DESCRIPTION
### What are the relevant tickets?
None,

### Description (What does it do?)
- The Git Guardian warns about a secret exposing the docker compose file which is just for local.


### How can this be tested?
- There should be no comment from GitGuardian
