### PR TITLE
fix(external course sync): sync course run dates if they are missing

### DIFF
--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -391,13 +391,18 @@ def create_or_update_emeritus_course_run(course, emeritus_course):
         )
         return course_run, True
     elif (
-        course_run.start_date
-        and emeritus_course.start_date
-        and course_run.start_date.date() != emeritus_course.start_date.date()
-    ) or (
-        course_run.end_date
-        and emeritus_course.end_date
-        and course_run.end_date.date() != emeritus_course.end_date.date()
+        (not course_run.start_date and emeritus_course.start_date)
+        or (
+            course_run.start_date
+            and emeritus_course.start_date
+            and course_run.start_date.date() != emeritus_course.start_date.date()
+        )
+        or (not course_run.end_date and emeritus_course.end_date)
+        or (
+            course_run.end_date
+            and emeritus_course.end_date
+            and course_run.end_date.date() != emeritus_course.end_date.date()
+        )
     ):
         course_run.start_date = emeritus_course.start_date
         course_run.end_date = emeritus_course.end_date


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Follow up fix for https://github.com/mitodl/mitxpro/pull/2998

### Description (What does it do?)
<!--- Describe your changes in detail -->
Course run dates were not updating If an external course run ID is added for a run and dates are null but the API has dates.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master branch
- Run command `./manage.py sync_external_course_runs --vendor-name emeritus`
- Go to Django Admin, filter Emeritus course runs.
- Remove start and end date for a course run. The external course run ID should exist.
- Now run the management command again `./manage.py sync_external_course_runs --vendor-name emeritus`
- The start and end date won't update.
- Checkout this branch and run the command again.
- Dates should sync.
