### PR TITLE
perf: optimize catalog queries for external coursware

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -532,7 +532,9 @@ class CatalogPage(Page):
             .order_by("id")
             .select_related("course")
         )
-        external_course_qset = ExternalCoursePage.objects.live().order_by("title")
+        external_course_qset = (
+            ExternalCoursePage.objects.live().select_related("course").order_by("title")
+        )
 
         if topic_filter != ALL_TOPICS:
             program_page_qset = program_page_qset.related_pages(topic_filter)
@@ -557,9 +559,11 @@ class CatalogPage(Page):
             "thumbnail_image",
         )
 
-        programs = [page.program for page in program_page_qset]
+        programs = [
+            page.program for page in [*program_page_qset, *external_program_qset]
+        ]
         courses = [
-            *[page.course for page in course_page_qset],
+            *[page.course for page in [*course_page_qset, *external_course_qset]],
             *[course for program in programs for course in program.courses.all()],
         ]
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
We optimized the catalog page a few months back. After that we change the course and program architecture for the external courseware. This has added a few extra queries that we can optimize very easily. This PR just does that.

For me, this has reduced the query count from 380s to 20s. The request time is reduced by half.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
Before:

<img width="1727" alt="Screenshot 2024-07-31 at 7 53 30 PM" src="https://github.com/user-attachments/assets/ec6e2df0-daa4-4ea9-b8c6-c876456e46c3">


After:

<img width="1727" alt="Screenshot 2024-07-31 at 7 54 23 PM" src="https://github.com/user-attachments/assets/a8e0c463-3060-4bd1-b031-8438ac5f17e9">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master
- Create a few internal and external courses.
- You can use `./manage.py sync_external_course_runs --vendor emeritus` for external courses.
- Visit catalog page.
- Now check the query count in silk at /silk/requests/
- Now checkout this branch and visit the catalog page.
- Monitor the drop in query count and request time.