### PR TITLE
fix: support email address from configurations(settings) on all templates

### DIFF
--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta
 
 import factory
 import pytest
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
 from django.urls import resolve, reverse
@@ -156,6 +157,7 @@ def test_webinar_context(staff_user):
         "courseware_url": program_page.get_url(),
         "default_banner_image": WEBINAR_HEADER_BANNER,
         "detail_page_url": webinar_page.get_url(request=request),
+        "support_email": settings.EMAIL_SUPPORT,
     }
 
 

--- a/cms/templates/partials/faqs.html
+++ b/cms/templates/partials/faqs.html
@@ -5,7 +5,7 @@
       <h3>
         Please review the following frequently asked questions before enrolling.
         Don’t see your question here? Please contact our team at
-        <a href="mailto:mitxpro@mit.edu">mitxpro@mit.edu</a>.
+        <a href="mailto:{{ support_email }}">{{ support_email }}</a>.
       </h3>
     </div>
     <ul id="accordion">

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -220,6 +220,7 @@ def send_course_run_enrollment_welcome_email(enrollment):
                         "run_start_date": run_start_date,
                         "run_start_time": run_start_time,
                         "run_date_range": run_duration,
+                        "support_email": settings.EMAIL_SUPPORT,
                     },
                 ),
                 EMAIL_WELCOME_COURSE_RUN_ENROLLMENT,
@@ -357,7 +358,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                                     "vat_id": purchaser.get("vat_id"),
                                 },
                                 "enable_taxes_display": bool(order["tax_rate"]),
-                                "email_support": settings.EMAIL_SUPPORT,
+                                "support_email": settings.EMAIL_SUPPORT,
                             },
                         ),
                     )

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -178,6 +178,7 @@ def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
                 "run_start_date": run_start_date.strftime(EMAIL_DATE_FORMAT),
                 "run_start_time": run_start_time,
                 "run_date_range": date_range,
+                "support_email": settings.EMAIL_SUPPORT,
             },
         )
         patched_mail_api.message_for_recipient.assert_called_once_with(
@@ -344,7 +345,7 @@ def test_send_ecommerce_order_receipt(mocker, receipt_data, settings):
                 "vat_id": "AT12349876",
             },
             "enable_taxes_display": False,
-            "email_support": settings.EMAIL_SUPPORT,
+            "support_email": settings.EMAIL_SUPPORT,
         },
     )
     patched_mail_api.messages_for_recipients.assert_called_once_with(

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -26,8 +26,8 @@
       <br />
       {% endif %}
       Support:
-      <a href="mailto:{{ email_support }}">
-        {{ email_support }}
+      <a href="mailto:{{ support_email }}">
+        {{ support_email }}
       </a>
       <br />
     </p>

--- a/mail/templates/welcome_course_run_enrollment/body.html
+++ b/mail/templates/welcome_course_run_enrollment/body.html
@@ -118,7 +118,7 @@
             Support Team is here to assist you. Feel free to check out the
             <a href="https://xpro.zendesk.com/hc/en-us">MIT xPRO Help Center</a>
             or reach out to us at
-            <a href="mailto:support@xpro.mit.edu">support@xpro.mit.edu</a>, and
+            <a href="mailto:{{ support_email }}">{{ support_email }}</a>, and
             we'll be happy to help.
           </p>
           <p style="margin: 0 0 10px">

--- a/mitxpro/views.py
+++ b/mitxpro/views.py
@@ -27,6 +27,7 @@ def get_base_context(request):  # noqa: ARG001
         context["domain_verification_tag"] = (
             settings.GOOGLE_DOMAIN_VERIFICATION_TAG_VALUE
         )
+    context["support_email"] = settings.EMAIL_SUPPORT
     return context
 
 

--- a/voucher/templates/redeemed.html
+++ b/voucher/templates/redeemed.html
@@ -17,7 +17,7 @@
     <p>
       MIT xPRO Customer Support
       <br />
-      <a href="mailto:xpro@mit.edu">xpro@mit.edu</a>
+      <a href="mailto:{{ support_email }}">{{ support_email }}</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
### What are the relevant tickets?
Following up: https://github.com/mitodl/mitxpro/pull/3127#issuecomment-2358035425

### Description (What does it do?)
This PR updates all templates to use the support email address from the configuration (settings) instead of hard-coded values.

### Screenshots (if appropriate):

FAQ page (on course details):
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/d7ccc301-1e66-431c-ab5c-732d703cae77">

Boeing Redeemed page:

<img width="1108" alt="Screenshot 2024-09-19 at 10 28 07 PM" src="https://github.com/user-attachments/assets/c63a2e4a-6121-48c6-bce3-5b8255549aeb">

Purchase Order Receipt email:

<img width="892" alt="Screenshot 2024-09-19 at 10 20 15 PM" src="https://github.com/user-attachments/assets/84f3cd08-96d4-463d-844f-a7dd1ab6f556">

Welcome Course Run Enrollment email:

<img width="892" alt="Screenshot 2024-09-19 at 10 21 18 PM" src="https://github.com/user-attachments/assets/a0dbf53f-47a9-4ee4-b08e-6136a0239475">


### How can this be tested?

- Ensure all templates now use the support email address from the configuration (settings) instead of hard-coded values:
   - Check the FAQ page (on course details).
   - Verify the support email on the Boeing Redeemed page.
   - Confirm the email in the Purchase Order Receipt email.
   - Verify the email in the Welcome Course Run Enrollment email.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
