### PR TITLE
revert: downgrade django-hijack 3.5.1 to 3.4.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -925,21 +925,19 @@ Django = ">=3.2"
 
 [[package]]
 name = "django-hijack"
-version = "3.5.1"
-description = "Enable users to hijack (=login as) and work on behalf of another user."
+version = "3.4.5"
+description = "django-hijack allows superusers to hijack (=login as) and work on behalf of another user."
 optional = false
-python-versions = ">=3.8"
+python-versions = "*"
 files = [
-    {file = "django_hijack-3.5.1-py3-none-any.whl", hash = "sha256:497dfa1764b9331800def8cbe05669fc06dbda28adc133bc1521d4d33bbbcdb4"},
-    {file = "django_hijack-3.5.1.tar.gz", hash = "sha256:df56a23794f842cdc1ddbe460bea2670d1d4f7d6017d35c89ba3b9307a9fd330"},
+    {file = "django-hijack-3.4.5.tar.gz", hash = "sha256:7e45b1de786bdc130628e4230b359dde6d8744ecd3bcd668d2b27c5d614a071c"},
+    {file = "django_hijack-3.4.5-py3-none-any.whl", hash = "sha256:129cbe75444b163135871a947d38ffb72181f4f2583544703fc9efe083c9ddad"},
 ]
 
 [package.dependencies]
-django = ">=4.2"
+django = ">=3.2"
 
 [package.extras]
-docs = ["mkdocs (==1.6.0)"]
-lint = ["msgcheck (==4.0.0)", "ruff (==0.4.8)"]
 test = ["pytest", "pytest-cov", "pytest-django"]
 
 [[package]]
@@ -4079,4 +4077,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.15"
-content-hash = "c48df9aba9cd74f278fdad367a5aa87398c9c3193a8f11a1af09aeb5c60e0c68"
+content-hash = "581f0909cc1d64dde8577a886f563a3ffbb2a8aef8d398d2afb7b7993c549542"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dj-database-url = "0.5.0"
 django = "4.2.13"
 django-anymail = { version = "8.6", extras = ["mailgun"] }
 django-filter = "^23.4"
-django-hijack = "3.5.1"
+django-hijack = "3.4.5"
 django-ipware = "3.0.7"
 django-oauth-toolkit = "1.7.1"
 django-redis = "5.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
None, Reverts https://github.com/mitodl/mitxpro/pull/3010


### Description (What does it do?)
In https://github.com/mitodl/mitxpro/pull/3016,  We noticed that django hijack was not working because they did major changes in how they serve the CSS & JS assets. As that happened, the JS started failing. We should do that as part of a separate ticket.

### How can this be tested?
Install deps locally, and try to hijkack a user.
