### PR TITLE
fix: fixed basket deletion issue

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -771,12 +771,13 @@ def complete_order(order):
     if order_coupon_ids:
         set_coupons_to_redeemed(order.purchaser.email, order_coupon_ids)
 
-    baskets = Basket.objects.select_for_update(skip_locked=True).filter(
-        user=order.purchaser
-    )
+    with transaction.atomic():
+        baskets = Basket.objects.select_for_update(skip_locked=True).filter(
+            user=order.purchaser
+        )
 
-    # clear the basket
-    clear_and_delete_baskets(baskets)
+        # clear the basket
+        clear_and_delete_baskets(baskets)
 
 
 def enroll_user_in_order_items(order):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -781,8 +781,8 @@ def complete_order(order):
     if order_coupon_ids:
         set_coupons_to_redeemed(order.purchaser.email, order_coupon_ids)
 
-        # clear the basket
-        clear_and_delete_baskets(order.purchaser)
+    # clear and delete the basket
+    clear_and_delete_baskets(order.purchaser)
 
 
 def enroll_user_in_order_items(order):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -727,7 +727,9 @@ def clear_and_delete_baskets(user=None):
     basket_filter = {"user": user} if user else {"updated_on__lte": cutoff_date}
 
     with transaction.atomic():
-        baskets = Basket.objects.select_for_update(skip_locked=True).filter(**basket_filter)
+        baskets = Basket.objects.select_for_update(skip_locked=True).filter(
+            **basket_filter
+        )
         log.info(
             "Basket deletion requested for baskets Ids: %s",
             [basket.id for basket in baskets],

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -70,7 +70,6 @@ from hubspot_xpro.task_helpers import sync_hubspot_deal
 from maxmind.api import ip_to_country_code
 from mitxpro.utils import case_insensitive_equal, first_or_none, now_in_utc
 
-
 log = logging.getLogger(__name__)
 
 ISO_8601_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1095,7 +1095,7 @@ def test_delete_baskets_with_user_args():
     Test to verify that the basket of the user passed in the clear_and_delete_baskets fn is deleted only
     """
     baskets = BasketFactory.create_batch(2)
-    
+
     assert Basket.objects.filter(user=baskets[0].user).count() == 1
     clear_and_delete_baskets(baskets[0].user)
     assert Basket.objects.filter(user=baskets[0].user).count() == 0
@@ -1109,15 +1109,21 @@ def test_delete_expired_basket(patch_now):
     """
     Test to verify that the expired baskets are deleted on calling clear_and_delete_baskets fn without user argument
     """
-    patch_now.return_value = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=settings.BASKET_EXPIRY_DAYS)
+    patch_now.return_value = datetime.datetime.now(
+        tz=datetime.timezone.utc
+    ) - datetime.timedelta(days=settings.BASKET_EXPIRY_DAYS)
     BasketFactory.create_batch(3)
-    patch_now.return_value = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=settings.BASKET_EXPIRY_DAYS + 1)
+    patch_now.return_value = datetime.datetime.now(
+        tz=datetime.timezone.utc
+    ) + datetime.timedelta(days=settings.BASKET_EXPIRY_DAYS + 1)
     unexpired_baskets = BasketFactory.create_batch(3)
     patch_now.stop()
     # Calling the clear baskets without user argument so it should delete the expired baskets
     clear_and_delete_baskets()
     assert Basket.objects.all().count() == 3
-    assert list(Basket.objects.all().values_list("id", flat=True)) == [basket.id for basket in unexpired_baskets]
+    assert list(Basket.objects.all().values_list("id", flat=True)) == [
+        basket.id for basket in unexpired_baskets
+    ]
 
 
 def test_complete_order(mocker, user, basket_and_coupons):
@@ -1137,7 +1143,8 @@ def test_complete_order(mocker, user, basket_and_coupons):
     patched_enroll.assert_called_once_with(order)
     patched_clear_and_delete_baskets.assert_called_once_with(mocker.ANY)
     assert (
-        patched_clear_and_delete_baskets.call_args[0][0] == basket_and_coupons.basket.user
+        patched_clear_and_delete_baskets.call_args[0][0]
+        == basket_and_coupons.basket.user
     )
 
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -2,11 +2,11 @@
 Test for ecommerce functions
 """
 
+import datetime
 import hashlib
 import hmac
 import ipaddress
 import uuid
-import datetime
 from base64 import b64encode
 from collections import defaultdict
 from datetime import timedelta
@@ -1098,7 +1098,7 @@ def test_delete_baskets_with_user_args(baskets_with_different_users):
     user2 = baskets_with_different_users.baskets[1].user
 
     assert Basket.objects.filter(user=user1).count() == 1
-    
+
     clear_and_delete_baskets(user1)
 
     assert Basket.objects.filter(user=user1).count() == 0
@@ -1132,7 +1132,7 @@ def test_active_baskets_are_not_deleted(mocker, user, basket_and_coupons):
     clear_and_delete_baskets()
     assert Basket.objects.filter(user=user).count() == 1
 
-    
+
 def test_complete_order(mocker, user, basket_and_coupons):
     """
     Test that complete_order enrolls a user in the items in their order and clears out checkout-related objects

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import ipaddress
 import uuid
+import datetime
 from base64 import b64encode
 from collections import defaultdict
 from datetime import timedelta
@@ -1071,9 +1072,9 @@ def test_company_multiple_global_consent_error(mocker, basket_and_agreement):
     )
 
 
-def test_clear_and_delete_baskets(user, basket_and_coupons):
+def test_clear_baskets(user, basket_and_coupons):
     """
-    Test to verify that the basket is cleared and deleted upon calling clear_and_delete_basket fn
+    Test to verify that the basket is cleared upon calling clear_and_delete_basket fn
     """
     basket_and_coupons.basket.user = user
     basket_and_coupons.basket.save()
@@ -1082,13 +1083,56 @@ def test_clear_and_delete_baskets(user, basket_and_coupons):
     assert CourseRunSelection.objects.filter(basket__user=user).count() > 0
     assert CouponSelection.objects.filter(basket__user=user).count() > 0
 
-    clear_and_delete_baskets([basket_and_coupons.basket])
+    clear_and_delete_baskets(basket_and_coupons.basket.user)
     assert Basket.objects.filter(user=user).count() == 0
     assert BasketItem.objects.filter(basket__user=user).count() == 0
     assert CourseRunSelection.objects.filter(basket__user=user).count() == 0
     assert CouponSelection.objects.filter(basket__user=user).count() == 0
 
 
+def test_delete_baskets_with_user_args(baskets_with_different_users):
+    """
+    Test to verify that the basket of the user passed in the clear_and_delete_baskets fn is deleted only
+    """
+    user1 = baskets_with_different_users.baskets[0].user
+    user2 = baskets_with_different_users.baskets[1].user
+
+    assert Basket.objects.filter(user=user1).count() == 1
+    
+    clear_and_delete_baskets(user1)
+
+    assert Basket.objects.filter(user=user1).count() == 0
+    assert Basket.objects.filter(user=user2).count() == 1  # Not deleting basket of other users
+
+
+def test_delete_expired_basket(mocker, user, basket_and_coupons):
+    """
+    Test to verify that the expired baskets are deleted on calling clear_and_delete_baskets fn without user argument
+    """
+    basket_and_coupons.basket.user = user
+    basket_and_coupons.basket.save()
+
+    now_in_utc = mocker.patch("ecommerce.api.now_in_utc")
+    now_in_utc.return_value = datetime.datetime.now(
+        tz=datetime.timezone.utc
+    ) + datetime.timedelta(days=settings.BASKET_EXPIRY_DAYS)
+
+    assert Basket.objects.filter(user=user).count() == 1
+    clear_and_delete_baskets()
+    assert Basket.objects.filter(user=user).count() == 0
+
+
+def test_active_baskets_are_not_deleted(mocker, user, basket_and_coupons):
+    """Test that the active baskets are not deleted on calling clear_and_delete_baskets fn without user argument"""
+    basket_and_coupons.basket.user = user
+    basket_and_coupons.basket.save()
+
+    mocker.patch("django.conf.settings.BASKET_EXPIRY_DAYS", 15)
+    assert Basket.objects.filter(user=user).count() == 1
+    clear_and_delete_baskets()
+    assert Basket.objects.filter(user=user).count() == 1
+
+    
 def test_complete_order(mocker, user, basket_and_coupons):
     """
     Test that complete_order enrolls a user in the items in their order and clears out checkout-related objects
@@ -1106,7 +1150,7 @@ def test_complete_order(mocker, user, basket_and_coupons):
     patched_enroll.assert_called_once_with(order)
     patched_clear_and_delete_baskets.assert_called_once_with(mocker.ANY)
     assert (
-        patched_clear_and_delete_baskets.call_args[0][0][0] == basket_and_coupons.basket
+        patched_clear_and_delete_baskets.call_args[0][0][0] == basket_and_coupons.basket.user
     )
 
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1143,7 +1143,7 @@ def test_complete_order(mocker, user, basket_and_coupons):
     patched_enroll.assert_called_once_with(order)
     patched_clear_and_delete_baskets.assert_called_once_with(mocker.ANY)
     assert (
-        patched_clear_and_delete_baskets.call_args[0][0][0] == basket_and_coupons.basket.user
+        patched_clear_and_delete_baskets.call_args[0][0] == basket_and_coupons.basket.user
     )
 
 

--- a/ecommerce/conftest.py
+++ b/ecommerce/conftest.py
@@ -31,21 +31,6 @@ CouponGroup = namedtuple(  # noqa: PYI024
 
 
 @pytest.fixture
-def baskets_with_different_users():
-    """
-    Multiple baskets for different users
-    """
-    user1 = UserFactory.create()
-    basket1 = BasketFactory.create(user=user1)
-
-    user2 = UserFactory.create()
-    basket2 = BasketFactory.create(user=user2)
-
-
-    return SimpleNamespace(baskets=[basket1, basket2])
-
-
-@pytest.fixture
 def basket_and_coupons():
     """
     Sample basket and coupon

--- a/ecommerce/conftest.py
+++ b/ecommerce/conftest.py
@@ -9,7 +9,6 @@ import pytest
 from ecommerce.api import ValidatedBasket
 from ecommerce.constants import DISCOUNT_TYPE_PERCENT_OFF
 from ecommerce.factories import (
-    BasketFactory,
     BasketItemFactory,
     CompanyFactory,
     CouponEligibilityFactory,
@@ -23,7 +22,6 @@ from ecommerce.factories import (
     ProductVersionFactory,
 )
 from ecommerce.models import CourseRunSelection
-from users.factories import UserFactory
 
 CouponGroup = namedtuple(  # noqa: PYI024
     "CouponGroup", ["coupon", "coupon_version", "payment", "payment_version"]

--- a/ecommerce/conftest.py
+++ b/ecommerce/conftest.py
@@ -25,7 +25,6 @@ from ecommerce.factories import (
 from ecommerce.models import CourseRunSelection
 from users.factories import UserFactory
 
-
 CouponGroup = namedtuple(  # noqa: PYI024
     "CouponGroup", ["coupon", "coupon_version", "payment", "payment_version"]
 )
@@ -41,7 +40,7 @@ def baskets_with_different_users():
 
     user2 = UserFactory.create()
     basket2 = BasketFactory.create(user=user2)
-    
+
 
     return SimpleNamespace(baskets=[basket1, basket2])
 

--- a/ecommerce/conftest.py
+++ b/ecommerce/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from ecommerce.api import ValidatedBasket
 from ecommerce.constants import DISCOUNT_TYPE_PERCENT_OFF
 from ecommerce.factories import (
+    BasketFactory,
     BasketItemFactory,
     CompanyFactory,
     CouponEligibilityFactory,
@@ -22,10 +23,27 @@ from ecommerce.factories import (
     ProductVersionFactory,
 )
 from ecommerce.models import CourseRunSelection
+from users.factories import UserFactory
+
 
 CouponGroup = namedtuple(  # noqa: PYI024
     "CouponGroup", ["coupon", "coupon_version", "payment", "payment_version"]
 )
+
+
+@pytest.fixture
+def baskets_with_different_users():
+    """
+    Multiple baskets for different users
+    """
+    user1 = UserFactory.create()
+    basket1 = BasketFactory.create(user=user1)
+
+    user2 = UserFactory.create()
+    basket2 = BasketFactory.create(user=user2)
+    
+
+    return SimpleNamespace(baskets=[basket1, basket2])
 
 
 @pytest.fixture

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -5,7 +5,6 @@ import logging
 from ecommerce.api import clear_and_delete_baskets
 from mitxpro.celery import app
 
-
 log = logging.getLogger(__name__)
 
 

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -1,14 +1,10 @@
 """Ecommerce Tasks"""
 
 import logging
-from datetime import timedelta
 
-from django.conf import settings
-from django.db import transaction
 from ecommerce.api import clear_and_delete_baskets
-from ecommerce.models import Basket
 from mitxpro.celery import app
-from mitxpro.utils import now_in_utc
+
 
 log = logging.getLogger(__name__)
 
@@ -18,13 +14,4 @@ def delete_expired_baskets(self):
     """Deletes the expired baskets"""
     log.info("Task ID: %s", self.request.id)
 
-    cutoff_date = now_in_utc() - timedelta(days=settings.BASKET_EXPIRY_DAYS)
-    log.info("Starting the deletion of expired baskets at %s", now_in_utc())
-
-    with transaction.atomic():
-        expired_baskets = Basket.objects.select_for_update(skip_locked=True).filter(
-            updated_on__lte=cutoff_date
-        )
-        log.info("Found %d expired baskets to delete", len(expired_baskets))
-        if expired_baskets:
-            clear_and_delete_baskets(expired_baskets)
+    clear_and_delete_baskets()

--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -4,7 +4,7 @@ import logging
 from datetime import timedelta
 
 from django.conf import settings
-
+from django.db import transaction
 from ecommerce.api import clear_and_delete_baskets
 from ecommerce.models import Basket
 from mitxpro.celery import app
@@ -21,9 +21,10 @@ def delete_expired_baskets(self):
     cutoff_date = now_in_utc() - timedelta(days=settings.BASKET_EXPIRY_DAYS)
     log.info("Starting the deletion of expired baskets at %s", now_in_utc())
 
-    expired_baskets = Basket.objects.select_for_update(skip_locked=True).filter(
-        updated_on__lte=cutoff_date
-    )
-    log.info("Found %d expired baskets to delete", len(expired_baskets))
-    if expired_baskets:
-        clear_and_delete_baskets(expired_baskets)
+    with transaction.atomic():
+        expired_baskets = Basket.objects.select_for_update(skip_locked=True).filter(
+            updated_on__lte=cutoff_date
+        )
+        log.info("Found %d expired baskets to delete", len(expired_baskets))
+        if expired_baskets:
+            clear_and_delete_baskets(expired_baskets)

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -10,4 +10,4 @@ def test_delete_expired_baskets(mocker):
     )
 
     tasks.delete_expired_baskets.delay()
-    patched_clear_and_delete_baskets.assert_called_once_with(mocker.ANY)
+    patched_clear_and_delete_baskets.assert_called_once_with()

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -1,44 +1,13 @@
 """Ecommerce Tasks Tests"""
 
-import datetime
-
-from django.conf import settings
-
 from ecommerce import tasks
 
 
-def test_delete_expired_baskets(mocker, user, basket_and_coupons):
+def test_delete_expired_baskets(mocker):
     """Test that the expired baskets are deleted on task run"""
     patched_clear_and_delete_baskets = mocker.patch(
         "ecommerce.tasks.clear_and_delete_baskets"
     )
 
-    basket_and_coupons.basket.user = user
-    basket_and_coupons.basket.save()
-
-    now_in_utc = mocker.patch("ecommerce.tasks.now_in_utc")
-    now_in_utc.return_value = datetime.datetime.now(
-        tz=datetime.timezone.utc
-    ) + datetime.timedelta(days=settings.BASKET_EXPIRY_DAYS)
-
     tasks.delete_expired_baskets.delay()
-
     patched_clear_and_delete_baskets.assert_called_once_with(mocker.ANY)
-    assert (
-        patched_clear_and_delete_baskets.call_args[0][0][0] == basket_and_coupons.basket
-    )
-
-
-def test_active_baskets_are_not_deleted(mocker, user, basket_and_coupons):
-    """Test that the active baskets are not deleted on task run"""
-    patched_clear_and_delete_baskets = mocker.patch(
-        "ecommerce.tasks.clear_and_delete_baskets"
-    )
-
-    basket_and_coupons.basket.user = user
-    basket_and_coupons.basket.save()
-
-    mocker.patch("django.conf.settings.BASKET_EXPIRY_DAYS", 15)
-
-    tasks.delete_expired_baskets.delay()
-    patched_clear_and_delete_baskets.assert_not_called()


### PR DESCRIPTION
### What are the relevant tickets?
Followup for https://github.com/mitodl/mitxpro/pull/3021

### Description (What does it do?)
We were getting [some errors](https://mit-office-of-digital-learning.sentry.io/issues/5715458782/?project=1413655&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0) while testing the functionality of [this PR](https://github.com/mitodl/mitxpro/pull/3021) on RC. This PR fixes those errors.


### How can this be tested?
- Validate that the checkout page is working properly

1 In the .env file set the value `BASKET_EXPIRY_DAYS=0` ( warning: this will delete all your baskets )
2 For any course, open the checkout page and don't complete the order. ( You can leave this step if you have existing basket and basket items )
3 Open the mitxpro shell by running `python manage.py shell` in the mitxpro directory
4 Run the following code in the shell:
```
>>> from ecommerce.models import Basket, BasketItem
>>> Basket.objects.all().count()
< number of existing baskets >
>>> BasketItem.objects.all().count()
< number of existing basket items >
```
5 Now run the following code
```
>>> from ecommerce.tasks import delete_expired_baskets
>>> delete_expired_baskets.delay()
``` 
6 In the celery logs, see the logs of this task. The task should be executed successfully and should show some useful logs.
7 Run the code in step 4 again. This time, the count will return 0
