### PR TITLE
fix: warning to run uwsgi with flags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --noinput &&
-      uwsgi uwsgi.ini --honour-stdin'
+      uwsgi uwsgi.ini --honour-stdin --enable-threads --py-call-uwsgi-fork-hooks'
     stdin_open: true
     tty: true
     ports:


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
It fixes a uwsgi warning to add a couple of flags.
<img width="1790" alt="Screenshot 2024-06-07 at 2 21 23 PM" src="https://github.com/mitodl/mitxpro/assets/52656433/bf68cdee-3d77-43e1-9f02-d85b23269c2d">

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Checkout master
2. Start the project using docker-compose up
3. monitor the web instance logs and you will get the warning attached in the Description
4. Stop the project with docker-compose stop and checkout this branch
5. Run the project with docker-compose up
6. You should not get the warning again.
