### PR TITLE
Styling for the hubspot forms fields available in the list provided

### DIFF
--- a/cms/templates/partials/hero.html
+++ b/cms/templates/partials/hero.html
@@ -35,7 +35,7 @@
           <h1>{{ page.title }}</h1>
           <h2>{{ page.subhead }}</h2>
         </div>
-        <div class="mt-5 mb-5 navbar navbar-expand-md header-button">
+        <div class="mt-5 mb-5 header-button">
           <div>
             {% include "partials/enroll_button.html" %}
           </div>

--- a/cms/templates/partials/keep_me_updated_button.html
+++ b/cms/templates/partials/keep_me_updated_button.html
@@ -1,5 +1,5 @@
 {% if hubspot_portal_id and page.marketing_hubspot_form_id and not enrolled %}
-<a data-toggle="modal" class="keep-me-updated enroll-now" href="#signup-modal-{{unique_identifier}}">
+<a data-toggle="modal" class="keep-me-updated" href="#signup-modal-{{unique_identifier}}">
   Keep me updated
 </a>
 
@@ -23,7 +23,7 @@
               <p>Not ready yet? No worries, get emailed on course updates, course schedules and more!</p>
             </div>
           </div>
-          <div class="container" id="marketing-hubspot-form-{{unique_identifier}}">
+          <div class="container hubspot-form-container" id="marketing-hubspot-form-{{unique_identifier}}">
           </div>
         </div>
       </div>

--- a/cms/templates/partials/keep_me_updated_button.html
+++ b/cms/templates/partials/keep_me_updated_button.html
@@ -67,6 +67,7 @@
           portalId: "{{ hubspot_portal_id | safe }}",
           formId: "{{ page.marketing_hubspot_form_id  | safe }}",
           target: "#marketing-hubspot-form-{{unique_identifier}}",
+          formInstanceId: "{{unique_identifier}}",
           onFormSubmitted: function($form, data) {
             if (!data.redirectUrl) {
               if ('firstname' in data.submissionValues) {

--- a/cms/templates/partials/subnav.html
+++ b/cms/templates/partials/subnav.html
@@ -2,12 +2,6 @@
   <a class="navbar-toggler collapsed active-block" data-toggle="collapse" data-target="#subNavBar">
     <span id="subNavBarSelector" class="collapsed-header">Who Should Enroll</span>
   </a>
-  <div class="sub-nav-enroll-button-block">
-    {% include "partials/enroll_button.html" %}
-  </div>
-  <div class="sub-nav-signup-button-block">
-    {% include "partials/keep_me_updated_button.html" with unique_identifier="subnav" %}
-  </div>
   <div id="subNavBar" class="collapse navbar-collapse justify-content-center">
     <ul class="navbar-nav container justify-content-center">
       {% if outcomes %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#learningOutcomes">What You Will Learn</a></li> {% endif %}
@@ -20,5 +14,11 @@
       {% if for_teams %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#forTeams">Enterprise</a></li> {% endif %}
       {% if faqs %} <li class="nav-item px-2 d-flex align-items-center"><a class="nav-link text-center" href="#faq">FAQs</a></li> {% endif %}
     </ul>
+  </div>
+  <div class="sub-nav-enroll-button-block">
+    {% include "partials/enroll_button.html" %}
+  </div>
+  <div class="sub-nav-signup-button-block">
+    {% include "partials/keep_me_updated_button.html" with unique_identifier="subnav" %}
   </div>
 </nav>

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -312,7 +312,7 @@
     }
 
     .hs-recaptcha, .hs-submit {
-        padding-top: 16px;
+      padding-top: 16px;
     }
 
     .hs-submit {

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -219,6 +219,166 @@
     }
   }
 
+  form {
+    width: 100%;
+    height: auto;
+
+    .hs-form-field {
+      padding-bottom: 16px;
+
+      label {
+        color: #495057;
+        font-family: Rajdhani;
+        font-size: 18px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: normal;
+      }
+
+      input[type="text"],
+      input[type="email"],
+      input[type="tel"],
+      select {
+        height: 50px;
+        width: 100%;
+        align-self: stretch;
+        border-radius: 4px;
+        border: 1px solid #CED4DA;
+        background: $white;
+        box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
+        padding: 12px;
+        font-family: Rajdhani;
+        font-size: 18px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: normal;
+        outline: none;
+
+        &:focus {
+          border: 2px solid #CED4DA;
+        }
+      }
+
+      .hs-error-msgs {
+        padding: 0;
+        margin: 0;
+        list-style: none;
+
+        label {
+          color: $primary;
+          display: block;
+        }
+      }
+
+      .multi-container {
+        padding: 0;
+        margin: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        .hs-form-radio {
+
+          label {
+            position: relative;
+
+            input {
+              height: 22px;
+              left: 0;
+              opacity: 0;
+              position: absolute;
+              top: 0;
+              width: 22px;
+            }
+
+            span {
+              display: inline-block;
+              margin-left: 28px;
+              margin-right: 32px;
+
+              &::before {
+                color: #B8C2CC;
+                border: 2px solid;
+                content: "";
+                height: 22px;
+                left: 0;
+                position: absolute;
+                top: 0;
+                width: 22px;
+                border-radius: 50%;
+              }
+
+              &::after {
+                color: $primary;
+                content: "";
+                opacity: 0;
+                border: 6px solid;
+                border-radius: 50%;
+                position: absolute;
+                left: 5px;
+                top: 5px;
+                transition: opacity 0.2s ease-in-out;
+              }
+            }
+
+            input:checked + span::after {
+              opacity: 1;
+            }
+
+            input:checked + span::before {
+              color: $primary;
+            }
+
+            input:not(:checked):hover + span::before {
+              background: $close-hover-background;
+              color: $primary;
+            }
+
+            input:not(:checked):hover + span {
+              cursor: pointer;
+            }
+          }
+        }
+
+        .hs-form-checkbox {
+          span {
+            display: inline-block;
+            margin-left: 8px;
+            margin-right: 32px;
+          }
+        }
+      }
+    }
+
+    .hs-submit {
+      padding-bottom: 10px;
+      text-align: right;
+
+      input[type="submit"] {
+        @extend .btn;
+        @extend .btn-primary;
+        border-radius: 5px;
+        background: $primary;
+        padding: 19px 25px;
+        font-family: Rajdhani;
+        font-size: 16px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: normal;
+        text-transform: uppercase;
+
+        &:hover {
+          text-decoration: none;
+          transition: all .2s ease-in;
+        }
+      }
+    }
+
+    .hs_error_rollup {
+      display: none;
+    }
+  }
 }
 
 .notifications {

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -80,6 +80,39 @@
 
   .header-button {
     padding: 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+
+    @include media-breakpoint-up(lg) {
+      .enroll-button,
+      .keep-me-updated {
+        flex: 1;
+      }
+
+      .keep-me-updated {
+        margin-left: 15px;
+      }
+    }
+
+    @include media-breakpoint-down(md) {
+      .keep-me-updated {
+        margin-left: 15px;
+      }
+    }
+
+    @include media-breakpoint-down(sm) {
+      flex-direction: column;
+      align-items: stretch;
+
+      .enroll-button,
+      .keep-me-updated {
+        margin-left: 0;
+        margin-bottom: 15px;
+        width: 100%;
+        justify-content: center;
+      }
+    }
   }
 
   .action-button {
@@ -207,10 +240,10 @@
     text-transform: uppercase;
     cursor: pointer;
     font-weight: 700;
-    margin-left: 20px;
 
     background: $white;
     border: 1px solid $primary;
+    white-space: nowrap;
 
     &:hover {
       // underline is at different levels since we centered the text and checkmark vertically, so it looks strange
@@ -218,7 +251,49 @@
       background: $close-hover-background;
     }
   }
+}
 
+.notifications {
+  .alert {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: center;
+  }
+}
+
+.modal-content-signup {
+  position: relative;
+  width: 500px;
+  background: $white;
+  border-radius: 4px;
+  color: $black;
+
+  .container {
+    display: block;
+  }
+
+  .close {
+    opacity: 1;
+  }
+
+  .signup-dialog {
+    text-align: center;
+    line-height: 26px;
+
+    h2 {
+      font-weight: 700;
+      font-size: 26px;
+      color: $primary;
+    }
+
+    p {
+      font-weight: 500;
+      font-size: 20px;
+    }
+  }
+}
+
+.hubspot-form-container {
   form {
     width: 100%;
     height: auto;
@@ -346,41 +421,5 @@
     .hs_error_rollup {
       display: none;
     }
-  }
-}
-
-.notifications {
-  .alert {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-align: center;
-  }
-}
-
-.modal-content-signup {
-  position: relative;
-  width: 500px;
-  background: $white;
-  border-radius: 4px;
-  color: $black;
-
-  .close {
-    opacity: 1;
-  }
-}
-
-.signup-dialog {
-  text-align: center;
-  line-height: 26px;
-
-  h2 {
-    font-weight: 700;
-    font-size: 26px;
-    color: $primary;
-  }
-
-  p {
-    font-weight: 500;
-    font-size: 20px;
   }
 }

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -230,7 +230,7 @@
       }
 
       label {
-        color: #495057;
+        color: $hs-form-field-label;
         font-family: Rajdhani;
         font-size: 18px;
         font-style: normal;

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -243,7 +243,7 @@
         width: 100%;
         align-self: stretch;
         border-radius: 4px;
-        border: 1px solid #CED4DA;
+        border: 1px solid $hs-form-field-border;
         background: $white;
         box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
         padding: 12px;
@@ -255,7 +255,7 @@
         outline: none;
 
         &:focus {
-          border: 2px solid #CED4DA;
+          border: 2px solid $hs-form-field-border;
         }
       }
 
@@ -298,7 +298,7 @@
               margin-right: 32px;
 
               &::before {
-                color: #B8C2CC;
+                color: $hs-form-field-radio-gray;
                 border: 2px solid;
                 content: "";
                 height: 22px;
@@ -356,7 +356,9 @@
       text-align: right;
 
       input[type="submit"] {
+        // sass-lint:disable-next-line no-placeholder-in-extend
         @extend .btn;
+        // sass-lint:disable-next-line no-placeholder-in-extend
         @extend .btn-primary;
         border-radius: 5px;
         background: $primary;

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -224,7 +224,7 @@
     height: auto;
 
     .hs-form-field {
-      > label:first-child > span {
+      > label:first-child > span:first-child {
         padding-top: 16px;
         display: inline-block;
       }
@@ -273,6 +273,7 @@
         }
       }
 
+      .inputs-list,
       .multi-container {
         padding: 0;
         margin: 0;
@@ -293,17 +294,20 @@
               margin-left: 28px;
               margin-right: 32px;
             }
+
+            input, span {
+              cursor: pointer;
+            }
           }
         }
 
-        .hs-form-checkbox {
+        .hs-form-checkbox,
+        .hs-form-booleancheckbox {
           span {
             margin-left: 8px;
             margin-right: 32px;
           }
-        }
 
-        .hs-form-radio,.hs-form-checkbox {
           input, span {
             cursor: pointer;
           }

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -1,4 +1,4 @@
-// sass-lint:disable mixins-before-declarations
+// sass-lint:disable mixins-before-declarations placeholder-in-extend
 #header {
   background-color: white;
   position: relative;
@@ -356,9 +356,7 @@
       text-align: right;
 
       input[type="submit"] {
-        // sass-lint:disable-next-line no-placeholder-in-extend
         @extend .btn;
-        // sass-lint:disable-next-line no-placeholder-in-extend
         @extend .btn-primary;
         border-radius: 5px;
         background: $primary;

--- a/static/scss/detail/header.scss
+++ b/static/scss/detail/header.scss
@@ -224,7 +224,10 @@
     height: auto;
 
     .hs-form-field {
-      padding-bottom: 16px;
+      > label:first-child > span {
+        padding-top: 16px;
+        display: inline-block;
+      }
 
       label {
         color: #495057;
@@ -279,76 +282,37 @@
         align-items: center;
 
         .hs-form-radio {
-
           label {
-            position: relative;
-
             input {
               height: 22px;
-              left: 0;
-              opacity: 0;
               position: absolute;
-              top: 0;
               width: 22px;
             }
 
             span {
-              display: inline-block;
               margin-left: 28px;
               margin-right: 32px;
-
-              &::before {
-                color: $hs-form-field-radio-gray;
-                border: 2px solid;
-                content: "";
-                height: 22px;
-                left: 0;
-                position: absolute;
-                top: 0;
-                width: 22px;
-                border-radius: 50%;
-              }
-
-              &::after {
-                color: $primary;
-                content: "";
-                opacity: 0;
-                border: 6px solid;
-                border-radius: 50%;
-                position: absolute;
-                left: 5px;
-                top: 5px;
-                transition: opacity 0.2s ease-in-out;
-              }
-            }
-
-            input:checked + span::after {
-              opacity: 1;
-            }
-
-            input:checked + span::before {
-              color: $primary;
-            }
-
-            input:not(:checked):hover + span::before {
-              background: $close-hover-background;
-              color: $primary;
-            }
-
-            input:not(:checked):hover + span {
-              cursor: pointer;
             }
           }
         }
 
         .hs-form-checkbox {
           span {
-            display: inline-block;
             margin-left: 8px;
             margin-right: 32px;
           }
         }
+
+        .hs-form-radio,.hs-form-checkbox {
+          input, span {
+            cursor: pointer;
+          }
+        }
       }
+    }
+
+    .hs-recaptcha, .hs-submit {
+        padding-top: 16px;
     }
 
     .hs-submit {

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -1,4 +1,4 @@
-// sass-lint:disable mixins-before-declarations placeholder-in-extend
+// sass-lint:disable mixins-before-declarations
 .sub-nav-bar {
   background: $gray-bg;
   display: flex;
@@ -32,6 +32,14 @@
 
     span.fa-chevron-up {
       display: block;
+    }
+
+    @include media-breakpoint-down (sm) {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-bottom: 10px;
     }
   }
 
@@ -175,6 +183,7 @@
 
       background: $white;
       border: 1px solid $primary;
+      white-space: nowrap;
 
       &:hover {
         text-decoration: none;
@@ -182,168 +191,6 @@
 
       }
     }
-
-    form {
-      width: 100%;
-      height: auto;
-
-      .hs-form-field {
-        > label:first-child > span:first-child {
-          padding-top: 16px;
-          display: inline-block;
-        }
-
-        label {
-          color: $hs-form-field-label;
-          font-family: Rajdhani;
-          font-size: 18px;
-          font-style: normal;
-          font-weight: 500;
-          line-height: normal;
-        }
-
-        input[type="text"],
-        input[type="email"],
-        input[type="tel"],
-        select {
-          height: 50px;
-          width: 100%;
-          align-self: stretch;
-          border-radius: 4px;
-          border: 1px solid $hs-form-field-border;
-          background: $white;
-          box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
-          padding: 12px;
-          font-family: Rajdhani;
-          font-size: 18px;
-          font-style: normal;
-          font-weight: 500;
-          line-height: normal;
-          outline: none;
-
-          &:focus {
-            border: 2px solid $hs-form-field-border;
-          }
-        }
-
-        .hs-error-msgs {
-          padding: 0;
-          margin: 0;
-          list-style: none;
-
-          label {
-            color: $primary;
-            display: block;
-          }
-        }
-
-        .inputs-list,
-        .multi-container {
-          padding: 0;
-          margin: 0;
-          list-style: none;
-
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-
-          .hs-form-radio {
-            label {
-              input {
-                height: 22px;
-                position: absolute;
-                width: 22px;
-              }
-
-              span {
-                margin-left: 28px;
-                margin-right: 32px;
-              }
-
-              input, span {
-                cursor: pointer;
-              }
-            }
-          }
-
-          .hs-form-checkbox,
-          .hs-form-booleancheckbox {
-            span {
-              margin-left: 8px;
-              margin-right: 32px;
-            }
-
-            input, span {
-              cursor: pointer;
-            }
-          }
-        }
-      }
-
-      .hs-recaptcha, .hs-submit {
-        padding-top: 16px;
-      }
-
-      .hs-submit {
-        padding-bottom: 10px;
-        text-align: right;
-
-        input[type="submit"] {
-          @extend .btn;
-          @extend .btn-primary;
-          border-radius: 5px;
-          background: $primary;
-          padding: 19px 25px;
-          font-family: Rajdhani;
-          font-size: 16px;
-          font-style: normal;
-          font-weight: 700;
-          line-height: normal;
-          text-transform: uppercase;
-
-          &:hover {
-            text-decoration: none;
-            transition: all .2s ease-in;
-          }
-        }
-      }
-
-      .hs_error_rollup {
-        display: none;
-      }
-    }
-  }
-}
-
-.modal-content-signup {
-  position: relative;
-  width: 500px;
-  background: $white;
-  border-radius: 4px;
-  color: $black;
-
-  .container {
-    display: block;
-  }
-
-  .close {
-    opacity: 1;
-  }
-}
-
-.signup-dialog {
-  text-align: center;
-  line-height: 26px;
-
-  h2 {
-    font-weight: 700;
-    font-size: 26px;
-    color: $primary;
-  }
-
-  p {
-    font-weight: 500;
-    font-size: 20px;
   }
 }
 

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -188,7 +188,7 @@
       height: auto;
 
       .hs-form-field {
-        > label:first-child > span {
+        > label:first-child > span:first-child {
           padding-top: 16px;
           display: inline-block;
         }
@@ -237,6 +237,7 @@
           }
         }
 
+        .inputs-list,
         .multi-container {
           padding: 0;
           margin: 0;
@@ -258,17 +259,20 @@
                 margin-left: 28px;
                 margin-right: 32px;
               }
+
+              input, span {
+                cursor: pointer;
+              }
             }
           }
 
-          .hs-form-checkbox {
+          .hs-form-checkbox,
+          .hs-form-booleancheckbox {
             span {
               margin-left: 8px;
               margin-right: 32px;
             }
-          }
 
-          .hs-form-radio,.hs-form-checkbox {
             input, span {
               cursor: pointer;
             }

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -182,6 +182,168 @@
 
       }
     }
+
+    form {
+      width: 100%;
+      height: auto;
+
+      .hs-form-field {
+        padding-bottom: 16px;
+
+        label {
+          color: #495057;
+          font-family: Rajdhani;
+          font-size: 18px;
+          font-style: normal;
+          font-weight: 500;
+          line-height: normal;
+        }
+
+        input[type="text"],
+        input[type="email"],
+        input[type="tel"],
+        select {
+          height: 50px;
+          width: 100%;
+          align-self: stretch;
+          border-radius: 4px;
+          border: 1px solid #CED4DA;
+          background: $white;
+          box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
+          padding: 12px;
+          font-family: Rajdhani;
+          font-size: 18px;
+          font-style: normal;
+          font-weight: 500;
+          line-height: normal;
+          outline: none;
+
+          &:focus {
+            border: 2px solid #CED4DA;
+          }
+        }
+
+        .hs-error-msgs {
+          padding: 0;
+          margin: 0;
+          list-style: none;
+
+          label {
+            color: $primary;
+            display: block;
+          }
+        }
+
+        .multi-container {
+          padding: 0;
+          margin: 0;
+          list-style: none;
+
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+
+          .hs-form-radio {
+
+            label {
+              position: relative;
+
+              input {
+                height: 22px;
+                left: 0;
+                opacity: 0;
+                position: absolute;
+                top: 0;
+                width: 22px;
+              }
+
+              span {
+                display: inline-block;
+                margin-left: 28px;
+                margin-right: 32px;
+
+                &::before {
+                  color: #B8C2CC;
+                  border: 2px solid;
+                  content: "";
+                  height: 22px;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                  width: 22px;
+                  border-radius: 50%;
+                }
+
+                &::after {
+                  color: $primary;
+                  content: "";
+                  opacity: 0;
+                  border: 6px solid;
+                  border-radius: 50%;
+                  position: absolute;
+                  left: 5px;
+                  top: 5px;
+                  transition: opacity 0.2s ease-in-out;
+                }
+              }
+
+              input:checked + span::after {
+                opacity: 1;
+              }
+
+              input:checked + span::before {
+                color: $primary;
+              }
+
+              input:not(:checked):hover + span::before {
+                background: $close-hover-background;
+                color: $primary;
+              }
+
+              input:not(:checked):hover + span {
+                cursor: pointer;
+              }
+            }
+          }
+
+          .hs-form-checkbox {
+            span {
+              display: inline-block;
+              margin-left: 8px;
+              margin-right: 32px;
+            }
+          }
+        }
+      }
+
+      .hs-submit {
+        padding-bottom: 10px;
+        text-align: right;
+
+        input[type="submit"] {
+          @extend .btn;
+          @extend .btn-primary;
+          border-radius: 5px;
+          background: $primary;
+          padding: 19px 25px;
+          font-family: Rajdhani;
+          font-size: 16px;
+          font-style: normal;
+          font-weight: 700;
+          line-height: normal;
+          text-transform: uppercase;
+
+          &:hover {
+            text-decoration: none;
+            transition: all .2s ease-in;
+          }
+        }
+      }
+
+      .hs_error_rollup {
+        display: none;
+      }
+    }
   }
 }
 

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -1,4 +1,4 @@
-// sass-lint:disable mixins-before-declarations
+// sass-lint:disable mixins-before-declarations placeholder-in-extend
 .sub-nav-bar {
   background: $gray-bg;
   display: flex;
@@ -321,9 +321,7 @@
         text-align: right;
 
         input[type="submit"] {
-          // sass-lint:disable-next-line no-placeholder-in-extend
           @extend .btn;
-          // sass-lint:disable-next-line no-placeholder-in-extend
           @extend .btn-primary;
           border-radius: 5px;
           background: $primary;

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -207,7 +207,7 @@
           width: 100%;
           align-self: stretch;
           border-radius: 4px;
-          border: 1px solid #CED4DA;
+          border: 1px solid $hs-form-field-border;
           background: $white;
           box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
           padding: 12px;
@@ -219,7 +219,7 @@
           outline: none;
 
           &:focus {
-            border: 2px solid #CED4DA;
+            border: 2px solid $hs-form-field-border;
           }
         }
 
@@ -263,7 +263,7 @@
                 margin-right: 32px;
 
                 &::before {
-                  color: #B8C2CC;
+                  color: $hs-form-field-radio-gray;
                   border: 2px solid;
                   content: "";
                   height: 22px;
@@ -321,7 +321,9 @@
         text-align: right;
 
         input[type="submit"] {
+          // sass-lint:disable-next-line no-placeholder-in-extend
           @extend .btn;
+          // sass-lint:disable-next-line no-placeholder-in-extend
           @extend .btn-primary;
           border-radius: 5px;
           background: $primary;

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -188,7 +188,10 @@
       height: auto;
 
       .hs-form-field {
-        padding-bottom: 16px;
+        > label:first-child > span {
+          padding-top: 16px;
+          display: inline-block;
+        }
 
         label {
           color: #495057;
@@ -244,76 +247,37 @@
           align-items: center;
 
           .hs-form-radio {
-
             label {
-              position: relative;
-
               input {
                 height: 22px;
-                left: 0;
-                opacity: 0;
                 position: absolute;
-                top: 0;
                 width: 22px;
               }
 
               span {
-                display: inline-block;
                 margin-left: 28px;
                 margin-right: 32px;
-
-                &::before {
-                  color: $hs-form-field-radio-gray;
-                  border: 2px solid;
-                  content: "";
-                  height: 22px;
-                  left: 0;
-                  position: absolute;
-                  top: 0;
-                  width: 22px;
-                  border-radius: 50%;
-                }
-
-                &::after {
-                  color: $primary;
-                  content: "";
-                  opacity: 0;
-                  border: 6px solid;
-                  border-radius: 50%;
-                  position: absolute;
-                  left: 5px;
-                  top: 5px;
-                  transition: opacity 0.2s ease-in-out;
-                }
-              }
-
-              input:checked + span::after {
-                opacity: 1;
-              }
-
-              input:checked + span::before {
-                color: $primary;
-              }
-
-              input:not(:checked):hover + span::before {
-                background: $close-hover-background;
-                color: $primary;
-              }
-
-              input:not(:checked):hover + span {
-                cursor: pointer;
               }
             }
           }
 
           .hs-form-checkbox {
             span {
-              display: inline-block;
               margin-left: 8px;
               margin-right: 32px;
             }
           }
+
+          .hs-form-radio,.hs-form-checkbox {
+            input, span {
+              cursor: pointer;
+            }
+          }
         }
+      }
+
+      .hs-recaptcha, .hs-submit {
+        padding-top: 16px;
       }
 
       .hs-submit {

--- a/static/scss/detail/subnav.scss
+++ b/static/scss/detail/subnav.scss
@@ -194,7 +194,7 @@
         }
 
         label {
-          color: #495057;
+          color: $hs-form-field-label;
           font-family: Rajdhani;
           font-size: 18px;
           font-style: normal;

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -39,4 +39,4 @@ $white: #fff;
 $alice-blue: #f4f6f7;
 $close-hover-background: #f9f2f3;
 $hs-form-field-border: #ced4da;
-$hs-form-field-radio-gray: #b8c2cc;
+$hs-form-field-label: #495057;

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -38,3 +38,5 @@ $black: #000;
 $white: #fff;
 $alice-blue: #f4f6f7;
 $close-hover-background: #f9f2f3;
+$hs-form-field-border: #ced4da;
+$hs-form-field-radio-gray: #b8c2cc;


### PR DESCRIPTION
### What are the relevant tickets?
Following up: https://github.com/mitodl/mitxpro/pull/2906#issuecomment-2025162702

### Description (What does it do?)
This PR adds styling for the hubspot forms fields available in the [list provided](https://docs.google.com/spreadsheets/d/14iYQ61sktb1At32b9-KrO0yk8DZoaB4Nc98U04eUdyo/edit?pli=1#gid=457117068):


### Screenshots (if appropriate):

**desktop:**
<img width="263" alt="1" src="https://github.com/mitodl/mitxpro/assets/41048311/bfa55adb-d7f1-4ab0-8208-7c208f2b39e2">

<img width="263" alt="3" src="https://github.com/mitodl/mitxpro/assets/41048311/f0ee7f96-f5af-4082-afda-aecf5ddf2d8b">

**Mobile:**
<img width="263" alt="mobile-1" src="https://github.com/mitodl/mitxpro/assets/41048311/713301e5-8b43-411e-a0e6-6b2b2a565d02">

**Mobile design(**keep me updated buttons**):** 

Mobile - header buttons:
<img width="235" alt="Mobile - header buttons" src="https://github.com/mitodl/mitxpro/assets/41048311/c1d445ef-b482-49ca-b063-597a696a2619">

Ipad:
<img width="354" alt="ipad - header buttons" src="https://github.com/mitodl/mitxpro/assets/41048311/4e47f5d9-f542-42ea-bc99-d4eef4a68555">

Mobile subnav - collapse view (with `keep me updated` button):
<img width="354" alt="Mobile subnav - collapse view" src="https://github.com/mitodl/mitxpro/assets/41048311/22dde25e-b695-453d-9d13-368354763a52">

Mobile subnav - collapse show view (with `keep me updated` button):
<img width="354" alt="Mobile subnav - collapse show view" src="https://github.com/mitodl/mitxpro/assets/41048311/3c82b59e-956d-402d-8d9e-a5ae8b30d219">


**Old mobile snapshots(header and subnav buttons):**


<img width="332" alt="old mobile - snapshot header buttons" src="https://github.com/mitodl/mitxpro/assets/41048311/3512ced1-48ad-4369-873c-a0e8d7b337d7">

<img width="332" alt="old mobile - snapshot subnav buttons" src="https://github.com/mitodl/mitxpro/assets/41048311/9b43100f-863d-4704-9f75-0ea8d808ae45">



### How can this be tested?

- Design to be validated: https://www.figma.com/proto/WE9AiQWwhDXe2W4jGTZL8Q/%F0%9F%93%90-MIT-xPro?type=design&node-id=154-2575&viewport=-782%2C262%2C0.18&t=QRs4HRUCF1F26rwP-0&scaling=min-zoom&starting-point-node-id=154%3A2575&show-proto-sidebar=1
- Ensure that the form chosen for testing is set as raw HTML for the design to be properly applied.


### Additional Context

- This PR applies comprehensive styling to the form fields available in the [provided form list](https://docs.google.com/spreadsheets/d/14iYQ61sktb1At32b9-KrO0yk8DZoaB4Nc98U04eUdyo/edit?pli=1#gid=457117068).

- Certain built-in HubSpot form field styles, such as checkboxes, are utilized as customization is not feasible per the design. Discussed with @mbilalmughal, who confirmed this as a known issue in the past due to limitations in customizing HubSpot checkboxes. So used build-in hubspot form checkbox.
- Also some form design properties i.e font-size and weight are different from xpro forms available in the platform, so kept it consistent, same like we have in xpro forms.

- ~~During testing with different forms, it was observed that the form gets stacked when trying to submit more than once. This behavior was noted after implementing the approach of setting the form as raw HTML, particularly when a redirect URL is not set~~. It was a [known issue](https://community.hubspot.com/t5/CMS-Development/Upcoming-Form-element-ID-attribute-is-being-changed-to-be-more/m-p/302679#:~:text=HubSpot%20forms%20render%20a%20%3Cform%3E%20element%20with%20a%20unique%20id%20attribute%20for%20each%20page%20on%20which%20the%20form%20is%20used.%20However%2C%20when%20multiple%20instances%20of%20the%20same%20form%20are%20added%20to%20the%20same%20page%2C%20the%20id%20for%20each%20form%20may%20not%20be%20unique.) by HubSpot if we are rendering the same form multiple times on the same page. It did not appear before because we had a form [rendering in an iframe](https://community.hubspot.com/t5/CMS-Development/Upcoming-Form-element-ID-attribute-is-being-changed-to-be-more/m-p/304507/highlight/true#M14409) and had not set it as raw HTML. It has been resolved by configuring the required attribute when rendering the form multiple times on the same page(i.e header and subnav) and setting it as raw HTML.

CC: @pdpinch @steven-hatch 
