### PR TITLE
fix: handle tampered queryparam

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -512,7 +512,14 @@ class CatalogPage(Page):
         Populate the context with live programs, courses and programs + courses
         """
         topic_filter = request.GET.get("topic", ALL_TOPICS)
+
+        # Best Match is the default sorting.
         sort_by = request.GET.get("sort-by", CatalogSorting.BEST_MATCH.sorting_value)
+        try:
+            CatalogSorting[sort_by.upper()]
+        except KeyError:
+            sort_by = CatalogSorting.BEST_MATCH.sorting_value
+
         program_page_qset = (
             ProgramPage.objects.live()
             .filter(program__live=True)

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -468,13 +468,21 @@ def test_catalog_page_topics_ordering(client, wagtail_basics):
 
 
 @pytest.mark.parametrize(
-    ("sort_by", "sort_by_title"),
+    ("sort_by", "expected_sort_by_title"),
     [
-        (sort_option.sorting_value, sort_option.sorting_title)
-        for sort_option in CatalogSorting
+        ("undefined", "Best Match"),
+        ("None", "Best Match"),
+        ("", "Best Match"),
+        (None, "Best Match"),
+        *[
+            (sort_option.sorting_value, sort_option.sorting_title)
+            for sort_option in CatalogSorting
+        ],
     ],
 )
-def test_catalog_page_sorting_context(client, wagtail_basics, sort_by, sort_by_title):
+def test_catalog_page_sorting_context(
+    client, wagtail_basics, sort_by, expected_sort_by_title
+):
     """
     Tests that active_sorting_title is correct based on the queryparam and context has sort_by_options.
     """
@@ -483,7 +491,7 @@ def test_catalog_page_sorting_context(client, wagtail_basics, sort_by, sort_by_t
     catalog_page.save_revision().publish()
 
     resp = client.get(f"{catalog_page.get_url()}?sort-by={sort_by}")
-    assert resp.context_data["active_sorting_title"] == sort_by_title
+    assert resp.context_data["active_sorting_title"] == expected_sort_by_title
     assert resp.context_data["sort_by_options"] == [
         {
             "value": sorting_option.sorting_value,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://mit-office-of-digital-learning.sentry.io/issues/5893848649/?project=1413655&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0&utc=true

### Description (What does it do?)
<!--- Describe your changes in detail -->
Handles sort by tampered URLs. Applies Best Match by default.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- On master branch
- Go to the catalog page
- Apply any sorting.
- Now change the query param `sort-by` in the URL. You will get 500.
- Now checkout this branch
- Repeat the above steps to ensure you do not get the error.