### PR TITLE
fix: homepage watch now video

### DIFF
--- a/cms/templates/partials/text-video-section.html
+++ b/cms/templates/partials/text-video-section.html
@@ -41,10 +41,11 @@
 <div class="light-box-video-holder hidden">
   {% embed page.video_url as youtube_video %}
   {% if youtube_video %}
+  <!-- prettier-ignore -->
   <div
     class="tv-video youtube-video"
     id="tv-light-box-yt-video"
-    data-href="{{ youtube_video }}"
+    data-href='{{ youtube_video }}'
   ></div>
   {% else %}
   <video


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
In pre-commit linting PR https://github.com/mitodl/mitxpro/commit/dfcc79767f92d7403df229935a0444ea1e559d0b#diff-f5e2f8fa45e40f3cf5f0bba328204a9f365241ba1a7fbfd85db75ee89429257a, prettier converted double quotes to single quotes and it resulted in the broken video URL on xPro Home page. Instead of the video source, it contained a random iframe string. This PR reverts the Prettier change.

Check testing instructions for the steps to reproduce.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots

BEFORE:
![Screenshot 2024-07-11 at 12 18 43 PM](https://github.com/mitodl/mitxpro/assets/52656433/90be403e-f7a8-424a-b2b6-739e042a1890)

AFTER:
![Screenshot 2024-07-11 at 12 18 51 PM](https://github.com/mitodl/mitxpro/assets/52656433/ed014e41-c5a6-4be8-83c3-d10b2176950c)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master or go to the prod homepage.
- For local, add a text video section for the homepage
- Click on the `Watch Now` button
- You will get an error.
- Now checkout this branch and test the same. Video should load.
