### PR TITLE
fix: use support email address from configurations(settings)

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -357,6 +357,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                                     "vat_id": purchaser.get("vat_id"),
                                 },
                                 "enable_taxes_display": bool(order["tax_rate"]),
+                                "email_support": settings.EMAIL_SUPPORT,
                             },
                         ),
                     )

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -346,6 +346,7 @@ def test_send_ecommerce_order_receipt(mocker, receipt_data, settings):
                 "vat_id": "AT12349876",
             },
             "enable_taxes_display": False,
+            "email_support": settings.EMAIL_SUPPORT,
         },
     )
     patched_mail_api.messages_for_recipients.assert_called_once_with(

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -26,8 +26,8 @@
       <br />
       {% endif %}
       Support:
-      <a href="mailto:support@xpro.mit.edu">
-        support@xpro.mit.edu
+      <a href="mailto:{{ email_support }}">
+        {{ email_support }}
       </a>
       <br />
     </p>


### PR DESCRIPTION
### What are the relevant tickets?
[#4841](https://github.com/mitodl/hq/issues/4841)

### Description (What does it do?)
This PR uses support email address from configurations(settings) in order receipts template.

### Screenshots (if appropriate):
<img width="888" alt="image" src="https://github.com/user-attachments/assets/a111574a-c386-4f31-b188-7c2283deaa3d">

### How can this be tested?
- Ensure that your XPro environment is properly configured.
- Perform an enrollment, and you should receive a "Purchase Order Receipt" email with the support email address pulled from the configurations (settings).

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
