### PR TITLE
fix: sync start dates for programs & courses between Program/Course pages & APIs

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -318,20 +318,18 @@ class ProgramSerializer(serializers.ModelSerializer):
             datetime: The ending date
         """
         filtered_end_runs = filter(
-            lambda run: run.end_date is not None, instance.course_runs
+            lambda run: (run.end_date is not None and run.live), instance.course_runs
         )
         sorted_runs = sorted(filtered_end_runs, key=lambda run: run.end_date)
+
         return sorted_runs[-1].end_date if sorted_runs else None
 
     def get_enrollment_start(self, instance):
         """
         enrollment_start is first date where enrollment starts for any live course run
         """
-        sorted_runs = sorted(
-            (run for run in instance.course_runs if run.enrollment_start),
-            key=lambda run: run.enrollment_start,
-        )
-        return sorted_runs[0].enrollment_start if sorted_runs else None
+        first_unexpired_run = instance.first_unexpired_run
+        return getattr(first_unexpired_run, "enrollment_start", None)
 
     def get_url(self, instance):
         """Get URL"""

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -307,11 +307,7 @@ class ProgramSerializer(serializers.ModelSerializer):
         Returns:
             datetime: The starting date
         """
-        filtered_start_runs = filter(
-            lambda run: run.start_date is not None, instance.course_runs
-        )
-        sorted_runs = sorted(filtered_start_runs, key=lambda run: run.start_date)
-        return sorted_runs[0].start_date if sorted_runs else None
+        return instance.first_unexpired_run().start_date
 
     def get_end_date(self, instance):
         """

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -307,7 +307,8 @@ class ProgramSerializer(serializers.ModelSerializer):
         Returns:
             datetime: The starting date
         """
-        return instance.first_unexpired_run().start_date
+        first_unexpired_run = instance.first_unexpired_run
+        return getattr(first_unexpired_run, "start_date", None)
 
     def get_end_date(self, instance):
         """

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -103,13 +103,21 @@ def test_serialize_program(  # noqa: PLR0913
     course1 = CourseFactory.create(program=program, position_in_program=1)
     course2 = CourseFactory.create(program=program, position_in_program=2)
 
-    course1_run1 = CourseRunFactory.create(course=course1, start_date = now - timedelta(5))
-    course1_run2 = CourseRunFactory.create(course=course1, start_date = now - timedelta(8))
-    course1_run3 = CourseRunFactory.create(course=course1, start_date = now)
+    course1_run1 = CourseRunFactory.create(
+        course=course1, start_date=now - timedelta(5)
+    )
+    course1_run2 = CourseRunFactory.create(
+        course=course1, start_date=now - timedelta(8)
+    )
+    course1_run3 = CourseRunFactory.create(course=course1, start_date=now)
 
-    course2_run1 = CourseRunFactory.create(course=course2, start_date = now - timedelta(3))
-    course2_run2 = CourseRunFactory.create(course=course2, start_date = now - timedelta(2))
-    course2_run3 = CourseRunFactory.create(course=course2, start_date = now)
+    course2_run1 = CourseRunFactory.create(
+        course=course2, start_date=now - timedelta(3)
+    )
+    course2_run2 = CourseRunFactory.create(
+        course=course2, start_date=now - timedelta(2)
+    )
+    course2_run3 = CourseRunFactory.create(course=course2, start_date=now)
 
     # run1 = CourseRunFactory.create(course__program=program, course__position_in_program=1, start_date=now - timedelta(5))
     # course1 = run1.course
@@ -120,7 +128,14 @@ def test_serialize_program(  # noqa: PLR0913
     #     + [CourseRunFactory.create(course=course1) for _ in range(2)]
     #     + [CourseRunFactory.create(course=course2) for _ in range(2)]
     # )
-    runs = [course1_run1, course1_run2, course1_run3, course2_run1, course2_run2, course2_run3]
+    runs = [
+        course1_run1,
+        course1_run2,
+        course1_run3,
+        course2_run1,
+        course2_run2,
+        course2_run3,
+    ]
 
     faculty_names = ["Teacher 1", "Teacher 2"]
     FacultyMembersPageFactory.create(

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -104,6 +104,12 @@ def test_serialize_program(  # noqa: PLR0913
     course1_runs = CourseRunFactory.create_batch(3, course=course1)
     course2_runs = CourseRunFactory.create_batch(3, course=course2)
 
+    non_live_run = CourseRunFactory.create(
+        course=course1,
+        end_date=datetime.max.astimezone(timezone.utc),
+        expiration_date=None,
+        live=False,
+    )
     runs = course1_runs + course2_runs
 
     faculty_names = ["Teacher 1", "Teacher 2"]
@@ -157,6 +163,7 @@ def test_serialize_program(  # noqa: PLR0913
             "platform": program.platform.name,
         },
     )
+    assert data["end_date"] != non_live_run.end_date.strftime(datetime_format)
 
 
 def test_base_course_serializer():
@@ -285,9 +292,9 @@ def test_serialize_course(  # noqa: PLR0913
             "credits": ceus if course_page else None,
             "is_external": is_external,
             "external_marketing_url": external_marketing_url if course_page else None,
-            "marketing_hubspot_form_id": marketing_hubspot_form_id
-            if course_page
-            else None,
+            "marketing_hubspot_form_id": (
+                marketing_hubspot_form_id if course_page else None
+            ),
             "platform": course.platform.name,
         },
     )
@@ -370,9 +377,11 @@ def test_serialize_course_run_enrollments(settings, has_company):
             else None
         ),
         "certificate": None,
-        "receipt": course_run_enrollment.order_id
-        if course_run_enrollment.order.status == Order.FULFILLED
-        else None,
+        "receipt": (
+            course_run_enrollment.order_id
+            if course_run_enrollment.order.status == Order.FULFILLED
+            else None
+        ),
     }
 
 
@@ -413,7 +422,9 @@ def test_serialize_program_enrollments(settings, has_company):
             [course_run_enrollments[1], course_run_enrollments[0]], many=True
         ).data,
         "certificate": None,
-        "receipt": program_enrollment.order_id
-        if program_enrollment.order.status == Order.FULFILLED
-        else None,
+        "receipt": (
+            program_enrollment.order_id
+            if program_enrollment.order.status == Order.FULFILLED
+            else None
+        ),
     }

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -142,9 +142,7 @@ def test_serialize_program(  # noqa: PLR0913
             "end_date": sorted(runs, key=lambda run: run.end_date)[
                 -1
             ].end_date.strftime(datetime_format),
-            "enrollment_start": sorted(runs, key=lambda run: run.enrollment_start)[
-                0
-            ].enrollment_start.strftime(datetime_format),
+            "enrollment_start": program.first_unexpired_run.enrollment_start,
             "url": f"http://localhost{program.page.get_url()}",
             "instructors": [{"name": name} for name in faculty_names],
             "topics": [{"name": topic.name} for topic in topics],

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -88,8 +88,6 @@ def test_serialize_program(  # noqa: PLR0913
 ):
     """Test Program serialization"""
 
-    now = datetime.now(tz=timezone.utc)
-
     program = ProgramFactory.create(
         is_external=is_external,
         page__certificate_page__CEUs=ceus,
@@ -103,39 +101,10 @@ def test_serialize_program(  # noqa: PLR0913
     course1 = CourseFactory.create(program=program, position_in_program=1)
     course2 = CourseFactory.create(program=program, position_in_program=2)
 
-    course1_run1 = CourseRunFactory.create(
-        course=course1, start_date=now - timedelta(5)
-    )
-    course1_run2 = CourseRunFactory.create(
-        course=course1, start_date=now - timedelta(8)
-    )
-    course1_run3 = CourseRunFactory.create(course=course1, start_date=now)
+    course1_runs = CourseRunFactory.create_batch(3, course=course1)
+    course2_runs = CourseRunFactory.create_batch(3, course=course2)
 
-    course2_run1 = CourseRunFactory.create(
-        course=course2, start_date=now - timedelta(3)
-    )
-    course2_run2 = CourseRunFactory.create(
-        course=course2, start_date=now - timedelta(2)
-    )
-    course2_run3 = CourseRunFactory.create(course=course2, start_date=now)
-
-    # run1 = CourseRunFactory.create(course__program=program, course__position_in_program=1, start_date=now - timedelta(5))
-    # course1 = run1.course
-    # run2 = CourseRunFactory.create(course__program=program, course__position_in_program=2)
-    # course2 = run2.course
-    # runs = (
-    #     [run1, run2]
-    #     + [CourseRunFactory.create(course=course1) for _ in range(2)]
-    #     + [CourseRunFactory.create(course=course2) for _ in range(2)]
-    # )
-    runs = [
-        course1_run1,
-        course1_run2,
-        course1_run3,
-        course2_run1,
-        course2_run2,
-        course2_run3,
-    ]
+    runs = course1_runs + course2_runs
 
     faculty_names = ["Teacher 1", "Teacher 2"]
     FacultyMembersPageFactory.create(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4373

### Description (What does it do?)
- FIxes the Programs API dates to match with the program CMS page dates

### How can this be tested?
- Create a program and some courses under a program
- Create some course runs along with some expired runs
- Create a course with some expired course runs
- At this point, It would be a good idea to reproduce this issue
- Check `/api/programs` and `api/courses` APIS & check the start date of a program is not from an expired run
- The start date on Course/Programs pages should match the start dates in both `/api/course` & `/api/programs`
- Also, Smoke test other things e.g. Checkout & `/api/products` for any impacts of this change


**NOTE:**
1. With this change the start dates should be equal to the start date of the earliest reactive course run from the first course in the program
2. The start date for a program could be `null` if there are no active course runs for the first course in the program

