### PR TITLE
feat: hide extra course runs if voucher is applied

### DIFF
--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -92,7 +92,7 @@ def test_send_bulk_enroll_emails(mocker, settings):
         assert user_message_props.recipient == assignment.email
         assert user_message_props.context == {
             "enrollable_title": assignment.product_coupon.product.content_object.title,
-            "enrollment_url": "http://test.com/checkout/?is_voucher_applied=false&product={}&code={}".format(
+            "enrollment_url": "http://test.com/checkout/?is_voucher_applied=False&product={}&code={}".format(
                 quote_plus(assignment.product_coupon.product.content_object.text_id),
                 assignment.product_coupon.coupon.coupon_code,
             ),

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -92,7 +92,7 @@ def test_send_bulk_enroll_emails(mocker, settings):
         assert user_message_props.recipient == assignment.email
         assert user_message_props.context == {
             "enrollable_title": assignment.product_coupon.product.content_object.title,
-            "enrollment_url": "http://test.com/checkout/?product={}&code={}".format(
+            "enrollment_url": "http://test.com/checkout/?is_voucher_applied=false&product={}&code={}".format(
                 quote_plus(assignment.product_coupon.product.content_object.text_id),
                 assignment.product_coupon.coupon.coupon_code,
             ),

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -63,7 +63,9 @@ def get_order_id_by_reference_number(*, reference_number, prefix):
     return order_id
 
 
-def make_checkout_url(*, product_id=None, code=None, run_tag=None):
+def make_checkout_url(
+    *, product_id=None, code=None, run_tag=None, is_voucher_applied="false"
+):
     """
     Helper function to create a checkout URL with appropriate query parameters.
 
@@ -71,6 +73,7 @@ def make_checkout_url(*, product_id=None, code=None, run_tag=None):
         product_id (int|str): A Product ID or text ID
         code (str): The coupon code
         run_tag (str): A ProgramRun run tag
+        is_voucher_applied (str): String to indicate if voucher is used for checkout
 
     Returns:
         str: The URL for the checkout page, including product and coupon code if available
@@ -79,7 +82,7 @@ def make_checkout_url(*, product_id=None, code=None, run_tag=None):
     if product_id is None and code is None:
         return base_checkout_url
 
-    query_params = {}
+    query_params = {"is_voucher_applied": is_voucher_applied}
     if product_id is not None:
         query_params["product"] = (
             product_id

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -64,7 +64,7 @@ def get_order_id_by_reference_number(*, reference_number, prefix):
 
 
 def make_checkout_url(
-    *, product_id=None, code=None, run_tag=None, is_voucher_applied="false"
+    *, product_id=None, code=None, run_tag=None, is_voucher_applied=False
 ):
     """
     Helper function to create a checkout URL with appropriate query parameters.
@@ -73,7 +73,7 @@ def make_checkout_url(
         product_id (int|str): A Product ID or text ID
         code (str): The coupon code
         run_tag (str): A ProgramRun run tag
-        is_voucher_applied (str): String to indicate if voucher is used for checkout
+        is_voucher_applied (bool): Boolean to indicate if voucher is used for checkout
 
     Returns:
         str: The URL for the checkout page, including product and coupon code if available

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1258,7 +1258,7 @@ def test_bulk_assignment_csv_view(settings, admin_client, admin_drf_client):
         [
             [
                 assignment.email,
-                "http://test.com/checkout/?product={}&code={}".format(
+                "http://test.com/checkout/?is_voucher_applied=false&product={}&code={}".format(
                     assignment.product_coupon.product.id,
                     assignment.product_coupon.coupon.coupon_code,
                 ),

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1258,7 +1258,7 @@ def test_bulk_assignment_csv_view(settings, admin_client, admin_drf_client):
         [
             [
                 assignment.email,
-                "http://test.com/checkout/?is_voucher_applied=false&product={}&code={}".format(
+                "http://test.com/checkout/?is_voucher_applied=False&product={}&code={}".format(
                     assignment.product_coupon.product.id,
                     assignment.product_coupon.coupon.coupon_code,
                 ),

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -198,17 +198,11 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                 Select a course run
               </option>
               {course.courseruns.map(run =>
-                run.product_id && !isVoucherApplied ? (
+                run.product_id && ((!isVoucherApplied) || (isVoucherApplied && run.product_id === item.product_id)) ? (
                   <option value={run.id} key={run.id}>
                     {formatRunTitle(run)}
                   </option>
-                ) : (
-                  run.product_id && isVoucherApplied && run.product_id === item.product_id ? (
-                    <option value={run.id} key={run.id}>
-                      {formatRunTitle(run)}
-                    </option>
-                  ) : null
-                )
+                ) : null
               )}
             </Field>
           </div>

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -58,7 +58,8 @@ type CommonProps = {
     productId: number | string,
     runId: number,
     setFieldError: SetFieldError
-  ) => Promise<void>
+  ) => Promise<void>,
+  isVoucherApplied: boolean
 }
 type OuterProps = CommonProps & {
   couponCode: ?string,
@@ -122,7 +123,8 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
       setFieldError,
       setValues,
       resetForm,
-      updateProduct
+      updateProduct,
+      isVoucherApplied
     } = this.props
 
     if (item.type === "program") {
@@ -196,11 +198,17 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                 Select a course run
               </option>
               {course.courseruns.map(run =>
-                run.product_id ? (
+                run.product_id && !isVoucherApplied ? (
                   <option value={run.id} key={run.id}>
                     {formatRunTitle(run)}
                   </option>
-                ) : null
+                ) : (
+                  run.product_id && isVoucherApplied && run.product_id === item.product_id ? (
+                    <option value={run.id} key={run.id}>
+                      {formatRunTitle(run)}
+                    </option>
+                  ) : null
+                )
               )}
             </Field>
           </div>
@@ -442,7 +450,8 @@ export class CheckoutForm extends React.Component<OuterProps> {
       requestPending,
       selectedRuns,
       submitCoupon,
-      updateProduct
+      updateProduct,
+      isVoucherApplied
     } = this.props
 
     return (
@@ -464,6 +473,7 @@ export class CheckoutForm extends React.Component<OuterProps> {
             onSubmit={onSubmit}
             submitCoupon={submitCoupon}
             updateProduct={updateProduct}
+            isVoucherApplied={isVoucherApplied}
             onMount={() => {
               // only submit if there is a couponCode query parameter,
               // and if it's different than one in the existing coupon

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -351,7 +351,7 @@ describe("CheckoutForm", () => {
     })
   })
 
-  it(`shows a select with only a single course run when voucher is applied`, async () => {
+  it(`shows a dropdown with only a single matching course run when voucher is applied`, async () => {
     basketItem.type = PRODUCT_TYPE_COURSERUN
     basketItem.courses = [basketItem.courses[0]]
     // $FlowFixMe

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -30,7 +30,8 @@ describe("CheckoutForm", () => {
     couponCode,
     basketItem,
     submitCouponStub,
-    updateProductStub
+    updateProductStub,
+    isVoucherApplied
 
   beforeEach(() => {
     basket = makeBasketResponse()
@@ -41,6 +42,7 @@ describe("CheckoutForm", () => {
     onSubmitStub = sandbox.stub()
     submitCouponStub = sandbox.stub()
     updateProductStub = sandbox.stub()
+    isVoucherApplied = false
     SETTINGS.zendesk_config = {
       help_widget_enabled: false,
       help_widget_key:     "fake_key"
@@ -63,6 +65,7 @@ describe("CheckoutForm", () => {
         submitCoupon={submitCouponStub}
         selectedRuns={{}}
         updateProduct={updateProductStub}
+        isVoucherApplied={isVoucherApplied}
         {...props}
       />
     )
@@ -234,6 +237,7 @@ describe("CheckoutForm", () => {
         item={basketItem}
         values={{ dataConsent: false }}
         errors={{ data_consents: errorMessage }}
+        isVoucherApplied={isVoucherApplied}
         onMount={sandbox.stub()}
       />
     )
@@ -363,6 +367,7 @@ describe("CheckoutForm", () => {
         setValues={sandbox.stub()}
         resetForm={resetFormStub}
         updateProduct={updateProductStub}
+        isVoucherApplied={isVoucherApplied}
         values={{}}
       />
     )
@@ -408,6 +413,7 @@ describe("CheckoutForm", () => {
           item={basketItem}
           onMount={sandbox.stub()}
           updateProduct={updateProductStub}
+          isVoucherApplied={isVoucherApplied}
           values={{
             dataConsent: checked
           }}
@@ -433,6 +439,7 @@ describe("CheckoutForm", () => {
         item={basketItem}
         onMount={sandbox.stub()}
         updateProduct={updateProductStub}
+        isVoucherApplied={isVoucherApplied}
         values={{}}
       />
     )
@@ -462,6 +469,7 @@ describe("CheckoutForm", () => {
             item={basketItem}
             onMount={sandbox.stub()}
             updateProduct={updateProductStub}
+            isVoucherApplied={isVoucherApplied}
             values={{}}
           />
         )

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -321,6 +321,7 @@ describe("CheckoutForm", () => {
     })
     sinon.assert.notCalled(submitCouponStub)
   })
+
   ;[PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM].forEach(type => {
     it(`shows a select with options for a product, and updates a ${type} run`, async () => {
       basketItem.type = type
@@ -348,6 +349,32 @@ describe("CheckoutForm", () => {
         })
       })
     })
+  })
+
+  it(`shows a select with only a single course run when voucher is applied`, async () => {
+    basketItem.type = PRODUCT_TYPE_COURSERUN
+    basketItem.courses = [basketItem.courses[0]]
+    // $FlowFixMe
+    basketItem.product_id = basketItem.courses[0].courseruns[0].product_id
+    const selectedRuns = calcSelectedRunIds(basketItem)
+    const isVoucherApplied = true
+    const inner = await renderForm({
+      selectedRuns,
+      isVoucherApplied
+    })
+    assert.equal(inner.find("select").length, basketItem.courses.length)
+    const course = basketItem.courses[0]
+
+    const select = inner.find("select").at(0)
+    const runs = course.courseruns
+    assert.equal(select.find("option").length, 2)
+    const firstOption = select.find("option").at(0)
+    assert.equal(firstOption.prop("value"), "")
+    assert.equal(firstOption.text(), "Select a course run")
+
+    const secondOption = select.find("option").at(1)
+    assert.equal(secondOption.prop("value"), runs[0].id)
+    assert.equal(secondOption.text(), formatRunTitle(runs[0]))
   })
 
   it("updates the product when the course run select is changed", async () => {

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -78,9 +78,10 @@ export class CheckoutPage extends React.Component<Props, State> {
     } = this.props
     const params = queryString.parse(search)
     return {
-      productId:   params.product,
-      preselectId: parseInt(params.preselect),
-      couponCode:  params.code
+      productId:        params.product,
+      preselectId:      parseInt(params.preselect),
+      couponCode:       params.code,
+      isVoucherApplied: params.is_voucher_applied === "true",
     }
   }
 
@@ -339,7 +340,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       const coupon = basket.coupons.find(coupon =>
         coupon.targets.includes(item.id)
       )
-      const { couponCode, preselectId } = this.getQueryParams()
+      const { couponCode, preselectId, isVoucherApplied } = this.getQueryParams()
       const selectedRuns = calcSelectedRunIds(item, preselectId)
       pageBody = (
         <CheckoutForm
@@ -352,6 +353,7 @@ export class CheckoutPage extends React.Component<Props, State> {
           onSubmit={this.submit}
           updateProduct={this.updateProduct}
           requestPending={requestPending}
+          isVoucherApplied={isVoucherApplied}
         />
       )
     }

--- a/static/js/containers/pages/CheckoutPage.js
+++ b/static/js/containers/pages/CheckoutPage.js
@@ -81,7 +81,7 @@ export class CheckoutPage extends React.Component<Props, State> {
       productId:        params.product,
       preselectId:      parseInt(params.preselect),
       couponCode:       params.code,
-      isVoucherApplied: params.is_voucher_applied === "true",
+      isVoucherApplied: params.is_voucher_applied && params.is_voucher_applied.toLowerCase() === "true",
     }
   }
 

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -145,7 +145,9 @@ class EnrollView(LoginRequiredMixin, View):
             voucher.product_id = product_id
             voucher.save()
             enroll_url = make_checkout_url(
-                product_id=product_id, code=voucher.coupon.coupon_code
+                product_id=product_id,
+                code=voucher.coupon.coupon_code,
+                is_voucher_applied="true",
             )
             return redirect(enroll_url)
         else:

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -147,7 +147,7 @@ class EnrollView(LoginRequiredMixin, View):
             enroll_url = make_checkout_url(
                 product_id=product_id,
                 code=voucher.coupon.coupon_code,
-                is_voucher_applied="true",
+                is_voucher_applied=True,
             )
             return redirect(enroll_url)
         else:

--- a/voucher/views_test.py
+++ b/voucher/views_test.py
@@ -190,7 +190,7 @@ def test_post_enroll_view_with_product_id_and_coupon_id(
     assert response.status_code == 302
     assert response.url == (
         f"{urljoin(settings.SITE_BASE_URL, reverse('checkout-page'))}?"
-        f"is_voucher_applied=true&product={product.id}&code={coupon_version.coupon.coupon_code}"
+        f"is_voucher_applied=True&product={product.id}&code={coupon_version.coupon.coupon_code}"
     )
     assert Voucher.objects.get(id=voucher.id).coupon == coupon_version.coupon
 
@@ -269,6 +269,6 @@ def test_post_enroll_view_with_stolen_coupon(
     assert response.status_code == 302
     assert response.url == (
         f"{urljoin(settings.SITE_BASE_URL, reverse('checkout-page'))}?"
-        f"is_voucher_applied=true&product={product.id}&code={coupon_version2.coupon.coupon_code}"
+        f"is_voucher_applied=True&product={product.id}&code={coupon_version2.coupon.coupon_code}"
     )
     assert Voucher.objects.get(id=voucher.id).coupon == coupon_version2.coupon

--- a/voucher/views_test.py
+++ b/voucher/views_test.py
@@ -190,7 +190,7 @@ def test_post_enroll_view_with_product_id_and_coupon_id(
     assert response.status_code == 302
     assert response.url == (
         f"{urljoin(settings.SITE_BASE_URL, reverse('checkout-page'))}?"
-        f"product={product.id}&code={coupon_version.coupon.coupon_code}"
+        f"is_voucher_applied=true&product={product.id}&code={coupon_version.coupon.coupon_code}"
     )
     assert Voucher.objects.get(id=voucher.id).coupon == coupon_version.coupon
 
@@ -269,6 +269,6 @@ def test_post_enroll_view_with_stolen_coupon(
     assert response.status_code == 302
     assert response.url == (
         f"{urljoin(settings.SITE_BASE_URL, reverse('checkout-page'))}?"
-        f"product={product.id}&code={coupon_version2.coupon.coupon_code}"
+        f"is_voucher_applied=true&product={product.id}&code={coupon_version2.coupon.coupon_code}"
     )
     assert Voucher.objects.get(id=voucher.id).coupon == coupon_version2.coupon


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Followup on https://github.com/mitodl/mitxpro/pull/2940 due to this comment https://github.com/mitodl/mitxpro/pull/2954#issuecomment-2069371773

### Description (What does it do?)
<!--- Describe your changes in detail -->
Hide extra course runs if checkout is made through a voucher. We had payment issues with Boeing when vouchers are used to enroll in different runs than the ones in the voucher. This PR hides extra runs from the checkout page when checkout is made through a voucher.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
With Voucher:
<img width="1005" alt="Screenshot 2024-04-25 at 12 13 07 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/a6c87423-b5c3-42f2-bc81-756837c24102">

Without Voucher:
<img width="1005" alt="Screenshot 2024-04-25 at 12 13 30 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/25ad8f1a-f2b4-4657-b547-52fd1ee08ea5">




### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Set following values in `.env`
```
VOUCHER_DOMESTIC_DATE_KEY=UNIQUE01
VOUCHER_DOMESTIC_EMPLOYEE_KEY=UNIQUE02
VOUCHER_DOMESTIC_EMPLOYEE_ID_KEY=UNIQUE03
VOUCHER_DOMESTIC_KEY=UNIQUE04
VOUCHER_DOMESTIC_COURSE_KEY=UNIQUE05
VOUCHER_DOMESTIC_CREDITS_KEY=UNIQUE06
VOUCHER_DOMESTIC_DATES_KEY=UNIQUE07
VOUCHER_DOMESTIC_AMOUNT_KEY=UNIQUE08
VOUCHER_INTERNATIONAL_EMPLOYEE_KEY=UNIQUE09
VOUCHER_INTERNATIONAL_PROGRAM_KEY=UNIQUE10
VOUCHER_INTERNATIONAL_COURSE_KEY=UNIQUE11
VOUCHER_INTERNATIONAL_SCHOOL_KEY=UNIQUE12
VOUCHER_INTERNATIONAL_EMPLOYEE_ID_KEY=UNIQUE13
VOUCHER_INTERNATIONAL_AMOUNT_KEY=UNIQUE14
VOUCHER_INTERNATIONAL_DATES_KEY=UNIQUE15
VOUCHER_INTERNATIONAL_COURSE_NAME_KEY=UNIQUE16
VOUCHER_INTERNATIONAL_COURSE_NUMBER_KEY=UNIQUE17
VOUCHER_COMPANY_ID=1
```
- Add course, course run, product, and product versions with `course id = AMxB` and `title = Manufacturing for Innovative Design and Production`
- **Course run start date should be 30th April 2018** (It is mentioned in the voucher that we will test)
- Create another run with a different start date and the product and product version for it.
- go to `/ecommerce/admin/coupons` as an admin user and choose the following:
    - 'Coupon codes'
    - 'Number of coupon codes': about 10 is probably more than enough
    - Percentage Discount: 100
    - Valid from: today or earlier
    - Course runs: select the course runs of course added in step 2 & 3
    - Company: default company with id=1
- goto `boeing/upload/` and upload the file which is located at `voucher/.test/domestic_voucher.pdf`
- It should find the matching course run
- Clicking on enroll should redirect to the checkout page with the correct product and discount.
- Checkout page should display only the first course run in the select options.
- Now edit the checkout page URL in your browser and remove `is_voucher_applied=True&` from the URL. Now you should see the 2nd run as well.
- Now set the Course run date to some other date and test the voucher. It should redirect to the resubmit page.

