### PR TITLE
fix: silently fail name validation on connection error

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -14,6 +14,7 @@ from django.shortcuts import reverse
 from edx_api.client import EdxApi
 from oauth2_provider.models import AccessToken, Application
 from oauthlib.common import generate_token
+from requests.exceptions import ConnectionError as RequestConnectionError
 from requests.exceptions import HTTPError
 from rest_framework import status
 
@@ -848,6 +849,9 @@ def validate_name_with_edx(name):
         response = edx_client.user_validation.validate_user_registration_info(
             registration_information={"name": name},
         )
+    except RequestConnectionError:
+        # Silently fail if connection cannot be established with the open edx instance.
+        return ""
     except Exception as exc:
         raise EdxApiRegistrationValidationException(name, exc.response) from exc
     else:

--- a/courseware/exceptions.py
+++ b/courseware/exceptions.py
@@ -78,7 +78,10 @@ class EdxApiRegistrationValidationException(Exception):  # noqa: N818
         """
         self.name = name
         self.response = error_response
+        error_summary = (
+            get_error_response_summary(self.response) if self.response else ""
+        )
         if msg is None:
             # Set some default useful error message
-            msg = f"EdX API error validating registration name {self.name}.\n{get_error_response_summary(self.response)}"
+            msg = f"EdX API error validating registration name {self.name}.\n{error_summary}"
         super().__init__(msg)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Silently fail if name validation on connection error(Will be helpful for local setups). Also, fixes an issue with the exception msg when the response is None.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Test that the name is validated against open edX and an appropriate error is raised and displayed to the user.
- Test that registration is successful when ConnectionError is thrown(open edX is down).
