### PR TITLE
fix: invalid certificate uuid should raise 404

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -655,6 +655,8 @@ class CertificateIndexPage(DisableSitemapURLMixin, RoutablePageMixin, Page):
             certificate = ProgramCertificate.objects.get(uuid=uuid)
         except ProgramCertificate.DoesNotExist:
             raise Http404  # noqa: B904
+        except ValidationError:
+            raise Http404  # noqa: B904
 
         # Get a CertificatePage to serve this request
         certificate_page = (
@@ -692,6 +694,8 @@ class CertificateIndexPage(DisableSitemapURLMixin, RoutablePageMixin, Page):
         try:
             certificate = CourseRunCertificate.objects.get(uuid=uuid)
         except CourseRunCertificate.DoesNotExist:
+            raise Http404  # noqa: B904
+        except ValidationError:
             raise Http404  # noqa: B904
 
         # Get a CertificatePage to serve this request

--- a/cms/models.py
+++ b/cms/models.py
@@ -639,7 +639,7 @@ class CertificateIndexPage(DisableSitemapURLMixin, RoutablePageMixin, Page):
             and not parent.get_children().type(cls).exists()
         )
 
-    @route(r"^program/([A-Fa-f0-9-]+)/?$")
+    @route(r"^program/([A-Fa-f0-9-]{36})/?$")
     def program_certificate(
         self,
         request,
@@ -654,8 +654,6 @@ class CertificateIndexPage(DisableSitemapURLMixin, RoutablePageMixin, Page):
         try:
             certificate = ProgramCertificate.objects.get(uuid=uuid)
         except ProgramCertificate.DoesNotExist:
-            raise Http404  # noqa: B904
-        except ValidationError:
             raise Http404  # noqa: B904
 
         # Get a CertificatePage to serve this request
@@ -679,7 +677,7 @@ class CertificateIndexPage(DisableSitemapURLMixin, RoutablePageMixin, Page):
         certificate_page.certificate = certificate
         return certificate_page.serve(request)
 
-    @route(r"^([A-Fa-f0-9-]+)/?$")
+    @route(r"^([A-Fa-f0-9-]{36})/?$")
     def course_certificate(
         self,
         request,
@@ -694,8 +692,6 @@ class CertificateIndexPage(DisableSitemapURLMixin, RoutablePageMixin, Page):
         try:
             certificate = CourseRunCertificate.objects.get(uuid=uuid)
         except CourseRunCertificate.DoesNotExist:
-            raise Http404  # noqa: B904
-        except ValidationError:
             raise Http404  # noqa: B904
 
         # Get a CertificatePage to serve this request

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1792,23 +1792,30 @@ def test_program_page_price_is_updated(superuser_client):
     assert program.current_price == 999
 
 
-def test_course_run_certificate_get(user_client):
-    """Test that course run certificate get is successful for a valid UUID and raises 404 for invalid UUID"""
-    certificate = CourseRunCertificateFactory.create()
-    resp = user_client.get(f"/certificate/{certificate.uuid}/")
+def test_certificate_request_with_valid_uuid(user_client):
+    """Test that certificate request is successful for course and program certificates."""
+    course_run_certificate = CourseRunCertificateFactory.create()
+    resp = user_client.get(f"/certificate/{course_run_certificate.uuid}/")
     assert resp.status_code == 200
 
-    invalid_uuid = str(certificate.uuid)[0:-12]
-    resp = user_client.get(f"/certificate/{invalid_uuid}/")
-    assert resp.status_code == 404
-
-
-def test_program_certificate_get(user_client):
-    """Test that program certificate get is successful for a valid UUID and raises 404 for invalid UUID"""
-    certificate = ProgramCertificateFactory.create()
-    resp = user_client.get(f"/certificate/program/{certificate.uuid}/")
+    program_certificate = ProgramCertificateFactory.create()
+    resp = user_client.get(f"/certificate/program/{program_certificate.uuid}/")
     assert resp.status_code == 200
 
-    invalid_uuid = str(certificate.uuid)[0:-12]
-    resp = user_client.get(f"/certificate/program/{invalid_uuid}/")
-    assert resp.status_code == 404
+
+@pytest.mark.parametrize(
+    "uuid_string",
+    [
+        "",
+        "1bebd843-ebf0-40c0-850e",
+        "1bebd843-ebf0-40c0-850e-fe73baa31b944444",
+        "1bebd843-ebf0-40c0-850e-fe73baa31b94-4ab4",
+    ],
+)
+def test_certificate_request_with_invalid_uuid(user_client, uuid_string):
+    """Test that course run and program certificate request returns a 404 for invalid uuids."""
+    program_certificate_resp = user_client.get(f"/certificate/program/{uuid_string}/")
+    assert program_certificate_resp.status_code == 404
+
+    course_certificate_resp = user_client.get(f"/certificate/{uuid_string}/")
+    assert course_certificate_resp.status_code == 404

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -64,7 +64,12 @@ from cms.models import (
     UserTestimonialsPage,
     WhoShouldEnrollPage,
 )
-from courses.factories import CourseFactory, CourseRunFactory
+from courses.factories import (
+    CourseFactory,
+    CourseRunCertificateFactory,
+    CourseRunFactory,
+    ProgramCertificateFactory,
+)
 
 pytestmark = [pytest.mark.django_db]
 
@@ -1785,3 +1790,25 @@ def test_program_page_price_is_updated(superuser_client):
     resp = superuser_client.post(path, data_to_post)
     assert resp.status_code == 302
     assert program.current_price == 999
+
+
+def test_course_run_certificate_get(user_client):
+    """Test that course run certificate get is successful for a valid UUID and raises 404 for invalid UUID"""
+    certificate = CourseRunCertificateFactory.create()
+    resp = user_client.get(f"/certificate/{certificate.uuid}/")
+    assert resp.status_code == 200
+
+    invalid_uuid = str(certificate.uuid)[0:-12]
+    resp = user_client.get(f"/certificate/{invalid_uuid}/")
+    assert resp.status_code == 404
+
+
+def test_program_certificate_get(user_client):
+    """Test that program certificate get is successful for a valid UUID and raises 404 for invalid UUID"""
+    certificate = ProgramCertificateFactory.create()
+    resp = user_client.get(f"/certificate/program/{certificate.uuid}/")
+    assert resp.status_code == 200
+
+    invalid_uuid = str(certificate.uuid)[0:-12]
+    resp = user_client.get(f"/certificate/program/{invalid_uuid}/")
+    assert resp.status_code == 404


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes [Sentry error](https://mit-office-of-digital-learning.sentry.io/issues/5393946540/?project=1413655&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=4) 

### Description (What does it do?)
<!--- Describe your changes in detail -->
Using an invalid UUID to get a course run or program certificate results in a 500 server error. It should return 404.

Steps to reproduce:

- Checkout master branch
- fetch `/certificate/f5ab714b-a7ee-498f-bbec-/`
- It will raise a validation error

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create Course Certificate and Program Certificate Pages in CMS
- Create Course Run Certificate and Program Certificate in Django Admin for a user
- Fetch the course certificate at `/certificate/<uuid>/` and the program certificate at `/certificate/program/<uuid>/`. You should see the valid certificates.
- Now Fetch course and program certificate with invalid UUID i.e. `f5ab714b-a7ee-498f-bbec-`. You should see a 404 page.
