### PR TITLE
refactor: upgrade docker-compose & CI postgres version to 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
     services:
       db:
-        image: postgres:12.19
+        image: postgres:15.7
         # Health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -5,7 +5,7 @@ x-environment: &py-environment
   NODE_ENV: "production"
   DEV_ENV: "True" # necessary to have nginx connect to web container
   SECRET_KEY: local_unsafe_key
-  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
+  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres # pragma: allowlist secret
   MITXPRO_BASE_URL: ${MITXPRO_BASE_URL:-http://xpro.odl.local:8053}
   MITXPRO_SECURE_SSL_REDIRECT: "False"
   MITXPRO_DB_DISABLE_SSL: "True"

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -5,7 +5,7 @@ x-environment: &py-environment
   NODE_ENV: "production"
   DEV_ENV: "True" # necessary to have nginx connect to web container
   SECRET_KEY: local_unsafe_key
-  DATABASE_URL: postgres://postgres@db:5432/postgres
+  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
   MITXPRO_BASE_URL: ${MITXPRO_BASE_URL:-http://xpro.odl.local:8053}
   MITXPRO_SECURE_SSL_REDIRECT: "False"
   MITXPRO_DB_DISABLE_SSL: "True"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ x-extra-hosts: &default-extra-hosts
 
 services:
   db:
-    image: postgres:12.19
+    image: postgres:15.7
     environment:
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
     ports:


### PR DESCRIPTION
### What are the relevant tickets?
[#4440](https://github.com/mitodl/hq/issues/4440)

### Description (What does it do?)
This PR upgrades the docker-compose & CI PostgreSQL version to 15.

### How can this be tested?
- Check out this branch and follow one of the solutions below to upgrade the PostgreSQL version in your local environment (with or without data migration):

## With Data Migration:
Follow these steps to upgrade PostgreSQL with data migration:

```sh
# 1. Using your old 12.19 database:
docker-compose exec -T db pg_dumpall -h db -U postgres > db_backup.sql
# 2. stop all containers
docker-compose stop
# 3 destroy the old database container
docker-compose rm -sv db
# 4. build+start the new database container
docker-compose up db -d
# 5. restore the database from backup
docker cp db_backup.sql $(docker-compose ps -q db):/tmp/backup.sql
docker-compose exec -T db psql -U postgres -d postgres -f /tmp/backup.sql
# 6. start the remaining containers
docker-compose up
# 7 verify postgres 15 is in use:
docker-compose exec -e PGPASSWORD=postgres db psql -h db -U postgres
```
**Note**: If you encounter `password authentication failed for user "postgres"` in STEP 6 due to no password being set for the user "postgres" in the SQL backup file, update the user password through the SQL shell `docker-compose exec -it db psql -U postgres postgres`:
  - `ALTER USER postgres PASSWORD 'postgres';`
 
## Without Data Migration
Follow these steps to upgrade PostgreSQL without data migration:
```sh
docker-compose down
docker-compose up -d
```
**Note**: These commands will cleanly restart your Docker Compose setup.