### PR TITLE
fix: check for courseware object in cms

### DIFF
--- a/cms/forms.py
+++ b/cms/forms.py
@@ -44,12 +44,12 @@ class CoursewareForm(WagtailAdminPageForm):
 
         instance = kwargs.get("instance", None)
         if instance and instance.id:
-            if instance.is_internal_or_external_course_page:
+            if instance.is_internal_or_external_course_page and instance.course:
                 course_runs = instance.course.courseruns.all()
                 course_run_choices = [("", "")] + [(run.id, run) for run in course_runs]
                 self.fields["course_run"].choices = course_run_choices
 
-            elif instance.is_internal_or_external_program_page:
+            elif instance.is_internal_or_external_program_page and instance.program:
                 self.fields["price"].initial = instance.program.current_price
 
     def save(self, commit=True):  # noqa: FBT002


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
[Sentry error](https://mit-office-of-digital-learning.sentry.io/issues/5275534297/?alert_rule_id=15045794&alert_type=issue&notification_uuid=7cdd45c7-eebd-40c5-bef8-bc04053152b8&project=1413655&referrer=slack)

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR fixes a case when a Courseware object is deleted and CMS tried to get price for the page using the deleted object.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master branch
- Create a course and a program in Django Admin
- Create a CMS page for the course for course or program
- Now delete the Course or Program from the Django Admin
- Go to the CMS page that you created. It will throw an error.
- Now checkout this branch and reload the CMS page.
- Page should load fine.
