### PR TITLE
feat!: remove partial voucher matching

### DIFF
--- a/static/scss/voucher.scss
+++ b/static/scss/voucher.scss
@@ -68,6 +68,10 @@
       font-weight: 600;
     }
 
+    .help-text {
+      margin-top: 1rem;
+    }
+
     .submit-row {
       margin-top: 25px;
     }

--- a/voucher/templates/enroll.html
+++ b/voucher/templates/enroll.html
@@ -18,15 +18,11 @@
             <form method="post" enctype="multipart/form-data" class="voucher-form ">
                 {% csrf_token %}
                 <div class="flex">
-                    <select name="coupon_version" id="coupon_version" classname="form-control">
-                        <option value="">Choose Course</option>
-                        {% for choice in eligible_choices %}
-                            <option value="{{ choice.0 }}">{{ choice.1 }}</option>
-                        {% endfor %}
-                    </select>
-                    <div id="voucher-error" class="form-error d-none">
-                        Please select a course from the list.
-                        If your expected course isn't in the list, please contact
+                    <input type="hidden" id="product_id" name="product_id" value={{ product_id }}>
+                    <input type="hidden" id="coupon_id" name="coupon_id" value={{ coupon_id }}>
+                    <b class="course-run-display-title">{{ course_run_display_title }}</b>
+                    <div class="help-text">
+                        If this is not the course you are trying to enroll in, please contact
                         <a href="https://xpro.zendesk.com/hc/en-us/requests/new" target="_blank" rel="noopener noreferrer">Customer Support</a>.
                     </div>
                 </div>
@@ -37,23 +33,4 @@
             </form>
         </div>
     </div>
-
-    <script type="text/javascript">
-      document.querySelector(".voucher-form").addEventListener("change", function(e) {
-        if (!$("#coupon_version").val()) {
-          $("#voucher-error").removeClass("d-none");
-        }
-        else
-          $("#voucher-error").addClass("d-none");
-      });
-
-      document.querySelector(".voucher-form").addEventListener("submit", function(e){
-        if (!$("#coupon_version").val()) {
-          $("#voucher-error").removeClass("d-none");
-          e.preventDefault();    //stop form from submitting
-        }
-        else
-          $("#voucher-error").addClass("d-none");
-      });
-    </script>
 {% endblock content %}

--- a/voucher/utils.py
+++ b/voucher/utils.py
@@ -1,6 +1,4 @@
 """PDF Parsing functions for Vouchers"""
-import difflib
-import json
 import logging
 import re
 from datetime import datetime
@@ -8,7 +6,6 @@ from uuid import uuid4
 
 import pdftotext
 from django.conf import settings
-from django.db.models import Q
 
 from courses.models import CourseRun
 from ecommerce.api import get_valid_coupon_versions

--- a/voucher/utils.py
+++ b/voucher/utils.py
@@ -73,18 +73,14 @@ def get_eligible_product_detail(voucher):
     )
     if not valid_coupon:
         log.error(
-            "Found no valid coupons for course run match for voucher %s", voucher.id
+            "Found no valid coupons for course run matching the voucher %s", voucher.id
         )
         return None, None, None
 
-    course_run_display_title = "{title} - starts {start_date}".format(
-        title=matching_course_run.title,
-        start_date=matching_course_run.start_date.strftime("%b %d, %Y"),
-    )
     return (
         matching_course_run.product.first().id,
         valid_coupon.coupon.id,
-        course_run_display_title,
+        f"{matching_course_run.title} - starts {matching_course_run.start_date.strftime('%b %d, %Y')}",
     )
 
 

--- a/voucher/utils.py
+++ b/voucher/utils.py
@@ -43,97 +43,52 @@ def get_current_voucher(user):
     return user.vouchers.order_by("uploaded").last()
 
 
-def get_eligible_coupon_choices(voucher):
+def get_eligible_product_detail(voucher):
     """
-    Find exact or partial matching course runs and get valid coupons for them
+    Find a matching course run and get a valid coupon for it
 
     Args:
-        voucher (Voucher): a voucher to find courses for
+        voucher (Voucher): a voucher to find course for
 
     Returns:
-        list of tuple:
-            list of ('[<product_id>, <coupon_id>]', <course title>) for an eligible coupon / CourseRun match
+        tuple: <product_id>, <coupon_id>, <course run display title> for the eligible coupon / CourseRun match
     """
-    course_matches = None
-    # Search for an exact match if all inputs exist
+    matching_course_run = None
     if voucher.course_id_input and voucher.course_title_input:
-        course_matches = (
+        matching_course_run = (
             CourseRun.objects.filter(
-                course__readable_id__exact=voucher.course_id_input,
-                course__title__exact=voucher.course_title_input,
+                course__readable_id__iexact=voucher.course_id_input,
+                course__title__iexact=voucher.course_title_input,
                 start_date__date=voucher.course_start_date_input,
             )
             .live()
             .enrollment_available()
             .available()
             .order_by("start_date")
-        )
+        ).first()
 
-    # Search for partial matches if no exact match was found
-    if course_matches is None or not course_matches.exists():
-        # Try partial matching
-        course_matches = (
-            CourseRun.objects.filter(
-                (
-                    Q(course__readable_id__icontains=voucher.course_id_input)
-                    if voucher.course_id_input
-                    else Q()
-                )
-                | (
-                    Q(course__title__icontains=voucher.course_title_input)
-                    if voucher.course_title_input
-                    else Q()
-                )
-                | Q(start_date__date=voucher.course_start_date_input)
-            )
-            .live()
-            .enrollment_available()
-            .available()
-            .order_by("start_date")
-        )
-
-    if not course_matches.exists():
-        # No partial matches found
+    if not matching_course_run:
         log.error("Found no matching course runs for voucher %s", voucher.id)
-        return []
+        return None, None, None
 
-    # Check for valid coupon options and return choices
-    valid_coupons = [
-        get_valid_voucher_coupons_version(voucher, match.product.first())
-        for match in course_matches
-    ]
-    eligible_choices = [
-        (
-            json.dumps(
-                (course_matches[i].product.first().id, valid_coupons[i].coupon.id)
-            ),
-            "{title} - starts {start_date}".format(
-                title=course_matches[i].title,
-                start_date=course_matches[i].start_date.strftime("%b %d, %Y"),
-            ),
+    valid_coupon = get_valid_voucher_coupons_version(
+        voucher, matching_course_run.product.first()
+    )
+    if not valid_coupon:
+        log.error(
+            "Found no valid coupons for course run match for voucher %s", voucher.id
         )
-        for i in range(len(course_matches))
-        if valid_coupons[i] is not None and course_matches[i].product is not None
-    ]
-    if course_matches and not eligible_choices:
-        log.error("Found no valid coupons for matches for voucher %s", voucher.id)
+        return None, None, None
 
-    if len(eligible_choices) > 1 and voucher.course_title_input:
-        eligible_choices_titles = [choice[1] for choice in eligible_choices]
-        close_matches = difflib.get_close_matches(
-            voucher.course_title_input,
-            eligible_choices_titles,
-            len(eligible_choices_titles),
-            0,
-        )
-        sorted_eligible_choices = []
-        for match in close_matches:
-            sorted_eligible_choices.append(  # noqa: PERF401
-                eligible_choices[eligible_choices_titles.index(match)]
-            )
-        eligible_choices = sorted_eligible_choices
-
-    return eligible_choices
+    course_run_display_title = "{title} - starts {start_date}".format(
+        title=matching_course_run.title,
+        start_date=matching_course_run.start_date.strftime("%b %d, %Y"),
+    )
+    return (
+        matching_course_run.product.first().id,
+        valid_coupon.coupon.id,
+        course_run_display_title,
+    )
 
 
 def get_valid_voucher_coupons_version(voucher, product):

--- a/voucher/utils_test.py
+++ b/voucher/utils_test.py
@@ -168,7 +168,7 @@ def test_exact_course_match_without_coupon(
     assert coupon_id is None
     assert course_run_display_title is None
     mock_logger.error.assert_called_once_with(
-        "Found no valid coupons for course run match for voucher %s", voucher.id
+        "Found no valid coupons for course run matching the voucher %s", voucher.id
     )
 
 

--- a/voucher/utils_test.py
+++ b/voucher/utils_test.py
@@ -1,5 +1,4 @@
 """Tests for utils.py"""
-import difflib
 import json
 import re
 from datetime import datetime, timezone

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -133,7 +133,7 @@ class EnrollView(LoginRequiredMixin, View):
                     new_coupon_version, "coupon"
                 ):
                     log.error(
-                        "Found no valid coupons for course run match for voucher %s",
+                        "Found no valid coupons for course run matching the voucher %s",
                         voucher.id,
                     )
                     return redirect("voucher:resubmit")

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -1,7 +1,6 @@
 """
 Voucher views
 """
-import json
 import logging
 from datetime import datetime, timezone
 
@@ -20,7 +19,7 @@ from voucher.forms import VOUCHER_PARSE_ERROR, UploadVoucherForm
 from voucher.models import Voucher
 from voucher.utils import (
     get_current_voucher,
-    get_eligible_coupon_choices,
+    get_eligible_product_detail,
     get_valid_voucher_coupons_version,
 )
 
@@ -83,7 +82,7 @@ class UploadVoucherFormView(LoginRequiredMixin, FormView):
 
 class EnrollView(LoginRequiredMixin, View):
     """
-    EnrollView checks the status of the voucher and looks for valid course runs to redeem it for
+    EnrollView checks the status of the voucher and looks for the valid course run to redeem it for
 
     On a POST, it redirects to the enrollment URL based on the submitted CouponEligibility object's product and
     coupon_code
@@ -91,23 +90,27 @@ class EnrollView(LoginRequiredMixin, View):
 
     def get(self, request):
         """
-        If voucher is not redeemed and valid coupons exist for course runs matching the input strings,
-        render the enroll form with CouponEligibility objects as choices.
+        Render the enroll form with the matching course run if the voucher
+        is not redeemed and a valid coupon exists for the matching course run,
         """
         voucher = get_current_voucher(self.request.user)
         if voucher is None:
             return redirect("voucher:upload")
         elif voucher.is_redeemed():
             return redirect("voucher:redeemed")
-        eligible_choices = get_eligible_coupon_choices(voucher)
-        if not eligible_choices:
+        product_id, coupon_id, course_run_display_title = get_eligible_product_detail(
+            voucher
+        )
+        if not (product_id and coupon_id and course_run_display_title):
             return redirect("voucher:resubmit")
         else:
             return render(
                 request,
                 "enroll.html",
                 context={
-                    "eligible_choices": eligible_choices,
+                    "product_id": product_id,
+                    "coupon_id": coupon_id,
+                    "course_run_display_title": course_run_display_title,
                     **get_base_context(self.request),
                 },
             )
@@ -117,11 +120,8 @@ class EnrollView(LoginRequiredMixin, View):
         Submit a CouponVersion object and redirect to the enrollment page
         """
         voucher = get_current_voucher(self.request.user)
-        try:
-            product_id, coupon_id = json.loads(request.POST["coupon_version"])
-        except json.JSONDecodeError:
-            messages.error(request, "Coupon Version is required.")
-            return self.get(request)
+        product_id = request.POST.get("product_id", None)
+        coupon_id = request.POST.get("coupon_id", None)
 
         if product_id and coupon_id:
             # Ensure no one has snagged this coupon while the user was waiting
@@ -133,7 +133,8 @@ class EnrollView(LoginRequiredMixin, View):
                     new_coupon_version, "coupon"
                 ):
                     log.error(
-                        "Found no valid coupons for matches for voucher %s", voucher.id
+                        "Found no valid coupons for course run match for voucher %s",
+                        voucher.id,
                     )
                     return redirect("voucher:resubmit")
                 else:

--- a/voucher/views_test.py
+++ b/voucher/views_test.py
@@ -233,7 +233,8 @@ def test_post_enroll_view_with_stolen_only_coupon(
     assert response.status_code == 302
     assert response.url == reverse("voucher:resubmit")
     mock_logger.error.assert_called_once_with(
-        "Found no valid coupons for course run match for voucher %s", context.voucher.id
+        "Found no valid coupons for course run matching the voucher %s",
+        context.voucher.id,
     )
 
 

--- a/voucher/views_test.py
+++ b/voucher/views_test.py
@@ -1,7 +1,6 @@
 """
 Test voucher views.py
 """
-import json
 from urllib.parse import urljoin
 
 import pytest


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/3809

### Description (What does it do?)
<!--- Describe your changes in detail -->
Update the voucher parsing to do exact matching. The existing process was to match the vouchers partially in case when there were no exact matches. Moving forward, we will only do exact matches and show a confirmation screen with the exact match.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots

**_BEFORE:_**
<img width="1737" alt="Screenshot 2024-04-05 at 2 53 01 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/ef214503-2a84-4364-973b-1a6f5845258c">
<img width="1737" alt="Screenshot 2024-04-05 at 2 53 08 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/1cdf366f-dbe8-4665-ac1c-37b43de2ffd9">
<img width="1737" alt="Screenshot 2024-04-05 at 2 53 52 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/fb4eafdc-3b1e-44a3-ac40-0beb169c87be">

_**AFTER:**_
<img width="1737" alt="Screenshot 2024-04-05 at 2 52 18 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/90b36875-0ab4-4748-9580-1e19ab2cc43a">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Set following values in `.env`
```
VOUCHER_DOMESTIC_DATE_KEY=UNIQUE01
VOUCHER_DOMESTIC_EMPLOYEE_KEY=UNIQUE02
VOUCHER_DOMESTIC_EMPLOYEE_ID_KEY=UNIQUE03
VOUCHER_DOMESTIC_KEY=UNIQUE04
VOUCHER_DOMESTIC_COURSE_KEY=UNIQUE05
VOUCHER_DOMESTIC_CREDITS_KEY=UNIQUE06
VOUCHER_DOMESTIC_DATES_KEY=UNIQUE07
VOUCHER_DOMESTIC_AMOUNT_KEY=UNIQUE08
VOUCHER_INTERNATIONAL_EMPLOYEE_KEY=UNIQUE09
VOUCHER_INTERNATIONAL_PROGRAM_KEY=UNIQUE10
VOUCHER_INTERNATIONAL_COURSE_KEY=UNIQUE11
VOUCHER_INTERNATIONAL_SCHOOL_KEY=UNIQUE12
VOUCHER_INTERNATIONAL_EMPLOYEE_ID_KEY=UNIQUE13
VOUCHER_INTERNATIONAL_AMOUNT_KEY=UNIQUE14
VOUCHER_INTERNATIONAL_DATES_KEY=UNIQUE15
VOUCHER_INTERNATIONAL_COURSE_NAME_KEY=UNIQUE16
VOUCHER_INTERNATIONAL_COURSE_NUMBER_KEY=UNIQUE17
VOUCHER_COMPANY_ID=1
```
- Add course, course run, product, and product versions with `course id = AMxB` and `title = Manufacturing for Innovative Design and Production`
- **Course run start date should be 30th April 2018** (It is mentioned in the voucher that we will test)
- go to `/ecommerce/admin/coupons` as an admin user and choose the following:
    - 'Coupon codes'
    - 'Number of coupon codes': about 10 is probably more than enough
    - Percentage Discount: 100
    - Valid from: today or earlier
    - Course runs: select the course runs of course added in step 2
    - Company: default company with id=1
- goto `boeing/upload/` and upload the file which is located at `voucher/.test/domestic_voucher.pdf`
- It should find the matching course run
- Clicking on enroll should redirect to the checkout page with the correct product and discount.
- Now set the Course run date to some other date and test the voucher. It should redirect to the resubmit page.

FOR INTERNATIONAL VOUCHER Testing:
Course Name: `Model-Based Systems Engineering`
Course Readable ID: `SysEngBx3`
Course Run Start Date: `9-Apr-2018`

Upload the file `voucher/.test/international_voucher.pdf`