### PR TITLE
refactor: standardize Catalog & API courseware

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -30,51 +30,36 @@ def get_catalog_sorting_keys(sorting, *, reverse):
     }
 
 
-def filter_and_sort_catalog_pages(
-    program_pages,
-    course_pages,
-    external_course_pages,
-    external_program_pages,
-    sort_by,
-):
+def sort_catalog_pages(program_pages, course_pages, sort_by):
     """
-    Filters program and course pages to only include those that should be visible in the catalog, then returns a tuple
+    Sorts program and course pages based on run dates and sort_by, then returns a tuple
     of sorted lists of pages
 
     Args:
-        program_pages (iterable of ProgramPage): ProgramPages to filter and sort
-        course_pages (iterable of CoursePage): CoursePages to filter and sort
-        external_course_pages (iterable of ExternalCoursePage): ExternalCoursePages to filter and sort
-        external_program_pages (iterable of ExternalProgramPage): ExternalProgramPages to filter and sort
+        program_pages (iterable of ProgramPage): ProgramPages/ExternalProgramPages to filter and sort
+        course_pages (iterable of CoursePage): CoursePages/ExternalCoursePages to filter and sort
         sort_by (str): Sorting applicable.
 
     Returns:
         tuple of (list of Pages): A tuple containing a list of combined ProgramPages, CoursePages, ExternalCoursePages and ExternalProgramPages, a list of
             ProgramPages and ExternalProgramPages, and a list of CoursePages and ExternalCoursePages, all sorted by the sort_by option.
     """
-    all_program_pages = program_pages + external_program_pages
-    all_course_pages = course_pages + external_course_pages
-
-    valid_program_pages = [
-        page for page in all_program_pages if page.product.is_catalog_visible
-    ]
-    valid_course_pages = [
-        page for page in all_course_pages if page.product.is_catalog_visible
-    ]
 
     page_run_dates = {
         page: page.product.next_run_date
         or datetime(year=MAXYEAR, month=1, day=1, tzinfo=UTC)
         for page in itertools.chain(
-            valid_program_pages,
-            valid_course_pages,
+            program_pages,
+            course_pages,
         )
     }
 
     price_desc_sorting_key = lambda page: (  # noqa: E731
-        page.product.current_price
-        if page.product.current_price is not None
-        else float("-inf"),
+        (
+            page.product.current_price
+            if page.product.current_price is not None
+            else float("-inf")
+        ),
         page.title,
     )
     price_asc_sorting_key = lambda page: (  # noqa: E731
@@ -98,17 +83,17 @@ def filter_and_sort_catalog_pages(
 
     return (
         sorted(
-            valid_program_pages + valid_course_pages,
+            program_pages + course_pages,
             key=sorting["sorting_key"]["all"],
             reverse=sorting["reverse"],
         ),
         sorted(
-            valid_program_pages,
+            program_pages,
             key=sorting["sorting_key"]["programs"],
             reverse=sorting["reverse"],
         ),
         sorted(
-            valid_course_pages,
+            course_pages,
             key=sorting["sorting_key"]["courses"],
             reverse=sorting["reverse"],
         ),

--- a/cms/templates/partials/card_details_top.html
+++ b/cms/templates/partials/card_details_top.html
@@ -37,12 +37,7 @@
       {{ courseware_page.duration }}
     </li>
     {% endif %}
-    {% if courseware_page.is_external_page and courseware_page.next_run_date %}
-    <li>
-      <strong>Next Start Date:</strong>
-      {{ courseware_page.next_run_date|date:"F j, Y" }}
-    </li>
-    {% elif courseware_page.product.next_run_date %}
+    {% if courseware_page.product.next_run_date %}
     <li>
       <strong>Next Start Date:</strong>
       {{ courseware_page.product.next_run_date|date:"F j, Y" }}

--- a/courses/data_provider.py
+++ b/courses/data_provider.py
@@ -1,0 +1,285 @@
+from django.db.models import Prefetch, Q
+
+from cms.models import CoursePage, ExternalCoursePage, ExternalProgramPage, ProgramPage
+from courses.models import Course, CourseRun, Program
+from ecommerce.models import Product
+from mitxpro.utils import now_in_utc
+
+
+class DataProvider:
+    """This should serve as the source of truth for all course/program pages/django objects filters"""
+
+    def get_courseware_filter(self, relative_filter="", sub_filter=""):
+        """
+        Generates course/program filter for the catalog visible and API consumable courses/programs.
+
+        Args:
+            relative_filter (str): A string representing the main filter
+            sub_filter (str): A string representing the sub filter that combines with the main filter to do extra filtering
+
+        Returns:
+            Q: Returns a Q object to apply on course/program models
+
+        """
+        relative_filter = relative_filter + sub_filter
+
+        courseware_live_filter = {
+            f"{relative_filter}live": True,
+            f"{relative_filter}courseruns__live": True,
+        }
+        courserun_start_date_filter = {
+            f"{relative_filter}courseruns__start_date__isnull": False,
+            f"{relative_filter}courseruns__start_date__gt": now_in_utc(),
+        }
+        courserun_enrollment_end_filter = {
+            f"{relative_filter}courseruns__enrollment_end__isnull": False,
+            f"{relative_filter}courseruns__enrollment_end__gt": now_in_utc(),
+        }
+        return Q(
+            Q(**courseware_live_filter)
+            & Q(Q(**courserun_start_date_filter) | Q(**courserun_enrollment_end_filter))
+        )
+
+    def get_data(self, filter_topic=None):
+        """
+        Method to get the data from the provider. Should be overridden in child classes
+
+        Args:
+            filter_topic (str): A string representing the the name of a topic
+
+        Returns:
+            QuerySet: Returns a QuerySet after applying all the filters
+        """
+        raise NotImplementedError
+
+
+class CourseProvider(DataProvider):
+    """Provider class to handle all Course (Django model) related queries"""
+
+    def get_courses(self):
+        """
+        Generates list of courses based on certain filters
+
+        Returns:
+            QuerySet: Returns a QuerySet after applying all the filters
+        """
+        products_prefetch = Prefetch(
+            "products", Product.objects.with_ordered_versions()
+        )
+        course_runs_prefetch = Prefetch(
+            "courseruns", CourseRun.objects.prefetch_related(products_prefetch)
+        )
+
+        return (
+            Course.objects.filter(
+                self.get_courseware_filter(relative_filter=""), live=True
+            )
+            .select_related("coursepage", "externalcoursepage", "platform")
+            .prefetch_related(
+                "coursepage__topics",
+                "externalcoursepage__topics",
+                course_runs_prefetch,
+            )
+            .filter(Q(coursepage__live=True) | Q(externalcoursepage__live=True))
+            .exclude(courseruns__products=None)
+            .distinct()
+        )
+
+    def get_data(self, filter_topic=None):  # noqa: ARG002
+        """
+        Get course objects filtered w.r.t filter_topic (A topic Name)
+
+        Args:
+            filter_topic (str): A string representing the the name of a topic
+
+        Returns:
+            QuerySet: Returns a QuerySet after applying all the filters on Course model
+
+        ** NOTE: The topic filter is not implemented here
+        """
+        return self.get_courses()
+
+
+class ProgramProvider(DataProvider):
+    """Provider class to handle all Program (Django model) related queries"""
+
+    def get_programs(self):
+        """
+        Generates list of programs based on certain filters
+
+        Returns:
+            QuerySet: Returns a QuerySet after applying all the filters
+        """
+        products_prefetch = Prefetch(
+            "products", Product.objects.with_ordered_versions()
+        )
+        course_runs_prefetch = Prefetch(
+            "courseruns", CourseRun.objects.prefetch_related(products_prefetch)
+        )
+        courses_prefetch = Prefetch(
+            "courses",
+            Course.objects.select_related(
+                "coursepage", "externalcoursepage", "platform"
+            ).prefetch_related(
+                course_runs_prefetch, "coursepage__topics", "externalcoursepage__topics"
+            ),
+        )
+
+        return (
+            Program.objects.filter(
+                self.get_courseware_filter(relative_filter="courses__"), live=True
+            )
+            .exclude(products=None)
+            .select_related("programpage", "externalprogrampage", "platform")
+            .prefetch_related(courses_prefetch, products_prefetch)
+            .filter(Q(programpage__live=True) | Q(externalprogrampage__live=True))
+            .distinct()
+        )
+
+    def get_data(self, filter_topic=None):  # noqa: ARG002
+        """
+        Get course objects filtered w.r.t filter_topic (A topic Name)
+
+        Args:
+            filter_topic (str): A string representing the the name of a topic
+
+        Returns:
+            QuerySet: Returns a QuerySet after applying all the filters on Program model
+
+        ** NOTE: The topic filter is not implemented here
+        """
+
+        return self.get_programs()
+
+
+class CoursePageProvider(DataProvider):
+    """Provider class to handle all Course Pages (CMS model) related queries"""
+
+    def get_course_pages(self, page_cls):
+        """
+        Get course pages based on the provided page_cls)
+
+        Args:
+            page_cls (CoursePage | ExternalCoursePage): A class representing the page model to query
+
+        Returns:
+            List: Returns a list after applying all the filters on CoursePage/ExternalCoursePage model
+        """
+
+        return (
+            page_cls.objects.live()
+            .filter(
+                (self.get_courseware_filter(relative_filter="course__")),
+            )
+            .order_by("id")
+            .select_related("course")
+            .distinct()
+        )
+
+    def get_internal_pages(self):
+        """Support method to get internal course pages"""
+        return self.get_course_pages(CoursePage)
+
+    def get_external_pages(self):
+        """Support method to get external course pages"""
+        return self.get_course_pages(ExternalCoursePage)
+
+    def get_data(self, filter_topic=None):
+        """
+        Get course pages filtered w.r.t filter_topic (A topic Name)
+
+        Args:
+            filter_topic (str): A string representing the the name of a topic
+
+        Returns:
+            List: Returns a list after applying all the filters on CoursePage/ExternalCoursePage model
+        """
+
+        internal_pages_qset = self.get_internal_pages()
+        external_pages_qset = self.get_external_pages()
+
+        if filter_topic is None:
+            return list(internal_pages_qset) + list(external_pages_qset)
+
+        internal_topic_filtered_qset = internal_pages_qset.filter(
+            Q(topics__name=filter_topic) | Q(topics__parent__name=filter_topic)
+        ).distinct()
+
+        external_topic_filtered_qset = external_pages_qset.filter(
+            Q(topics__name=filter_topic) | Q(topics__parent__name=filter_topic)
+        ).distinct()
+        return list(internal_topic_filtered_qset) + list(external_topic_filtered_qset)
+
+
+class ProgramPageProvider(DataProvider):
+    """Provider class to handle all Program Pages (CMS model) related queries"""
+
+    def get_program_pages(self, page_cls):
+        """
+        Get program pages based on the provided page_cls (Possible Values: ProgramPage | ExternalProgramPage))
+
+        Args:
+            page_cls (ProgramPage | ExternalProgramPage): A class representing the Program page model to query
+
+        Returns:
+            List: Returns a list after applying all the filters on ProgramPage/ExternalProgramPage model
+        """
+
+        if page_cls == ProgramPage:
+            prefetch_type = "coursepage"
+        else:
+            prefetch_type = "externalcoursepage"
+
+        return (
+            page_cls.objects.live()
+            .filter(
+                (self.get_courseware_filter(relative_filter="program__courses__")),
+                program__live=True,
+            )
+            .order_by("id")
+            .select_related("program")
+            .prefetch_related(
+                Prefetch(
+                    "program__courses",
+                    Course.objects.order_by("position_in_program").select_related(
+                        prefetch_type
+                    ),
+                ),
+            )
+            .distinct()
+        )
+
+    def get_internal_pages(self):
+        """Support method to get internal program pages"""
+        return self.get_program_pages(ProgramPage)
+
+    def get_external_pages(self):
+        """Support method to get external program pages"""
+        return self.get_program_pages(ExternalProgramPage)
+
+    def get_data(self, filter_topic=None):
+        """
+        Get program pages filtered w.r.t filter_topic (A topic Name)
+
+        Args:
+            filter_topic (str): A string representing the the name of a topic
+
+        Returns:
+            List: Returns a list after applying all the filters on ProgramPage/ExternalProgramPage model
+        """
+        internal_pages_qset = self.get_internal_pages()
+        external_pages_qset = self.get_external_pages()
+
+        if filter_topic is None:
+            return list(internal_pages_qset) + list(external_pages_qset)
+
+        internal_topic_filtered_qset = internal_pages_qset.filter(
+            Q(program__courses__coursepage__topics__name=filter_topic)
+            | Q(program__courses__coursepage__topics__parent__name=filter_topic)
+        ).distinct()
+
+        external_topic_filtered_qset = external_pages_qset.filter(
+            Q(program__courses__coursepage__topics__name=filter_topic)
+            | Q(program__courses__coursepage__topics__parent__name=filter_topic)
+        ).distinct()
+        return list(internal_topic_filtered_qset) + list(external_topic_filtered_qset)

--- a/courses/data_provider_test.py
+++ b/courses/data_provider_test.py
@@ -1,0 +1,133 @@
+from datetime import timedelta
+
+import pytest
+
+from cms.factories import (
+    CoursePageFactory,
+    ExternalCoursePageFactory,
+    ExternalProgramPageFactory,
+    ProgramPageFactory,
+)
+from courses.data_provider import CoursePageProvider, ProgramPageProvider
+from courses.factories import CourseFactory, CourseRunFactory, ProgramFactory
+from mitxpro.utils import now_in_utc
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("is_external", [True, False])
+@pytest.mark.parametrize("is_program_live", [True, False])
+@pytest.mark.parametrize("has_program_page", [True, False])
+@pytest.mark.parametrize("is_program_page_live", [True, False])
+@pytest.mark.parametrize("has_course", [True, False])
+@pytest.mark.parametrize("has_course_run", [True, False])
+@pytest.mark.parametrize(
+    "start_date",
+    [None, now_in_utc() + timedelta(days=1), now_in_utc() - timedelta(days=1)],
+)
+@pytest.mark.parametrize(
+    "enrollment_end_date",
+    [None, now_in_utc() + timedelta(days=1), now_in_utc() - timedelta(days=1)],
+)
+def test_filter_program_pages(  # noqa: PLR0913
+    is_external,
+    is_program_live,
+    has_program_page,
+    is_program_page_live,
+    has_course,
+    has_course_run,
+    start_date,
+    enrollment_end_date,
+):
+    """
+    Test that sort_catalog_pages removes program/course/external course pages that do not have a future start date
+    or enrollment end date, and returns appropriately sorted lists of pages
+    """
+    program = ProgramFactory.create(live=is_program_live, page=None)
+    if has_program_page:
+        (
+            ExternalProgramPageFactory.create(
+                program=program, live=is_program_page_live
+            )
+            if is_external
+            else ProgramPageFactory.create(program=program, live=is_program_page_live)
+        )
+
+    if has_course:
+        course = CourseFactory.create(program=program, is_external=is_external)
+
+        if has_course_run:
+            CourseRunFactory.create(
+                course=course,
+                start_date=start_date,
+                enrollment_end=enrollment_end_date,
+            )
+
+    if (
+        is_program_live
+        and has_program_page
+        and is_program_page_live
+        and has_course
+        and has_course_run
+        and (
+            (start_date is not None and start_date > now_in_utc())
+            or (enrollment_end_date is not None and enrollment_end_date > now_in_utc())
+        )
+    ):
+        assert len(ProgramPageProvider().get_data()) == 1
+    else:
+        assert len(ProgramPageProvider().get_data()) == 0
+
+
+@pytest.mark.parametrize("is_external", [True, False])
+@pytest.mark.parametrize("is_course_live", [True, False])
+@pytest.mark.parametrize("has_course_page", [True, False])
+@pytest.mark.parametrize("is_course_page_live", [True, False])
+@pytest.mark.parametrize("has_course_run", [True, False])
+@pytest.mark.parametrize(
+    "start_date",
+    [None, now_in_utc() + timedelta(days=1), now_in_utc() - timedelta(days=1)],
+)
+@pytest.mark.parametrize(
+    "enrollment_end_date",
+    [None, now_in_utc() + timedelta(days=1), now_in_utc() - timedelta(days=1)],
+)
+def test_filter_course_pages(  # noqa: PLR0913
+    is_external,
+    is_course_live,
+    has_course_page,
+    is_course_page_live,
+    has_course_run,
+    start_date,
+    enrollment_end_date,
+):
+    """
+    Test that sort_catalog_pages removes program/course/external course pages that do not have a future start date
+    or enrollment end date, and returns appropriately sorted lists of pages
+    """
+    course = CourseFactory.create(live=is_course_live, page=None)
+    if has_course_page:
+        (
+            ExternalCoursePageFactory.create(course=course, live=is_course_page_live)
+            if is_external
+            else CoursePageFactory.create(course=course, live=is_course_page_live)
+        )
+    if has_course_run:
+        CourseRunFactory.create(
+            course=course,
+            start_date=start_date,
+            enrollment_end=enrollment_end_date,
+        )
+    if (
+        is_course_live
+        and has_course_page
+        and is_course_page_live
+        and has_course_run
+        and (
+            (start_date is not None and start_date > now_in_utc())
+            or (enrollment_end_date is not None and enrollment_end_date > now_in_utc())
+        )
+    ):
+        assert len(CoursePageProvider().get_data()) == 1
+    else:
+        assert len(CoursePageProvider().get_data()) == 0

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -96,29 +96,6 @@ def test_program_next_run_date():
     assert program.next_run_date == first_course_future_dates[0]
 
 
-def test_program_is_catalog_visible():
-    """
-    is_catalog_visible should return True if a program has any course run that has a start date or enrollment end
-    date in the future
-    """
-    program = ProgramFactory.create()
-    runs = CourseRunFactory.create_batch(
-        2, course__program=program, past_start=True, past_enrollment_end=True
-    )
-    assert program.is_catalog_visible is False
-
-    now = now_in_utc()
-    run = runs[0]
-    run.start_date = now + timedelta(hours=1)
-    run.save()
-    assert program.is_catalog_visible is True
-
-    run.start_date = now - timedelta(hours=1)
-    run.enrollment_end = now + timedelta(hours=1)
-    run.save()
-    assert program.is_catalog_visible is True
-
-
 def test_program_first_course_unexpired_runs():
     """
     first_course_unexpired_runs should return the unexpired course runs of the first course
@@ -522,29 +499,6 @@ def test_course_next_run_date():
     del course.next_run_date
 
     assert course.next_run_date == future_dates[0]
-
-
-def test_course_is_catalog_visible():
-    """
-    is_catalog_visible should return True if a course has any course run that has a start date or enrollment end
-    date in the future
-    """
-    course = CourseFactory.create()
-    runs = CourseRunFactory.create_batch(
-        2, course=course, past_start=True, past_enrollment_end=True
-    )
-    assert course.is_catalog_visible is False
-
-    now = now_in_utc()
-    run = runs[0]
-    run.start_date = now + timedelta(hours=1)
-    run.save()
-    assert course.is_catalog_visible is True
-
-    run.start_date = now - timedelta(hours=1)
-    run.enrollment_end = now + timedelta(hours=1)
-    run.save()
-    assert course.is_catalog_visible is True
 
 
 def test_course_page():

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -6,7 +6,6 @@ import logging
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Q
 from requests.exceptions import HTTPError
 from rest_framework.status import HTTP_404_NOT_FOUND
 
@@ -20,7 +19,7 @@ from courses.models import (
     ProgramEnrollment,
 )
 from courseware.api import get_edx_api_course_detail_client
-from mitxpro.utils import has_equal_properties, now_in_utc
+from mitxpro.utils import has_equal_properties
 
 log = logging.getLogger(__name__)
 
@@ -320,27 +319,3 @@ def is_program_text_id(item_text_id):
         bool: True if the given id is a program id
     """
     return item_text_id.startswith(PROGRAM_TEXT_ID_PREFIX)
-
-
-def get_catalog_course_filter(relative_filter=""):
-    """
-    Generates course filter for the catalog visible course pages.
-    """
-    courseware_live_filter = {
-        f"{relative_filter}course__live": True,
-        f"{relative_filter}course__courseruns__live": True,
-        f"{relative_filter}live": True,
-    }
-    courserun_start_date_filter = {
-        f"{relative_filter}course__courseruns__start_date__isnull": False,
-        f"{relative_filter}course__courseruns__start_date__gt": now_in_utc(),
-    }
-    courserun_enrollment_end_filter = {
-        f"{relative_filter}course__courseruns__enrollment_end__isnull": False,
-        f"{relative_filter}course__courseruns__enrollment_end__gt": now_in_utc(),
-    }
-
-    return Q(
-        Q(**courseware_live_filter)
-        & Q(Q(**courserun_start_date_filter) | Q(**courserun_enrollment_end_filter))
-    )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5266

### Description (What does it do?)
- Standardize the logic between Catalog and courseware APIs
- Refactor the code to be more generic in handling external and internal courseware
- Add more tests and Refactor existing tests
- Removes unnecessary code




### How can this be tested?
**NOTE:** This PR would probably require extensive testing of Catalog and courseware APIs and smoke testing of the whole application.

- On master create a data set of various internal and external Courses & Programs
- Check the courses on Catalog and Courses in the `/api/courses`
- Verify the existing logic based on [this sheet](https://docs.google.com/spreadsheets/d/1VqWs7CEN7J47iEiwtReeAS6nyQlyTp9qTR9mg9_V4dI/edit?gid=0#gid=0). You can see that there is a difference between which courses are displayed on Catalog and which are part of the APIs.
- Create a scenario while being on master where you see difference of courses on Catalog and `api/courses`

**Shift to this branch**

- Verify that you see exactly the same set of courses/programs on catalog and the APIs
- Note that, The product is now required for all the courses and programs to be displayable on Catalog and APIs
- Note that, The course run start/enrollment end date conditions are applied on both 
- Perform filter checking, sort by on catalog
- Check all the APIs `/api/courses`, `/api/programs`, `/api/products`


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
