### PR TITLE
fix: add productversion description for CMS products and raise error if empty

### DIFF
--- a/cms/forms.py
+++ b/cms/forms.py
@@ -3,11 +3,7 @@ Custom forms for the cms
 """
 
 from django import forms
-from django.contrib.contenttypes.models import ContentType
 from wagtail.admin.forms import WagtailAdminPageForm
-
-from courses.models import CourseRun, Program
-from ecommerce.models import Product, ProductVersion
 
 
 class CertificatePageForm(WagtailAdminPageForm):
@@ -52,38 +48,3 @@ class CoursewareForm(WagtailAdminPageForm):
 
             elif instance.is_internal_or_external_program_page and instance.program:
                 self.fields["price"].initial = instance.program.current_price
-
-    def save(self, commit=True):  # noqa: FBT002
-        """
-        Handles pricing update and creates product(if required) and product version for a course run.
-        """
-        page = super().save(commit=False)
-
-        course_run_id = self.cleaned_data["course_run"]
-        price = self.cleaned_data["price"]
-        if page.is_internal_or_external_course_page and course_run_id and price:
-            course_run = CourseRun.objects.get(id=course_run_id)
-            if course_run.current_price != price:
-                product, _ = Product.objects.get_or_create(
-                    content_type=ContentType.objects.get_for_model(CourseRun),
-                    object_id=course_run.id,
-                )
-                ProductVersion.objects.create(
-                    product=product, price=price, description=course_run.text_id
-                )
-
-        elif (
-            page.is_internal_or_external_program_page
-            and price != page.program.current_price
-        ):
-            product, _ = Product.objects.get_or_create(
-                content_type=ContentType.objects.get_for_model(Program),
-                object_id=page.program.id,
-            )
-            ProductVersion.objects.create(
-                product=product, price=price, description=page.program.text_id
-            )
-
-        if commit:
-            page.save()
-        return page

--- a/cms/forms.py
+++ b/cms/forms.py
@@ -63,13 +63,14 @@ class CoursewareForm(WagtailAdminPageForm):
         price = self.cleaned_data["price"]
         if page.is_internal_or_external_course_page and course_run_id and price:
             course_run = CourseRun.objects.get(id=course_run_id)
-            product, _ = Product.objects.get_or_create(
-                content_type=ContentType.objects.get_for_model(CourseRun),
-                object_id=course_run.id,
-            )
-            ProductVersion.objects.create(
-                product=product, price=price, description=course_run.text_id
-            )
+            if course_run.current_price != price:
+                product, _ = Product.objects.get_or_create(
+                    content_type=ContentType.objects.get_for_model(CourseRun),
+                    object_id=course_run.id,
+                )
+                ProductVersion.objects.create(
+                    product=product, price=price, description=course_run.text_id
+                )
 
         elif (
             page.is_internal_or_external_program_page

--- a/cms/forms.py
+++ b/cms/forms.py
@@ -67,7 +67,9 @@ class CoursewareForm(WagtailAdminPageForm):
                 content_type=ContentType.objects.get_for_model(CourseRun),
                 object_id=course_run.id,
             )
-            ProductVersion.objects.create(product=product, price=price)
+            ProductVersion.objects.create(
+                product=product, price=price, description=course_run.text_id
+            )
 
         elif (
             page.is_internal_or_external_program_page
@@ -77,7 +79,9 @@ class CoursewareForm(WagtailAdminPageForm):
                 content_type=ContentType.objects.get_for_model(Program),
                 object_id=page.program.id,
             )
-            ProductVersion.objects.create(product=product, price=price)
+            ProductVersion.objects.create(
+                product=product, price=price, description=page.program.text_id
+            )
 
         if commit:
             page.save()

--- a/cms/models.py
+++ b/cms/models.py
@@ -1184,9 +1184,17 @@ class ProgramProductPage(ProductPage):
     objects = ProgramProductPageManager()
     parent_page_types = ["ProgramIndexPage"]
 
-    content_panels = (
-        [FieldPanel("program")] + ProductPage.content_panels + [FieldPanel("price")]  # noqa: RUF005
-    )
+    content_panels = [
+        FieldPanel("program"),
+        *ProductPage.content_panels,
+        MultiFieldPanel(
+            [
+                FieldPanel("price"),
+            ],
+            heading="Set Price",
+            help_text="Price is not changed when a page is saved as draft.",
+        ),
+    ]
     base_form_class = CoursewareForm
 
     program = models.OneToOneField(
@@ -1318,22 +1326,19 @@ class CourseProductPage(ProductPage):
 
     parent_page_types = ["CourseIndexPage"]
 
-    content_panels = (
-        [  # noqa: RUF005
-            FieldPanel("course"),
-            FieldPanel("topics"),
-        ]
-        + ProductPage.content_panels
-        + [
-            MultiFieldPanel(
-                [
-                    FieldPanel("course_run", widget=forms.Select),
-                    FieldPanel("price"),
-                ],
-                heading="Set Price",
-            ),
-        ]
-    )
+    content_panels = [
+        FieldPanel("course"),
+        FieldPanel("topics"),
+        *ProductPage.content_panels,
+        MultiFieldPanel(
+            [
+                FieldPanel("course_run", widget=forms.Select),
+                FieldPanel("price"),
+            ],
+            heading="Set Price",
+            help_text="Price is not changed when a page is saved as draft.",
+        ),
+    ]
     base_form_class = CoursewareForm
 
     @cached_property

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -8,6 +8,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
 from django.urls import resolve, reverse
+from wagtail import hooks
 from wagtail.coreutils import WAGTAIL_APPEND_SLASH
 from wagtail.test.utils.form_data import querydict_from_html
 
@@ -64,6 +65,7 @@ from cms.models import (
     UserTestimonialsPage,
     WhoShouldEnrollPage,
 )
+from cms.wagtail_hooks import create_product_and_versions_for_courseware_pages
 from courses.factories import (
     CourseFactory,
     CourseRunCertificateFactory,
@@ -1730,6 +1732,9 @@ def test_course_page_price_change_fields_are_visible(superuser_client):
     ].choices
 
 
+@hooks.register_temporarily(
+    "after_publish_page", create_product_and_versions_for_courseware_pages
+)
 def test_course_page_price_is_updated(superuser_client):
     """
     Test that the course price can be set in the CoursePage.
@@ -1746,7 +1751,7 @@ def test_course_page_price_is_updated(superuser_client):
     data_to_post = querydict_from_html(
         response.content.decode(), form_id="page-edit-form"
     )
-    data_to_post["action-publish"] = ""
+    data_to_post["action-publish"] = "action-publish"
     data_to_post["content-count"] = 0
     data_to_post["price"] = 1234
     data_to_post["course_run"] = course_run.id
@@ -1770,6 +1775,9 @@ def test_program_page_price_change_field_is_visible(superuser_client):
     assert "price" in resp.context_data["form"].fields
 
 
+@hooks.register_temporarily(
+    "after_publish_page", create_product_and_versions_for_courseware_pages
+)
 def test_program_page_price_is_updated(superuser_client):
     """
     Test that the course price can be changed in the ProgramPage.
@@ -1784,7 +1792,7 @@ def test_program_page_price_is_updated(superuser_client):
     data_to_post = querydict_from_html(
         response.content.decode(), form_id="page-edit-form"
     )
-    data_to_post["action-publish"] = ""
+    data_to_post["action-publish"] = "action-publish"
     data_to_post["content-count"] = 0
     data_to_post["price"] = 999
     resp = superuser_client.post(path, data_to_post)

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1766,7 +1766,7 @@ def test_course_page_price_is_updated(superuser_client):
 )
 def test_course_page_price_is_not_updated_when_saved_as_draft(superuser_client):
     """
-    Test that the course price is not updated when CoursePage is saved as draft.
+    Test that a new `ProductVersion` is not created when a CoursePage is saved as draft.
     """
     course_run = CourseRunFactory.create(
         course__page__thumbnail_image=None, course__page__background_image=None
@@ -1837,7 +1837,7 @@ def test_program_page_price_is_updated(superuser_client):
 )
 def test_program_page_price_is_not_updated_when_saved_as_draft(superuser_client):
     """
-    Test that the program price is not updated when page is saved a draft.
+    Test that a new `ProductVersion` is not created when program page is saved a draft.
     """
     program = ProgramFactory.create(
         page__thumbnail_image=None, page__background_image=None

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -1,7 +1,11 @@
 """Custom hooks to configure wagtail behavior"""
 
+from django.contrib.contenttypes.models import ContentType
 from wagtail import hooks
 from wagtail.admin.api.views import PagesAdminAPIViewSet
+
+from courses.models import CourseRun, Program
+from ecommerce.models import Product, ProductVersion
 
 
 @hooks.register("construct_explorer_page_queryset")
@@ -26,3 +30,46 @@ class OrderedPagesAPIEndpoint(PagesAdminAPIViewSet):
 def configure_admin_api_default_order(router):
     """Swap admin pages API for our own flavor that orders results by title"""
     router.register_endpoint("pages", OrderedPagesAPIEndpoint)
+
+
+@hooks.register("after_publish_page")
+def create_product_and_product_versions(request, page):
+    """
+    Creates Product and Product Version for the courseware pages on page publish.
+    """
+    if not (
+        page.is_internal_or_external_course_page
+        or page.is_internal_or_external_program_page
+    ):
+        return
+
+    form_class = page.specific_class.get_edit_handler().get_form_class()
+    form = form_class(request.POST, instance=page)
+    if not form.is_valid():
+        return
+
+    course_run_id = form.cleaned_data["course_run"]
+    price = form.cleaned_data["price"]
+
+    if page.is_internal_or_external_course_page and course_run_id and price:
+        course_run = CourseRun.objects.get(id=course_run_id)
+        if course_run.current_price != price:
+            product, _ = Product.objects.get_or_create(
+                content_type=ContentType.objects.get_for_model(CourseRun),
+                object_id=course_run.id,
+            )
+            ProductVersion.objects.create(
+                product=product, price=price, description=course_run.text_id
+            )
+
+    elif (
+        page.is_internal_or_external_program_page
+        and price != page.program.current_price
+    ):
+        product, _ = Product.objects.get_or_create(
+            content_type=ContentType.objects.get_for_model(Program),
+            object_id=page.program.id,
+        )
+        ProductVersion.objects.create(
+            product=product, price=price, description=page.program.text_id
+        )

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -33,7 +33,7 @@ def configure_admin_api_default_order(router):
 
 
 @hooks.register("after_publish_page")
-def create_product_and_product_versions(request, page):
+def create_product_and_versions_for_courseware_pages(request, page):
     """
     Creates Product and Product Version for the courseware pages on page publish.
     """

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail import hooks
 from wagtail.admin.api.views import PagesAdminAPIViewSet
 
-from cms.models import CoursePage, ExternalCoursePage, ExternalProgramPage, ProgramPage
 from courses.models import CourseRun, Program
 from ecommerce.models import Product, ProductVersion
 
@@ -38,14 +37,9 @@ def create_product_and_versions_for_courseware_pages(request, page):
     """
     Creates Product and Product Version for the courseware pages on page publish.
     """
-    courseware_classes = [
-        CoursePage,
-        ExternalCoursePage,
-        ExternalProgramPage,
-        ProgramPage,
-    ]
-    if not any(
-        isinstance(page, courseware_cls) for courseware_cls in courseware_classes
+    if not (
+        hasattr(page, "is_internal_or_external_course_page")
+        or hasattr(page, "is_internal_or_external_program_page")
     ):
         return
 

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail import hooks
 from wagtail.admin.api.views import PagesAdminAPIViewSet
 
+from cms.models import CoursePage, ExternalCoursePage, ExternalProgramPage, ProgramPage
 from courses.models import CourseRun, Program
 from ecommerce.models import Product, ProductVersion
 
@@ -37,9 +38,14 @@ def create_product_and_versions_for_courseware_pages(request, page):
     """
     Creates Product and Product Version for the courseware pages on page publish.
     """
-    if not (
-        page.is_internal_or_external_course_page
-        or page.is_internal_or_external_program_page
+    courseware_classes = [
+        CoursePage,
+        ExternalCoursePage,
+        ExternalProgramPage,
+        ProgramPage,
+    ]
+    if not any(
+        isinstance(page, courseware_cls) for courseware_cls in courseware_classes
     ):
         return
 

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -234,6 +234,8 @@ class ProductVersion(TimestampedModel):
                 "The content object for this ProductVersion (%s) does not have a `text_id` property",
                 str(self.id),
             )
+        if not self.description:
+            raise ValidationError("Description is a required field.")  # noqa: EM101
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -267,8 +267,9 @@ def test_product_version_save_empty_description(mocker):
         product=ProductFactory.create(content_object=LineFactory())
     )
     product_version.description = ""
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc:
         product_version.save()
+    assert exc.value.message == "Description is a required field."
 
 
 @pytest.mark.parametrize(

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -261,6 +261,16 @@ def test_product_version_save_text_id_badproduct(mocker):
     )
 
 
+def test_product_version_save_empty_description(mocker):
+    """ProductVersion should raise ValidationError if ProductVersion.description is empty"""
+    product_version = ProductVersionFactory.create(
+        product=ProductFactory.create(content_object=LineFactory())
+    )
+    product_version.description = ""
+    with pytest.raises(ValidationError):
+        product_version.save()
+
+
 @pytest.mark.parametrize(
     "factory",
     [ProductVersionFactory, CouponVersionFactory, CouponPaymentVersionFactory],

--- a/ecommerce/wagtail_views.py
+++ b/ecommerce/wagtail_views.py
@@ -120,7 +120,6 @@ class ProductVersionViewSet(ModelViewSet):
         "product",
         "price",
         "description",
-        "text_id",
         "requires_enrollment_code",
     )
     list_display = (

--- a/localdev/seed/api.py
+++ b/localdev/seed/api.py
@@ -387,7 +387,11 @@ class SeedDataLoader:
             self.seed_result.add_created(product)
         latest_version = product.latest_version
         if not latest_version or not has_equal_properties(latest_version, product_data):
-            new_version = ProductVersion.objects.create(product=product, **product_data)
+            new_version = ProductVersion.objects.create(
+                product=product,
+                description=product.content_object.text_id,
+                **product_data,
+            )
             self.seed_result.add_created(new_version)
             return new_version
         else:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/4851

### Description (What does it do?)
<!--- Describe your changes in detail -->
ProductVersion.description is required for Cybersourse. It was not added for products created via CMS. This PR fixes the issue and also adds a Validation to make sure that description cannot be empty.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master
- Create a course, course run
- Create a course page through CMS and add a price
- Notice that the created product versions do not have a description
- Now checkout this branch and repeat the steps. The description should be set to CourseRun.courseware_id OR Program.readable_id for the programs.
- Go to the Django shell.
- Try to create a ProductVersion with description with:
  - `from ecommerce.models import ProductVersion`
  - `ProductVersion.objects.create(product_id=1, price=199)`
  - It should raise a validation error