### PR TITLE
feat: set enrollment end for emeritus courses

### DIFF
--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -86,6 +86,9 @@ class EmeritusCourse:
         self.end_date = (
             end_datetime.replace(hour=23, minute=59) if end_datetime else None
         )
+        # Emeritus does not allow enrollments after start date.
+        # We set the course run enrollment_end to the start date to
+        # hide the course run from the course details page.
         self.enrollment_end = self.start_date
 
         self.marketing_url = clean_url(

--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -86,6 +86,7 @@ class EmeritusCourse:
         self.end_date = (
             end_datetime.replace(hour=23, minute=59) if end_datetime else None
         )
+        self.enrollment_end = self.start_date
 
         self.marketing_url = clean_url(
             emeritus_course_json.get("landing_page_url"), remove_query_params=True
@@ -452,6 +453,7 @@ def create_or_update_emeritus_course_run(course, emeritus_course):
             run_tag=emeritus_course.course_run_tag,
             start_date=emeritus_course.start_date,
             end_date=emeritus_course.end_date,
+            enrollment_end=emeritus_course.enrollment_end,
             live=True,
         )
         log.info(
@@ -471,9 +473,17 @@ def create_or_update_emeritus_course_run(course, emeritus_course):
             and emeritus_course.end_date
             and course_run.end_date.date() != emeritus_course.end_date.date()
         )
+        or (not course_run.enrollment_end and emeritus_course.enrollment_end)
+        or (
+            course_run.enrollment_end
+            and emeritus_course.enrollment_end
+            and course_run.enrollment_end.date()
+            != emeritus_course.enrollment_end.date()
+        )
     ):
         course_run.start_date = emeritus_course.start_date
         course_run.end_date = emeritus_course.end_date
+        course_run.enrollment_end = emeritus_course.enrollment_end
         course_run.save()
         log.info(
             f"Updated Course Run, title: {emeritus_course.course_title}, external_course_run_id: {course_run.external_course_run_id}"  # noqa: G004

--- a/courses/sync_external_courses/emeritus_api_test.py
+++ b/courses/sync_external_courses/emeritus_api_test.py
@@ -259,6 +259,7 @@ def test_create_or_update_emeritus_course_run(
             "external_course_run_id": emeritus_course.course_run_code,
             "start_date": emeritus_course.start_date,
             "end_date": emeritus_course.end_date,
+            "enrollment_end": emeritus_course.enrollment_end,
         }
     else:
         expected_data = {
@@ -268,6 +269,7 @@ def test_create_or_update_emeritus_course_run(
             "run_tag": emeritus_course.course_run_tag,
             "start_date": emeritus_course.start_date,
             "end_date": emeritus_course.end_date,
+            "enrollment_end": emeritus_course.enrollment_end,
             "live": True,
         }
     for attr_name, expected_value in expected_data.items():


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/5013

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds enrollment end date same as the start date for the emeritus courses. For emeritus courses enrollment is closed after the start date. Please go through the related ticket.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master
- Run `./manage.py sync_external_course_runs --vendor emeritus`. It will create the emeritus courses.
- go to the catalog page and note the Next Start Date
- Now go to the course detail page and see that there is a different date. Start date is in the past.
- For emeritus courses, enrollment is closed after the start date, we should not display such start dates.
- Now checkout this branch.
- Run the above command and verify that the part start dates are not appearing on the Course Detail Page. You can also verify that the `Next Start Date` on Catalog page is same as `Start Date` in the detail page.
- Verify the Course run data in django admin. It should have enrollment end same as the start date.