### PR TITLE
fix: do not publish external course if saved as draft

### DIFF
--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -413,8 +413,9 @@ def create_or_update_emeritus_course_page(course_index_page, course, emeritus_co
         if not latest_revision.description and emeritus_course.description:
             latest_revision.description = emeritus_course.description
 
+        is_draft = course_page.has_unpublished_changes
         revision = latest_revision.save_revision()
-        if course_page.live and course_page.has_unpublished_changes:
+        if not is_draft:
             revision.publish()
         log.info(
             f"Updated external course page for course title: {emeritus_course.course_title}"  # noqa: G004


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fix for https://github.com/mitodl/mitxpro/pull/3048

### Description (What does it do?)
<!--- Describe your changes in detail -->
if a course page is published the first time and then saved as draft. The command `./manage.py sync_external_course_runs --vendor emeritus` will publish it. This PR adds a check for that.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master
- Run `./manage.py sync_external_course_runs --vendor emeritus`
- Now visit any Emeritus course page in CMS.
- It should be in Live state. You check this in course list.
- Now remove external course URL and publish it. You will see this change in live version as learn more link is hidden now.
- Now change the title of course page and save it as draft.
- Now run the command again.
- It will update the external URL but it will also publish the course page. You will see that the Draft title is visible on live page and external link is also visible.
- Now checkout this branch and repeat the above steps.
- 