### PR TITLE
fix: draft page issues in API ingestion

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -726,12 +726,12 @@ class WagtailCachedPageMixin:
 
     @cached_property
     def child_pages(self):
-        """Gets child pages for the wagtail page"""
+        """Gets only live/published child pages for a Wagtail page"""
         return self.get_children().select_related("content_type").live()
 
     @cached_property
     def child_pages_including_draft(self):
-        """Gets child pages for the wagtail page including draft pages"""
+        """Gets all child pages for a Wagtail page including draft pages"""
         return self.get_children().select_related("content_type")
 
     def _get_child_page_of_type(self, cls, *, including_draft=False):
@@ -751,6 +751,10 @@ class WagtailCachedPageMixin:
             None,
         )
         return child.specific if child else None
+
+    def get_child_page_of_type_including_draft(self, cls):
+        """Gets the first child page of the given type if it exists including draft"""
+        return self._get_child_page_of_type(cls, including_draft=True)
 
 
 class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Page):

--- a/cms/models.py
+++ b/cms/models.py
@@ -729,13 +729,23 @@ class WagtailCachedPageMixin:
         """Gets child pages for the wagtail page"""
         return self.get_children().select_related("content_type").live()
 
-    def _get_child_page_of_type(self, cls):
+    @cached_property
+    def child_pages_including_draft(self):
+        """Gets child pages for the wagtail page including draft pages"""
+        return self.get_children().select_related("content_type")
+
+    def _get_child_page_of_type(self, cls, *, including_draft=False):
         """Gets the first child page of the given type if it exists"""
 
+        child_pages = (
+            self.child_pages
+            if not including_draft
+            else self.child_pages_including_draft
+        )
         child = next(
             (
                 page
-                for page in self.child_pages
+                for page in child_pages
                 if page.content_type.model == cls.__name__.lower()
             ),
             None,

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1823,8 +1823,8 @@ def test_certificate_request_with_invalid_uuid(user_client, uuid_string):
 
 def test_get_child_page_of_type_including_draft():
     """
-    Test that `_get_child_page_of_type` returns a draft page if `including_draft=True`
-    and a New child page of type cannot be created.
+    Test that `get_child_page_of_type_including_draft` returns a draft
+    child page and a New child page of type cannot be created.
     """
     external_course_page = ExternalCoursePageFactory.create()
 

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1830,8 +1830,8 @@ def test_get_child_page_of_type_including_draft():
 
     assert external_course_page.outcomes is None
     assert (
-        external_course_page._get_child_page_of_type(  # noqa: SLF001
-            LearningOutcomesPage, including_draft=True
+        external_course_page.get_child_page_of_type_including_draft(
+            LearningOutcomesPage
         )
         is None
     )

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1852,8 +1852,8 @@ def test_get_child_page_of_type_with_draft():
 
     assert external_course_page.outcomes is None
     assert (
-        external_course_page._get_child_page_of_type(  # noqa: SLF001
-            LearningOutcomesPage, including_draft=True
+        external_course_page.get_child_page_of_type_including_draft(
+            LearningOutcomesPage
         )
         == learning_outcomes_page
     )

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -1821,7 +1821,7 @@ def test_certificate_request_with_invalid_uuid(user_client, uuid_string):
     assert course_certificate_resp.status_code == 404
 
 
-def test_get_child_page_of_type_with_draft():
+def test_get_child_page_of_type_including_draft():
     """
     Test that `_get_child_page_of_type` returns a draft page if `including_draft=True`
     and a New child page of type cannot be created.

--- a/courses/management/commands/sync_external_course_runs.py
+++ b/courses/management/commands/sync_external_course_runs.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
             )
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Number of Courses Pages Created {len(stats['course_pages_created'])}."
+                    f"Number of Course Pages Created {len(stats['course_pages_created'])}."
                 )
             )
             self.stdout.write(
@@ -117,7 +117,7 @@ class Command(BaseCommand):
             )
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Number of Courses Pages Updated {len(stats['course_pages_updated'])}."
+                    f"Number of Course Pages Updated {len(stats['course_pages_updated'])}."
                 )
             )
             self.stdout.write(

--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -308,16 +308,16 @@ def update_emeritus_course_runs(emeritus_courses):  # noqa: C901, PLR0915
                     course_page.topics.add(topic)
                     course_page.save()
 
-            outcomes_page = course_page._get_child_page_of_type(  # noqa: SLF001
-                LearningOutcomesPage, including_draft=True
+            outcomes_page = course_page.get_child_page_of_type_including_draft(
+                LearningOutcomesPage
             )
             if not outcomes_page and emeritus_course.learning_outcomes_list:
                 create_learning_outcomes_page(
                     course_page, emeritus_course.learning_outcomes_list
                 )
 
-            who_should_enroll_page = course_page._get_child_page_of_type(  # noqa: SLF001
-                WhoShouldEnrollPage, including_draft=True
+            who_should_enroll_page = course_page.get_child_page_of_type_including_draft(
+                WhoShouldEnrollPage
             )
             if not who_should_enroll_page and emeritus_course.who_should_enroll_list:
                 create_who_should_enroll_in_page(
@@ -404,27 +404,19 @@ def create_or_update_emeritus_course_page(course_index_page, course, emeritus_co
         created = True
     else:
         latest_revision = course_page.get_latest_revision_as_object()
-        # Only update course page fields with API if they are empty in the latest revision.
-        course_page_attrs_changed = False
-        if not latest_revision.external_marketing_url and emeritus_course.marketing_url:
-            course_page.external_marketing_url = emeritus_course.marketing_url
-            course_page_attrs_changed = True
-        if not latest_revision.duration and emeritus_course.duration:
-            course_page.duration = emeritus_course.duration
-            course_page_attrs_changed = True
-        if not latest_revision.description and emeritus_course.description:
-            course_page.description = emeritus_course.description
-            course_page_attrs_changed = True
 
-        if course_page_attrs_changed:
-            if course_page.has_unpublished_changes:
-                # If course is in draft, we need to save a revision with the updated data.
-                course_page.save_revision()
-            else:
-                course_page.save()
-            log.info(
-                f"Updated external course page for course title: {emeritus_course.course_title}"  # noqa: G004
-            )
+        # Only update course page fields with API if they are empty in the latest revision.
+        if not latest_revision.external_marketing_url and emeritus_course.marketing_url:
+            latest_revision.external_marketing_url = emeritus_course.marketing_url
+        if not latest_revision.duration and emeritus_course.duration:
+            latest_revision.duration = emeritus_course.duration
+        if not latest_revision.description and emeritus_course.description:
+            latest_revision.description = emeritus_course.description
+
+        latest_revision.save_revision()
+        log.info(
+            f"Updated external course page for course title: {emeritus_course.course_title}"  # noqa: G004
+        )
 
     return course_page, created
 

--- a/courses/sync_external_courses/emeritus_api_test.py
+++ b/courses/sync_external_courses/emeritus_api_test.py
@@ -35,9 +35,9 @@ from mitxpro.utils import clean_url
 
 
 @pytest.fixture
-def emeritus_course_json():
+def emeritus_course_data():
     """
-    Emeritus Course JSON with Future dates.
+    Emeritus Course data with Future dates.
     """
     start_date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")  # noqa: DTZ005
     end_date = (datetime.now() + timedelta(days=2)).strftime("%Y-%m-%d")  # noqa: DTZ005
@@ -121,7 +121,7 @@ def test_generate_external_course_run_courseware_id(
 )
 @pytest.mark.django_db
 def test_create_or_update_emeritus_course_page(
-    create_course_page, is_draft, emeritus_course_json
+    create_course_page, is_draft, emeritus_course_data
 ):
     """
     Test that `create_or_update_emeritus_course_page` creates a new course or updates the existing.
@@ -133,7 +133,7 @@ def test_create_or_update_emeritus_course_page(
     if create_course_page:
         external_course_page = ExternalCoursePageFactory.create(
             course=course,
-            title=emeritus_course_json["program_name"],
+            title=emeritus_course_data["program_name"],
             external_marketing_url="",
             duration="",
             description="",
@@ -142,15 +142,15 @@ def test_create_or_update_emeritus_course_page(
             external_course_page.unpublish()
 
     course_page, _ = create_or_update_emeritus_course_page(
-        course_index_page, course, EmeritusCourse(emeritus_course_json)
+        course_index_page, course, EmeritusCourse(emeritus_course_data)
     )
-    assert course_page.title == emeritus_course_json["program_name"]
+    assert course_page.title == emeritus_course_data["program_name"]
     assert course_page.external_marketing_url == clean_url(
-        emeritus_course_json["landing_page_url"], remove_query_params=True
+        emeritus_course_data["landing_page_url"], remove_query_params=True
     )
     assert course_page.course == course
-    assert course_page.duration == f"{emeritus_course_json['total_weeks']} Weeks"
-    assert course_page.description == emeritus_course_json["description"]
+    assert course_page.duration == f"{emeritus_course_data['total_weeks']} Weeks"
+    assert course_page.description == emeritus_course_data["description"]
 
 
 @pytest.mark.django_db
@@ -225,12 +225,12 @@ def test_parse_emeritus_data_str():
 @pytest.mark.parametrize("create_existing_course_run", [True, False])
 @pytest.mark.django_db
 def test_create_or_update_emeritus_course_run(
-    create_existing_course_run, emeritus_course_json
+    create_existing_course_run, emeritus_course_data
 ):
     """
     Tests that `create_or_update_emeritus_course_run` creates or updates a course run
     """
-    emeritus_course = EmeritusCourse(emeritus_course_json)
+    emeritus_course = EmeritusCourse(emeritus_course_data)
     course = CourseFactory.create()
     if create_existing_course_run:
         CourseRunFactory.create(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->

- If ExternalCoursePage is unpublished for Emeritus, the updates do not work as expected. We need to save the revisions in this case.
- If WhoShouldEnroll or LearningOutcomes Page exist and are unpublished, the command does not look by default, this PR makes room to fetch the draft pages.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master
- Sync Emeritus Course Runs with `./manage.py sync_external_course_runs --vendor emeritus`
- Now unpublish a course page in CMS and remove one of the `external_marketing_url`, `duration`, or `description`.
- Now save the page in Draft
- Run the above command, you won't see the updated data(the one you removed should be added again from the API. The logic is to add the data in case it is missing.)
- Now unpublish WhoShouldEnroll or LearningOutcomes page for one of the Emeritus Course Page.
- Run the above command, it will through a unique slug error.
- Now checkout this branch and repeat the above steps.
- CoursePage should update and there should be no exception for the WhoShouldEnroll or LearningOutcomes page.
