### PR TITLE
fix(external course sync): publish revision if course is live and has unpublished changes

### DIFF
--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -413,7 +413,9 @@ def create_or_update_emeritus_course_page(course_index_page, course, emeritus_co
         if not latest_revision.description and emeritus_course.description:
             latest_revision.description = emeritus_course.description
 
-        latest_revision.save_revision()
+        revision = latest_revision.save_revision()
+        if course_page.live and course_page.has_unpublished_changes:
+            revision.publish()
         log.info(
             f"Updated external course page for course title: {emeritus_course.course_title}"  # noqa: G004
         )

--- a/courses/sync_external_courses/emeritus_api_test.py
+++ b/courses/sync_external_courses/emeritus_api_test.py
@@ -141,16 +141,22 @@ def test_create_or_update_emeritus_course_page(
         if is_draft:
             external_course_page.unpublish()
 
-    course_page, _ = create_or_update_emeritus_course_page(
+    external_course_page, _ = create_or_update_emeritus_course_page(
         course_index_page, course, EmeritusCourse(emeritus_course_data)
     )
-    assert course_page.title == emeritus_course_data["program_name"]
-    assert course_page.external_marketing_url == clean_url(
+    assert external_course_page.title == emeritus_course_data["program_name"]
+    assert external_course_page.external_marketing_url == clean_url(
         emeritus_course_data["landing_page_url"], remove_query_params=True
     )
-    assert course_page.course == course
-    assert course_page.duration == f"{emeritus_course_data['total_weeks']} Weeks"
-    assert course_page.description == emeritus_course_data["description"]
+    assert external_course_page.course == course
+    assert (
+        external_course_page.duration == f"{emeritus_course_data['total_weeks']} Weeks"
+    )
+    assert external_course_page.description == emeritus_course_data["description"]
+
+    if is_draft:
+        assert external_course_page.has_unpublished_changes
+        assert not external_course_page.live
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fix for https://github.com/mitodl/mitxpro/pull/3048

### Description (What does it do?)
<!--- Describe your changes in detail -->
When a course page already exists, we save the revision. It saves the draft revisions and does not publish them. This PR publishes a page revision if it has unpublished changes and the page is live.

Steps to reproduce:

- Check out the master branch.
- Run `./manage.py sync_external_course_runs --vendor emeritus`
- Pick any course and see that it has an external URL, description, and duration.
- Visit the course detail page. All the data should be updated.
- Now go to CMS and change an external course page, i.e. remove duration, external URL, or description. Publish it.
- Now visit the course details and the changes should reflect.
- Now rerun the above command, and you will see that the fields you updated in the above steps are repopulated.
- Now check the course page in CMS, it will have repopulated data.
- Visit the course detail page, it won't have the updated data as it saved the revision as a draft.
- Now check out this branch and try to reproduce the above issue.
- Verify that an unpublished page should not go live after current changes.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Follow the steps to reproduce in the description.
