### PR TITLE
fix: display homepage topics with courses

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -890,7 +890,9 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
             **super().get_context(request),
             **get_base_context(request),
             "catalog_page": CatalogPage.objects.first(),
-            "topics": CourseTopic.objects.parent_topic_names(),
+            "topics": [
+                topic.name for topic in CourseTopic.parent_topics_with_courses()
+            ],
             "webinars_list_page": WebinarIndexPage.objects.first(),
             # The context variables below are added to avoid duplicate queries within the templates
             "about_mit_xpro": self.about_mit_xpro,

--- a/courses/models.py
+++ b/courses/models.py
@@ -111,18 +111,21 @@ class CourseTopicQuerySet(models.QuerySet):
         """
         from courses.utils import get_catalog_course_filter
 
-        catalog_course_visible_filter = get_catalog_course_filter(
+        internal_course_visible_filter = get_catalog_course_filter(
             relative_filter="coursepage__"
+        )
+        external_course_visible_filter = get_catalog_course_filter(
+            relative_filter="externalcoursepage__"
         )
         topics_queryset = (
             self.parent_topics()
             .annotate(
                 internal_course_count=models.Count(
-                    "coursepage", filter=catalog_course_visible_filter, distinct=True
+                    "coursepage", filter=internal_course_visible_filter, distinct=True
                 ),
                 external_course_count=models.Count(
                     "externalcoursepage",
-                    filter=models.Q(externalcoursepage__course__live=True),
+                    filter=external_course_visible_filter,
                     distinct=True,
                 ),
             )
@@ -132,12 +135,12 @@ class CourseTopicQuerySet(models.QuerySet):
                     self.filter(parent__isnull=False).annotate(
                         internal_course_count=models.Count(
                             "coursepage",
-                            filter=catalog_course_visible_filter,
+                            filter=internal_course_visible_filter,
                             distinct=True,
                         ),
                         external_course_count=models.Count(
                             "externalcoursepage",
-                            filter=models.Q(externalcoursepage__course__live=True),
+                            filter=external_course_visible_filter,
                             distinct=True,
                         ),
                     ),

--- a/static/js/components/CatalogMenu.js
+++ b/static/js/components/CatalogMenu.js
@@ -34,7 +34,7 @@ const CatalogMenu = ({ courseTopics }: Props) => {
               <a
                 className="dropdown-item"
                 key={index}
-                href={`/catalog/?topic=${courseTopic.name}`}
+                href={`/catalog/?topic=${encodeURIComponent(courseTopic.name)}`}
                 aria-label={courseTopic.name}
               >
                 {courseTopic.name} ({courseTopic.course_count})


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/5627

### Description (What does it do?)
<!--- Describe your changes in detail -->
Show homepage topics with courses.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
<img width="1267" alt="Screenshot 2024-09-27 at 12 26 08 PM" src="https://github.com/user-attachments/assets/e56186ea-35b2-4f7c-b23d-7db2138f4b2d">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Associate topics with courses in the CMS course pages.
- Keep a few topics without associating the courses.
- Verify that the homepage shows topics with courses.
- Verify that the topics match the courses dropdown in the header.

