### PR TITLE
feat: add course and program availability in APIs

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -113,6 +113,16 @@ class CourseSerializer(serializers.ModelSerializer):
     credits = serializers.SerializerMethodField()
     platform = serializers.SerializerMethodField()
     marketing_hubspot_form_id = serializers.SerializerMethodField()
+    availability = serializers.SerializerMethodField()
+
+    def get_availability(self, instance):  # noqa: ARG002
+        """Get course availability"""
+
+        # This is a hard coded value because the consumers of the API need this field.
+        # In an ideal situation the availability could be "dated" or "anytime".
+        # Since all the courses in xPRO are dated so we will not check for "self paced"
+        # courses to determine if the course could be "anytime"
+        return "dated"
 
     def get_url(self, instance):
         """Get CMS Page URL for the course"""
@@ -217,6 +227,7 @@ class CourseSerializer(serializers.ModelSerializer):
             "credits",
             "is_external",
             "platform",
+            "availability",
         ]
 
 
@@ -280,6 +291,16 @@ class ProgramSerializer(serializers.ModelSerializer):
     video_url = serializers.SerializerMethodField()
     credits = serializers.SerializerMethodField()
     platform = serializers.SerializerMethodField()
+    availability = serializers.SerializerMethodField()
+
+    def get_availability(self, instance):  # noqa: ARG002
+        """Get program availability"""
+
+        # This is a hard coded value because the consumers of the API need this field.
+        # In an ideal situation the availability could be "dated" or "anytime".
+        # Since all the courses in xPRO are dated so we will not check for "self paced"
+        # courses to determine if the course could be "anytime"
+        return "dated"
 
     def get_courses(self, instance):
         """Serializer for courses"""
@@ -411,6 +432,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "credits",
             "is_external",
             "platform",
+            "availability",
         ]
 
 

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -298,7 +298,7 @@ class ProgramSerializer(serializers.ModelSerializer):
 
         # This is a hard coded value because the consumers of the API need this field.
         # In an ideal situation the availability could be "dated" or "anytime".
-        # Since all the courses in xPRO are dated so we will not check for "self paced"
+        # Since all the programs in xPRO are dated so we will not check for "self paced"
         # courses to determine if the course could be "anytime"
         return "dated"
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -161,6 +161,7 @@ def test_serialize_program(  # noqa: PLR0913
             "external_marketing_url": external_marketing_url,
             "marketing_hubspot_form_id": marketing_hubspot_form_id,
             "platform": program.platform.name,
+            "availability": "dated",
         },
     )
     assert data["end_date"] != non_live_run.end_date.strftime(datetime_format)
@@ -296,6 +297,7 @@ def test_serialize_course(  # noqa: PLR0913
                 marketing_hubspot_form_id if course_page else None
             ),
             "platform": course.platform.name,
+            "availability": "dated",
         },
     )
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4953

### Description (What does it do?)
Adds the availability field in `/courses` and `/programs` APIs
Currently, We just send a hard-coded value because the calculation of the `anytime` value of availability is not possible in xPRO

### How can this be tested?
- Create a couple of courses and programs
- Shift to this branch
- Check the responses of `/api/courses` and `/api/programs` and they should have an availability field in the response
- Check other APIs are not affected e.g. `/api/products`
