### PR TITLE
fix: catalog prices for external courses

### DIFF
--- a/cms/templates/partials/card_details_top.html
+++ b/cms/templates/partials/card_details_top.html
@@ -24,11 +24,6 @@
       <strong>Price:</strong>
       ${{ courseware_page.product.current_price|floatformat:"0"|intcomma }}
     </li>
-    {% elif courseware_page.is_internal_or_external_course_page and courseware_page.product.first_unexpired_run.current_price %}
-    <li>
-      <strong>Price:</strong>
-      ${{ courseware_page.product.first_unexpired_run.current_price|floatformat:"0"|intcomma }}
-    </li>
     {% endif %}
     {% if object_type == "program" %}
     <li>

--- a/courses/models.py
+++ b/courses/models.py
@@ -549,6 +549,13 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
             else []
         )
 
+    @property
+    def current_price(self):
+        """Gets the current price for the first unexpired run"""
+        return (
+            self.first_unexpired_run.current_price if self.first_unexpired_run else None
+        )
+
     def available_runs(self, user):
         """
         Get all enrollable runs for a Course that a user has not already enrolled in.

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -327,6 +327,18 @@ def test_course_run_unexpired(end_days, enroll_days, expected):
     )
 
 
+def test_course_current_price():
+    """
+    current_price should return the price of the latest product version of the first unexpired course run
+    """
+    course = CourseFactory.create()
+    runs = CourseRunFactory.create_batch(2, course=course)
+    ProductVersionFactory.create_batch(
+        2, product=ProductFactory(content_object=factory.Iterator(runs))
+    )
+    assert course.current_price == course.first_unexpired_run.current_price
+
+
 def test_course_run_current_price():
     """
     current_price should return the price of the latest product version if it exists


### PR DESCRIPTION
### What are the relevant tickets?
None, Prices for external courses were not shown on the catalog page

### Description (What does it do?)
Removes the checks and allows external courses prices to be shown on Catalog page


### Screenshots (if appropriate):
**Courses**
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/3dc03fe8-6c05-4923-a1f2-a1f29345146f">

**Programs**
![image](https://github.com/user-attachments/assets/36712d7f-7fba-4402-b45d-1c48bf0b9082)

### How can this be tested?
- Create some external courses with prices
- Open these course details pages and check the price is being displayed
- Open `/catalog` page and verify that the prices are also shown on the catalog page items.
- Run above steps with programs as well

NOTE: Please test different combinations of courses and programs e.g. draft, live, with without product versions 



