### PR TITLE
Revert "fix(deps): update dependency sass to ~1.78.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "redux-logger": "^3.0.6",
     "redux-query": "^2.3.1",
     "reselect": "^4.0.0",
-    "sass": "~1.78.0",
+    "sass": "~1.64.2",
     "sass-lint": "^1.13.1",
     "sass-loader": "^12.1.0",
     "serialize-javascript": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8853,7 +8853,7 @@ __metadata:
     redux-logger: ^3.0.6
     redux-query: ^2.3.1
     reselect: ^4.0.0
-    sass: ~1.78.0
+    sass: ~1.64.2
     sass-lint: ^1.13.1
     sass-loader: ^12.1.0
     serialize-javascript: ^3.1.0
@@ -11193,16 +11193,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:~1.78.0":
-  version: 1.78.0
-  resolution: "sass@npm:1.78.0"
+"sass@npm:~1.64.2":
+  version: 1.64.2
+  resolution: "sass@npm:1.64.2"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: ea856bd224c85d831a5800195750c2dd008d101771d071dbaca886c47fe4f131c30c328755d7a974ad944ba5b3aafa7a9f6010952da306436dcebddb41580e1c
+  checksum: 43a5c9b9b3b6ba27feb5c45eba90edc437b15a30fd443f5d2623bbd59fe4a922f2a6a9990296c6a6c2b5bce7f401922c5049357415f50b745952c2d478bc5526
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit 11c79361f30bf36696f0c4cd72613a5ee5de3f02.

### What are the relevant tickets?
No ticket is created.

### Description (What does it do?)
I've noticed some warnings on the xPro local environment, due to the auto-merged Renovate PR: https://github.com/mitodl/mitxpro/pull/3131.

```
watch-1   | LOG from ./node_modules/sass-loader/dist/cjs.js sass-loader ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./static/scss/layout.scss
watch-1   | <w> Deprecation Passing percentage units to the global abs() function is deprecated.
watch-1   | <w> In the future, this will emit a CSS abs() function to be resolved by the browser.
watch-1   | <w> To preserve current behavior: math.abs(100%)
watch-1   | <w> To emit a CSS abs() now: abs(#{100%})
watch-1   | <w> More info: https://sass-lang.com/d/abs-percent
watch-1   | <w> 
watch-1   | <w> node_modules/bootstrap/scss/vendor/_rfs.scss 54:14             divide()
watch-1   | <w> node_modules/bootstrap/scss/mixins/_grid.scss 66:15            row-cols()
watch-1   | <w> node_modules/bootstrap/scss/mixins/_grid-framework.scss 43:13  @content
watch-1   | <w> node_modules/bootstrap/scss/mixins/_breakpoints.scss 65:5      media-breakpoint-up()
watch-1   | <w> node_modules/bootstrap/scss/mixins/_grid-framework.scss 32:5   make-grid-columns()
watch-1   | <w> node_modules/bootstrap/scss/_grid.scss 72:3                    @import
watch-1   | <w> node_modules/bootstrap/scss/bootstrap.scss 16:9                @import
watch-1   | <w> static/scss/layout.scss 6:9                                    root stylesheet
watch-1   | <w> 
watch-1   | <w> Deprecation Sass's behavior for declarations that appear after nested
watch-1   | <w> rules will be changing to match the behavior specified by CSS in an upcoming
watch-1   | <w> version. To keep the existing behavior, move the declaration above the nested
watch-1   | <w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
watch-1   | <w> 
watch-1   | <w> More info: https://sass-lang.com/d/mixed-decls
watch-1   | <w> 
watch-1   | <w> node_modules/bootstrap/scss/_custom-forms.scss 415:5  @import
watch-1   | <w> node_modules/bootstrap/scss/bootstrap.scss 24:9       @import
watch-1   | <w> static/scss/layout.scss 6:9                           root stylesheet
watch-1   | <w> 
watch-1   | <w> Deprecation Sass's behavior for declarations that appear after nested
watch-1   | <w> rules will be changing to match the behavior specified by CSS in an upcoming
watch-1   | <w> version. To keep the existing behavior, move the declaration above the nested
watch-1   | <w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
watch-1   | <w> 
watch-1   | <w> More info: https://sass-lang.com/d/mixed-decls
watch-1   | <w> 
watch-1   | <w> node_modules/bootstrap/scss/_custom-forms.scss 441:5  @import
watch-1   | <w> node_modules/bootstrap/scss/bootstrap.scss 24:9       @import
watch-1   | <w> static/scss/layout.scss 6:9                           root stylesheet
watch-1   | <w> 
watch-1   | <w> Deprecation Sass's behavior for declarations that appear after nested
watch-1   | <w> rules will be changing to match the behavior specified by CSS in an upcoming
watch-1   | <w> version. To keep the existing behavior, move the declaration above the nested
watch-1   | <w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
watch-1   | <w> 
watch-1   | <w> More info: https://sass-lang.com/d/mixed-decls
watch-1   | <w> 
watch-1   | <w> node_modules/bootstrap/scss/_custom-forms.scss 470:5  @import
watch-1   | <w> node_modules/bootstrap/scss/bootstrap.scss 24:9       @import
watch-1   | <w> static/scss/layout.scss 6:9                           root stylesheet
watch-1   | <w> 
watch-1   | <w> Deprecation Sass's behavior for declarations that appear after nested
watch-1   | <w> rules will be changing to match the behavior specified by CSS in an upcoming
watch-1   | <w> version. To keep the existing behavior, move the declaration above the nested
watch-1   | <w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
watch-1   | <w> 
watch-1   | <w> More info: https://sass-lang.com/d/mixed-decls
watch-1   | <w> 
watch-1   | <w> node_modules/bootstrap/scss/_navbar.scss 174:9             @content
watch-1   | <w> node_modules/bootstrap/scss/mixins/_breakpoints.scss 65:5  media-breakpoint-up()
watch-1   | <w> node_modules/bootstrap/scss/_navbar.scss 173:7             @import
watch-1   | <w> node_modules/bootstrap/scss/bootstrap.scss 26:9            @import
watch-1   | <w> static/scss/layout.scss 6:9                                root stylesheet
watch-1   | <w> 
watch-1   | <w> Deprecation Sass's behavior for declarations that appear after nested
watch-1   | <w> rules will be changing to match the behavior specified by CSS in an upcoming
watch-1   | <w> version. To keep the existing behavior, move the declaration above the nested
watch-1   | <w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
watch-1   | <w> 
watch-1   | <w> More info: https://sass-lang.com/d/mixed-decls
watch-1   | <w> 
watch-1   | <w> node_modules/bootstrap/scss/_navbar.scss 175:9             @content
watch-1   | <w> node_modules/bootstrap/scss/mixins/_breakpoints.scss 65:5  media-breakpoint-up()
watch-1   | <w> node_modules/bootstrap/scss/_navbar.scss 173:7             @import
watch-1   | <w> node_modules/bootstrap/scss/bootstrap.scss 26:9            @import
watch-1   | <w> static/scss/layout.scss 6:9                                root stylesheet
watch-1   | <w> 
watch-1   | <w> 40 repetitive deprecation warnings omitted.
watch-1   | <w> 
watch-1   | <w> null
watch-1   | 
watch-1   | webpack 5.94.0 compiled successfully in 29370 ms
```

According to the comments in this [link](https://github.com/mitodl/mitxpro/pull/3015#issuecomment-2226369739) https://github.com/mitodl/mitxpro/pull/3015#issuecomment-2226369739, the issue is resolved only in [Bootstrap v5.3.2 ](https://github.com/twbs/bootstrap/releases/tag/v5.3.2)and beyond.
We need to revert this to avoid releasing it on RC until https://github.com/mitodl/mitxpro/pull/3079 is merged.

Note: The Bootstrap dependency upgrade to v5 is still a `work in progress`, as per the label in this PR https://github.com/mitodl/mitxpro/pull/3079.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- Check out this branch and run `docker-compose up`. There should be no related warnings appearing.
- Check that all main pages are working.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
