### PR TITLE
feat: added task id logs for sync_db_to_hubspot command

### DIFF
--- a/hubspot_xpro/management/commands/sync_db_to_hubspot.py
+++ b/hubspot_xpro/management/commands/sync_db_to_hubspot.py
@@ -42,6 +42,7 @@ class Command(BaseCommand):
             User._meta.app_label,  # noqa: SLF001
             create=self.create,
         )
+        self.stdout.write(f"Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -60,6 +61,7 @@ class Command(BaseCommand):
             Product._meta.app_label,  # noqa: SLF001
             create=self.create,
         )
+        self.stdout.write(f"Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -75,6 +77,7 @@ class Command(BaseCommand):
         """
         sys.stdout.write("  Syncing b2b orders with hubspot deals...\n")
         task = batch_upsert_hubspot_b2b_deals.delay(self.create)
+        self.stdout.write(f"Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -94,6 +97,7 @@ class Command(BaseCommand):
             self.create,
             object_ids=self.object_ids,
         )
+        self.stdout.write(f"Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -113,6 +117,7 @@ class Command(BaseCommand):
             self.create,
             object_ids=self.object_ids,
         )
+        self.stdout.write(f"Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -126,6 +131,7 @@ class Command(BaseCommand):
         """
         sys.stdout.write("  Syncing deal associations with hubspot...\n")
         task = batch_upsert_associations.delay(order_ids=self.object_ids)
+        self.stdout.write(f"Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()

--- a/hubspot_xpro/management/commands/sync_db_to_hubspot.py
+++ b/hubspot_xpro/management/commands/sync_db_to_hubspot.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         """
         Sync all users with contacts in hubspot
         """
-        sys.stdout.write("  Syncing users with hubspot contacts...\n")
+        sys.stdout.write("Syncing users with hubspot contacts...\n")
         task = batch_upsert_hubspot_objects.delay(
             HubspotObjectType.CONTACTS.value,
             ContentType.objects.get_for_model(User).model,
@@ -47,14 +47,14 @@ class Command(BaseCommand):
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            f"Syncing of users to hubspot contacts finished, took {total_seconds} seconds\n"
+            f"  Syncing of users to hubspot contacts finished, took {total_seconds} seconds\n"
         )
 
     def sync_products(self):
         """
         Sync all products with products in hubspot
         """
-        sys.stdout.write("  Syncing products with hubspot products...\n")
+        sys.stdout.write("Syncing products with hubspot products...\n")
         task = batch_upsert_hubspot_objects.delay(
             HubspotObjectType.PRODUCTS.value,
             ContentType.objects.get_for_model(Product).model,
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            "Syncing of products to hubspot finished, took {} seconds\n".format(  # noqa: UP032
+            "  Syncing of products to hubspot finished, took {} seconds\n".format(  # noqa: UP032
                 total_seconds
             )
         )
@@ -75,21 +75,21 @@ class Command(BaseCommand):
         """
         Sync all b2b orders with deals in hubspot
         """
-        sys.stdout.write("  Syncing b2b orders with hubspot deals...\n")
+        sys.stdout.write("Syncing b2b orders with hubspot deals...\n")
         task = batch_upsert_hubspot_b2b_deals.delay(self.create)
         self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            f"Syncing of b2b orders/lines to hubspot finished, took {total_seconds} seconds\n"
+            f"  Syncing of b2b orders/lines to hubspot finished, took {total_seconds} seconds\n"
         )
 
     def sync_deals(self):
         """
         Sync all orders with deals in hubspot
         """
-        sys.stdout.write("  Syncing orders with hubspot deals...\n")
+        sys.stdout.write("Syncing orders with hubspot deals...\n")
         task = batch_upsert_hubspot_objects.delay(
             HubspotObjectType.DEALS.value,
             ContentType.objects.get_for_model(Order).model,
@@ -102,14 +102,14 @@ class Command(BaseCommand):
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            f"Syncing of orders/lines to hubspot finished, took {total_seconds} seconds\n"
+            f"  Syncing of orders/lines to hubspot finished, took {total_seconds} seconds\n"
         )
 
     def sync_lines(self):
         """
         Sync all orders with line_items in hubspot
         """
-        sys.stdout.write("  Syncing order lines with hubspot line_items...\n")
+        sys.stdout.write("Syncing order lines with hubspot line_items...\n")
         task = batch_upsert_hubspot_objects.delay(
             HubspotObjectType.LINES.value,
             ContentType.objects.get_for_model(Line).model,
@@ -122,21 +122,21 @@ class Command(BaseCommand):
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            f"Syncing of order lines to hubspot finished, took {total_seconds} seconds\n"
+            f"  Syncing of order lines to hubspot finished, took {total_seconds} seconds\n"
         )
 
     def sync_associations(self):
         """
         Sync all deal associations in hubspot
         """
-        sys.stdout.write("  Syncing deal associations with hubspot...\n")
+        sys.stdout.write("Syncing deal associations with hubspot...\n")
         task = batch_upsert_associations.delay(order_ids=self.object_ids)
         self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            f"Syncing of deal associations to hubspot finished, took {total_seconds} seconds\n"
+            f"  Syncing of deal associations to hubspot finished, took {total_seconds} seconds\n"
         )
 
     def sync_all(self):

--- a/hubspot_xpro/management/commands/sync_db_to_hubspot.py
+++ b/hubspot_xpro/management/commands/sync_db_to_hubspot.py
@@ -35,14 +35,14 @@ class Command(BaseCommand):
         """
         Sync all users with contacts in hubspot
         """
-        sys.stdout.write("Syncing users with hubspot contacts...\n")
+        sys.stdout.write("  Syncing users with hubspot contacts...\n")
         task = batch_upsert_hubspot_objects.delay(
             HubspotObjectType.CONTACTS.value,
             ContentType.objects.get_for_model(User).model,
             User._meta.app_label,  # noqa: SLF001
             create=self.create,
         )
-        self.stdout.write(f"Task id is {task.id}")
+        self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -61,7 +61,7 @@ class Command(BaseCommand):
             Product._meta.app_label,  # noqa: SLF001
             create=self.create,
         )
-        self.stdout.write(f"Task id is {task.id}")
+        self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -77,7 +77,7 @@ class Command(BaseCommand):
         """
         sys.stdout.write("  Syncing b2b orders with hubspot deals...\n")
         task = batch_upsert_hubspot_b2b_deals.delay(self.create)
-        self.stdout.write(f"Task id is {task.id}")
+        self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -97,7 +97,7 @@ class Command(BaseCommand):
             self.create,
             object_ids=self.object_ids,
         )
-        self.stdout.write(f"Task id is {task.id}")
+        self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -117,7 +117,7 @@ class Command(BaseCommand):
             self.create,
             object_ids=self.object_ids,
         )
-        self.stdout.write(f"Task id is {task.id}")
+        self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
@@ -131,7 +131,7 @@ class Command(BaseCommand):
         """
         sys.stdout.write("  Syncing deal associations with hubspot...\n")
         task = batch_upsert_associations.delay(order_ids=self.object_ids)
-        self.stdout.write(f"Task id is {task.id}")
+        self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4192

### Description (What does it do?)
This PR adds the code to log the task ids of all the celery tasks which are started by the `sync_db_to_hubspot` management command  

### Screenshots (if appropriate):
<img width="661" alt="Screenshot 2024-07-11 at 3 53 25 PM" src="https://github.com/mitodl/mitxpro/assets/88967643/8060c8d2-3716-4fcb-b73e-0a997056e68b">


### How can this be tested?
- Create a developer account on hubspot using https://developers.hubspot.com/beta-docs/getting-started/account-types#create-a-developer-test-account
- Create a private app in your developer account with the following scopes:
    - CRM: everything except quotes and feedback
    - Standard: crm.export, crm.import, e-commerce, integration-sync
 - Set `MITOL_HUBSPOT_API_PRIVATE_TOKEN` to the private app token in your .env file
 - In the web container, run `./manage.py sync_db_to_hubspot update` 
 - Validate that the task id is being logged
