### PR TITLE
feat: display tax details for countries where taxes are enabled

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -156,6 +156,21 @@ def calculate_tax(
     return (0, "", item_price)
 
 
+def display_taxes(user):
+    """
+    Calculates the taxes display for a specific user.
+
+    Args:
+        user(users.User): User object
+    """
+    return (
+        settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False)
+        and user.is_authenticated
+        and user.legal_address.country
+        in TaxRate.objects.filter(active=True).values_list("country_code", flat=True)
+    )
+
+
 def generate_cybersource_sa_signature(payload):
     """
     Generate an HMAC SHA256 signature for the CyberSource Secure Acceptance payload

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -169,8 +169,9 @@ def display_taxes(user):
     return (
         settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False)
         and user.is_authenticated
-        and user.legal_address.country
-        in TaxRate.objects.filter(active=True).values_list("country_code", flat=True)
+        and TaxRate.objects.filter(
+            active=True, country_code=user.legal_address.country
+        ).exists()
     )
 
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -156,22 +156,20 @@ def calculate_tax(
     return (0, "", item_price)
 
 
-def display_taxes(user):
+def display_taxes(request):
     """
     Returns a boolean to manage the taxes display.
 
     Args:
-        user(users.User): User object
+        request(HttpRequest): Request object
 
     Returns:
         Boolean: True if flag and taxes are enabled for the specific country.
     """
+    visitor_country = determine_visitor_country(request)
     return (
         settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False)
-        and user.is_authenticated
-        and TaxRate.objects.filter(
-            active=True, country_code=user.legal_address.country
-        ).exists()
+        and TaxRate.objects.filter(active=True, country_code=visitor_country).exists()
     )
 
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -158,10 +158,13 @@ def calculate_tax(
 
 def display_taxes(user):
     """
-    Calculates the taxes display for a specific user.
+    Returns a boolean to manage the taxes display.
 
     Args:
         user(users.User): User object
+
+    Returns:
+        Boolean: True if flag and taxes are enabled for the specific country.
     """
     return (
         settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False)

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -21,7 +21,6 @@ from mail.constants import (
     EMAIL_WELCOME_COURSE_RUN_ENROLLMENT,
 )
 from mitxpro.utils import format_price
-from users.models import User
 
 log = logging.getLogger()
 ENROLL_ERROR_EMAIL_SUBJECT = "MIT xPRO enrollment error"
@@ -298,7 +297,6 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
         cyber_source_provided_email: Include the email address if user provide though CyberSource payment process.
         order: An order.
     """
-    from ecommerce.api import display_taxes
     from ecommerce.serializers import OrderReceiptSerializer
 
     data = OrderReceiptSerializer(instance=order).data
@@ -308,7 +306,6 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
     order = data.get("order")
     receipt = data.get("receipt")
     country = pycountry.countries.get(alpha_2=purchaser.get("country"))
-    user = User.objects.get(email=purchaser.get("email"))
     recipients = [purchaser.get("email")]
     if cyber_source_provided_email and cyber_source_provided_email not in recipients:
         recipients.append(cyber_source_provided_email)
@@ -359,7 +356,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                                     "company": purchaser.get("company"),
                                     "vat_id": purchaser.get("vat_id"),
                                 },
-                                "enable_taxes_display": display_taxes(user),
+                                "enable_taxes_display": bool(order["tax_rate"]),
                             },
                         ),
                     )

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -21,6 +21,7 @@ from mail.constants import (
     EMAIL_WELCOME_COURSE_RUN_ENROLLMENT,
 )
 from mitxpro.utils import format_price
+from users.models import User
 
 log = logging.getLogger()
 ENROLL_ERROR_EMAIL_SUBJECT = "MIT xPRO enrollment error"
@@ -297,6 +298,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
         cyber_source_provided_email: Include the email address if user provide though CyberSource payment process.
         order: An order.
     """
+    from ecommerce.api import display_taxes
     from ecommerce.serializers import OrderReceiptSerializer
 
     data = OrderReceiptSerializer(instance=order).data
@@ -306,6 +308,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
     order = data.get("order")
     receipt = data.get("receipt")
     country = pycountry.countries.get(alpha_2=purchaser.get("country"))
+    user = User.objects.get(email=purchaser.get("email"))
     recipients = [purchaser.get("email")]
     if cyber_source_provided_email and cyber_source_provided_email not in recipients:
         recipients.append(cyber_source_provided_email)
@@ -356,9 +359,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                                     "company": purchaser.get("company"),
                                     "vat_id": purchaser.get("vat_id"),
                                 },
-                                "enable_taxes_display": settings.FEATURES.get(
-                                    "ENABLE_TAXES_DISPLAY", False
-                                ),
+                                "enable_taxes_display": display_taxes(user),
                             },
                         ),
                     )

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -22,7 +22,7 @@
       Cambridge, MA 02139 USA
       <br />
       {% if enable_taxes_display %}
-      GSTIN: Pending
+      GSTIN: 9923USA29055OSB
       <br />
       {% endif %}
       Support:

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -581,6 +581,8 @@ def get_js_settings(request: HttpRequest):
     Returns:
         dict: the settings object
     """
+    from ecommerce.api import display_taxes
+
     return {
         "gtmTrackingID": settings.GTM_TRACKING_ID,
         "gaTrackingID": settings.GA_TRACKING_ID,
@@ -600,7 +602,7 @@ def get_js_settings(request: HttpRequest):
         "course_dropdown": settings.FEATURES.get("COURSE_DROPDOWN", False),
         "webinars": settings.FEATURES.get("WEBINARS", False),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
-        "enable_taxes_display": settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False),
+        "enable_taxes_display": display_taxes(request.user),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
     }
 

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -602,7 +602,7 @@ def get_js_settings(request: HttpRequest):
         "course_dropdown": settings.FEATURES.get("COURSE_DROPDOWN", False),
         "webinars": settings.FEATURES.get("WEBINARS", False),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
-        "enable_taxes_display": display_taxes(request.user),
+        "enable_taxes_display": display_taxes(request),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
     }
 

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -455,7 +455,7 @@ def test_request_get_with_timeout_retry(mocker):
     assert result == mock_response
 
 
-def test_get_js_settings(settings, rf):
+def test_get_js_settings(settings, rf, user):
     """Test get_js_settings"""
     settings.GA_TRACKING_ID = "fake"
     settings.GTM_TRACKING_ID = "fake"
@@ -477,6 +477,7 @@ def test_get_js_settings(settings, rf):
     settings.FEATURES["ENABLE_ENTERPRISE"] = False
 
     request = rf.get("/")
+    request.user = user
 
     assert get_js_settings(request) == {
         "gaTrackingID": "fake",

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -106,7 +106,7 @@ export class ReceiptPage extends React.Component<Props> {
                         NE49-2000
                         <br />
                         Cambridge, MA 02139 USA
-                        {SETTINGS.enable_taxes_display ? (
+                        {orderReceipt.order.tax_rate ? (
                           <div>GSTIN: 9923USA29055OSB</div>
                         ) : (
                           <br />
@@ -253,10 +253,10 @@ export class ReceiptPage extends React.Component<Props> {
                         <th>Quantity</th>
                         <th>Unit Price</th>
                         <th>Discount</th>
-                        {SETTINGS.enable_taxes_display ? (
+                        {orderReceipt.order.tax_rate ? (
                           <th>Total Before Tax</th>
                         ) : null}
-                        {SETTINGS.enable_taxes_display ? (
+                        {orderReceipt.order.tax_rate ? (
                           <th>
                             Tax ({formatNumber(orderReceipt.order.tax_rate)}%)
                           </th>
@@ -296,14 +296,14 @@ export class ReceiptPage extends React.Component<Props> {
                               <p>Discount</p>
                               <div>{formatDiscount(line.discount)}</div>
                             </td>
-                            {SETTINGS.enable_taxes_display ? (
+                            {orderReceipt.order.tax_rate ? (
                               <td>
                                 <p>Total Before Tax</p>
                                 <div>{formatPrice(line.total_before_tax)}</div>
                               </td>
                             ) : null}
 
-                            {SETTINGS.enable_taxes_display ? (
+                            {orderReceipt.order.tax_rate ? (
                               <td>
                                 <p>
                                   Tax (
@@ -321,11 +321,11 @@ export class ReceiptPage extends React.Component<Props> {
                       })}
                     </tbody>
                   </table>
-                  {SETTINGS.enable_taxes_display ? (
+                  {orderReceipt.order.tax_rate ? (
                     <div className="receipt-hsn">HSN: 9992</div>
                   ) : null}
                 </div>
-                {SETTINGS.enable_taxes_display ? (
+                {orderReceipt.order.tax_rate ? (
                   <div className="footnote-signature">
                     <img
                       src="static/images/receipts/signature_only.png"

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -107,7 +107,7 @@ export class ReceiptPage extends React.Component<Props> {
                         <br />
                         Cambridge, MA 02139 USA
                         {SETTINGS.enable_taxes_display ? (
-                          <div>GSTIN: Pending</div>
+                          <div>GSTIN: 9923USA29055OSB</div>
                         ) : null}
                         Support:{" "}
                         <a href={`mailto:${SETTINGS.support_email}`}>

--- a/static/js/containers/pages/ReceiptPage.js
+++ b/static/js/containers/pages/ReceiptPage.js
@@ -108,7 +108,9 @@ export class ReceiptPage extends React.Component<Props> {
                         Cambridge, MA 02139 USA
                         {SETTINGS.enable_taxes_display ? (
                           <div>GSTIN: 9923USA29055OSB</div>
-                        ) : null}
+                        ) : (
+                          <br />
+                        )}
                         Support:{" "}
                         <a href={`mailto:${SETTINGS.support_email}`}>
                           {SETTINGS.support_email}

--- a/static/scss/receipt.scss
+++ b/static/scss/receipt.scss
@@ -261,11 +261,20 @@ $label-color: #8a8b8c;
     display: none !important;
   }
 
+  iframe[title="Message from company"],
+  iframe[title="Close message"] {
+    display: none !important;
+  }
+
   .receipt-wrapper {
     padding: 0 15px;
     font:
       500 16px/21px Rajdhani,
       "Times New Roman",
       serif;
+
+    .footnote-signature {
+      padding-top: 300px;
+    }
   }
 }

--- a/static/scss/receipt.scss
+++ b/static/scss/receipt.scss
@@ -257,7 +257,8 @@ $label-color: #8a8b8c;
   .print-btn,
   .print-row,
   .footer,
-  .header-holder {
+  .header-holder,
+  .notifications {
     display: none !important;
   }
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/5250

### Description (What does it do?)
<!--- Describe your changes in detail -->
Hides tax details for countries where taxes are not enabled. This includes changes on the Checkout Page, Email Receipt, and Dashboard Receipt Details. It also updates the signature display in the receipt PDF and removes the zendesk help widget text from the receipt.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

With Taxes Enabled:
<img width="1344" alt="Screenshot 2024-08-22 at 2 58 29 PM" src="https://github.com/user-attachments/assets/8b2c3318-5367-4e5e-9ea5-e7970f0d3633">
<img width="1227" alt="Screenshot 2024-08-22 at 3 02 11 PM" src="https://github.com/user-attachments/assets/341a9ff0-4d32-408a-aa98-713ef1b7db4b">
<img width="1227" alt="Screenshot 2024-08-22 at 3 05 42 PM" src="https://github.com/user-attachments/assets/650bb6d7-53fb-4ea7-9b03-1ec8dada4b1d">
<img width="1227" alt="Screenshot 2024-08-22 at 3 06 17 PM" src="https://github.com/user-attachments/assets/6e008986-1c14-4b70-9c6e-772d10143c16">

With Taxes Disabled:
<img width="1146" alt="Screenshot 2024-08-22 at 2 58 46 PM" src="https://github.com/user-attachments/assets/38882976-581c-4e16-9912-5633378f86e6">
<img width="1227" alt="Screenshot 2024-08-22 at 2 59 24 PM" src="https://github.com/user-attachments/assets/00710166-9ce0-495a-a985-e8aef2047a81">
<img width="1227" alt="Screenshot 2024-08-22 at 3 00 42 PM" src="https://github.com/user-attachments/assets/7adb4a8c-8337-40d8-8c8b-e04e125c0930">


Receipt Signatures:
[MIT xPRO _ Receipt.pdf](https://github.com/user-attachments/files/16709938/MIT.xPRO._.Receipt.pdf)



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- To test NO Taxes:
  - Disable FEATURE_ENABLE_TAXES_DISPLAY in .env, You won't see any taxes in the checkout, receipt email, and dashboard receipt.
  - Enabled FEATURE_ENABLE_TAXES_DISPLAY, Add a TaxRate in admin for any other country or your country but disable it. You should not see any taxes as there is no active tax rate for your country.
- Test Taxes Enabled.
  - Created TaxRate with active state. You should see taxes on the checkout page, email receipt, and dashboard receipt.
- Verify that the signatures are at the bottom of the page for the PDF Receipt.
- Verify that you do not see the Zendesk widget text in receipt.