### PR TITLE
chore: add fake EMERITUS_API_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,5 @@ HUBSPOT_ID_PREFIX=
 
 MITOL_DIGITAL_CREDENTIALS_VERIFY_SERVICE_BASE_URL=http://host.docker.internal:5000/
 MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET=test-hmac-secret  # pragma: allowlist secret
+
+EMERITUS_API_KEY=fake_api_key


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds EMERITUS_API_KEY to .env.example

