### PR TITLE
feat: add catalog filter feature flag

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -637,7 +637,9 @@ class CatalogPage(Page):
                 }
                 for sorting_option in CatalogSorting
             ],
-            enable_catalog_sorting=settings.FEATURES.get("ENABLE_CATALOG_SORTING", False),
+            enable_catalog_sorting=settings.FEATURES.get(
+                "ENABLE_CATALOG_SORTING", False
+            ),
         )
 
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -637,7 +637,7 @@ class CatalogPage(Page):
                 }
                 for sorting_option in CatalogSorting
             ],
-            enable_catalog_filter=settings.FEATURES.get("ENABLE_CATALOG_FILTER", False),
+            enable_catalog_sorting=settings.FEATURES.get("ENABLE_CATALOG_SORTING", False),
         )
 
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -637,6 +637,7 @@ class CatalogPage(Page):
                 }
                 for sorting_option in CatalogSorting
             ],
+            enable_catalog_filter=settings.FEATURES.get("ENABLE_CATALOG_FILTER", False),
         )
 
 

--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -164,94 +164,94 @@
                     {% endfor %}
                   </div>
                 </div>
+                {% endif %}
               </div>
-              {% endif %}
-            </div>
-            <div class="tab-content">
-              {% if featured_product.program %}
-              {% include "partials/featured_card.html" with courseware_page=featured_product object_type="program" %}
-              {% elif featured_product.course %}
-              {% include "partials/featured_card.html" with courseware_page=featured_product object_type="course"%}
-              {% endif %}
+              <div class="tab-content">
+                {% if featured_product.program %}
+                {% include "partials/featured_card.html" with courseware_page=featured_product object_type="program" %}
+                {% elif featured_product.course %}
+                {% include "partials/featured_card.html" with courseware_page=featured_product object_type="course"%}
+                {% endif %}
 
-              {% if active_tab == "all-tab" %}
-              <div
-                class="tab-pane catalog-body fade in show active"
-                id="all"
-                role="tabpanel"
-                aria-labelledby="all-tab"
-              >
-                {% else %}
+                {% if active_tab == "all-tab" %}
                 <div
-                  class="tab-pane catalog-body fade"
+                  class="tab-pane catalog-body fade in show active"
                   id="all"
                   role="tabpanel"
                   aria-labelledby="all-tab"
                 >
-                  {% endif %}
-                  {% for page in all_pages %}
-                  {% if page.program or page.is_external_program_page %}
-                  {% include "partials/catalog_card.html" with courseware_page=page object_type="program" tab="all" %}
-                  {% elif page.course or page.is_external_course_page %}
-                  {% include "partials/catalog_card.html" with courseware_page=page object_type="course" tab="all"%}
-                  {% endif %}
-                  {% endfor %}
-                </div>
-
-                {% if active_tab == "programs-tab" %}
-                <div
-                  class="tab-pane catalog-body fade in show active"
-                  id="programs"
-                  role="tabpanel"
-                  aria-labelledby="programs-tab"
-                >
                   {% else %}
                   <div
                     class="tab-pane catalog-body fade"
+                    id="all"
+                    role="tabpanel"
+                    aria-labelledby="all-tab"
+                  >
+                    {% endif %}
+                    {% for page in all_pages %}
+                    {% if page.program or page.is_external_program_page %}
+                    {% include "partials/catalog_card.html" with courseware_page=page object_type="program" tab="all" %}
+                    {% elif page.course or page.is_external_course_page %}
+                    {% include "partials/catalog_card.html" with courseware_page=page object_type="course" tab="all"%}
+                    {% endif %}
+                    {% endfor %}
+                  </div>
+
+                  {% if active_tab == "programs-tab" %}
+                  <div
+                    class="tab-pane catalog-body fade in show active"
                     id="programs"
                     role="tabpanel"
                     aria-labelledby="programs-tab"
                   >
-                    {% endif %}
-                    <h1>PROGRAMS</h1>
-                    {% for program_page in program_pages %}
-                    {% include "partials/catalog_card.html" with courseware_page=program_page object_type="program" tab="program" %}
-                    {% endfor %}
-                  </div>
-
-                  {% if active_tab == "courses-tab" %}
-                  <div
-                    class="tab-pane catalog-body fade in show active"
-                    id="courses"
-                    role="tabpanel"
-                    aria-labelledby="courses-tab"
-                  >
                     {% else %}
                     <div
                       class="tab-pane catalog-body fade"
+                      id="programs"
+                      role="tabpanel"
+                      aria-labelledby="programs-tab"
+                    >
+                      {% endif %}
+                      <h1>PROGRAMS</h1>
+                      {% for program_page in program_pages %}
+                      {% include "partials/catalog_card.html" with courseware_page=program_page object_type="program" tab="program" %}
+                      {% endfor %}
+                    </div>
+
+                    {% if active_tab == "courses-tab" %}
+                    <div
+                      class="tab-pane catalog-body fade in show active"
                       id="courses"
                       role="tabpanel"
                       aria-labelledby="courses-tab"
                     >
-                      {% endif %}
-                      <h1>COURSES</h1>
-                      {% for course_page in course_pages %}
-                      {% include "partials/catalog_card.html" with courseware_page=course_page object_type="course" tab="course" %}
-                      {% endfor %}
+                      {% else %}
+                      <div
+                        class="tab-pane catalog-body fade"
+                        id="courses"
+                        role="tabpanel"
+                        aria-labelledby="courses-tab"
+                      >
+                        {% endif %}
+                        <h1>COURSES</h1>
+                        {% for course_page in course_pages %}
+                        {% include "partials/catalog_card.html" with courseware_page=course_page object_type="course" tab="course" %}
+                        {% endfor %}
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        {% endblock %}
+          {% endblock %}
 
-        {% block contact-us %}
-        {% if hubspot_new_courses_form_guid and hubspot_portal_id %}
-        {% include "subscription.html" %}
-        {% endif %}
-        {% endblock %}
+          {% block contact-us %}
+          {% if hubspot_new_courses_form_guid and hubspot_portal_id %}
+          {% include "subscription.html" %}
+          {% endif %}
+          {% endblock %}
+        </div>
       </div>
     </div>
   </div>

--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -126,6 +126,7 @@
                   </li>
                 </ul>
               </div>
+            {% if enable_catalog_filter %}
               <div
                 class="catalog-sort-by-dropdown dropdown"
                 id="catalogSortDropdown"
@@ -164,6 +165,8 @@
                   </div>
                 </div>
               </div>
+              {% endif %}
+            </div>
               <div class="tab-content">
                 {% if featured_product.program %}
                 {% include "partials/featured_card.html" with courseware_page=featured_product object_type="program" %}

--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -126,7 +126,7 @@
                   </li>
                 </ul>
               </div>
-              {% if enable_catalog_filter %}
+              {% if enable_catalog_sorting %}
               <div
                 class="catalog-sort-by-dropdown dropdown"
                 id="catalogSortDropdown"

--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -126,7 +126,7 @@
                   </li>
                 </ul>
               </div>
-            {% if enable_catalog_filter %}
+              {% if enable_catalog_filter %}
               <div
                 class="catalog-sort-by-dropdown dropdown"
                 id="catalogSortDropdown"
@@ -167,92 +167,91 @@
               </div>
               {% endif %}
             </div>
-              <div class="tab-content">
-                {% if featured_product.program %}
-                {% include "partials/featured_card.html" with courseware_page=featured_product object_type="program" %}
-                {% elif featured_product.course %}
-                {% include "partials/featured_card.html" with courseware_page=featured_product object_type="course"%}
-                {% endif %}
+            <div class="tab-content">
+              {% if featured_product.program %}
+              {% include "partials/featured_card.html" with courseware_page=featured_product object_type="program" %}
+              {% elif featured_product.course %}
+              {% include "partials/featured_card.html" with courseware_page=featured_product object_type="course"%}
+              {% endif %}
 
-                {% if active_tab == "all-tab" %}
+              {% if active_tab == "all-tab" %}
+              <div
+                class="tab-pane catalog-body fade in show active"
+                id="all"
+                role="tabpanel"
+                aria-labelledby="all-tab"
+              >
+                {% else %}
                 <div
-                  class="tab-pane catalog-body fade in show active"
+                  class="tab-pane catalog-body fade"
                   id="all"
                   role="tabpanel"
                   aria-labelledby="all-tab"
                 >
+                  {% endif %}
+                  {% for page in all_pages %}
+                  {% if page.program or page.is_external_program_page %}
+                  {% include "partials/catalog_card.html" with courseware_page=page object_type="program" tab="all" %}
+                  {% elif page.course or page.is_external_course_page %}
+                  {% include "partials/catalog_card.html" with courseware_page=page object_type="course" tab="all"%}
+                  {% endif %}
+                  {% endfor %}
+                </div>
+
+                {% if active_tab == "programs-tab" %}
+                <div
+                  class="tab-pane catalog-body fade in show active"
+                  id="programs"
+                  role="tabpanel"
+                  aria-labelledby="programs-tab"
+                >
                   {% else %}
                   <div
                     class="tab-pane catalog-body fade"
-                    id="all"
-                    role="tabpanel"
-                    aria-labelledby="all-tab"
-                  >
-                    {% endif %}
-                    {% for page in all_pages %}
-                    {% if page.program or page.is_external_program_page %}
-                    {% include "partials/catalog_card.html" with courseware_page=page object_type="program" tab="all" %}
-                    {% elif page.course or page.is_external_course_page %}
-                    {% include "partials/catalog_card.html" with courseware_page=page object_type="course" tab="all"%}
-                    {% endif %}
-                    {% endfor %}
-                  </div>
-
-                  {% if active_tab == "programs-tab" %}
-                  <div
-                    class="tab-pane catalog-body fade in show active"
                     id="programs"
                     role="tabpanel"
                     aria-labelledby="programs-tab"
                   >
+                    {% endif %}
+                    <h1>PROGRAMS</h1>
+                    {% for program_page in program_pages %}
+                    {% include "partials/catalog_card.html" with courseware_page=program_page object_type="program" tab="program" %}
+                    {% endfor %}
+                  </div>
+
+                  {% if active_tab == "courses-tab" %}
+                  <div
+                    class="tab-pane catalog-body fade in show active"
+                    id="courses"
+                    role="tabpanel"
+                    aria-labelledby="courses-tab"
+                  >
                     {% else %}
                     <div
                       class="tab-pane catalog-body fade"
-                      id="programs"
-                      role="tabpanel"
-                      aria-labelledby="programs-tab"
-                    >
-                      {% endif %}
-                      <h1>PROGRAMS</h1>
-                      {% for program_page in program_pages %}
-                      {% include "partials/catalog_card.html" with courseware_page=program_page object_type="program" tab="program" %}
-                      {% endfor %}
-                    </div>
-
-                    {% if active_tab == "courses-tab" %}
-                    <div
-                      class="tab-pane catalog-body fade in show active"
                       id="courses"
                       role="tabpanel"
                       aria-labelledby="courses-tab"
                     >
-                      {% else %}
-                      <div
-                        class="tab-pane catalog-body fade"
-                        id="courses"
-                        role="tabpanel"
-                        aria-labelledby="courses-tab"
-                      >
-                        {% endif %}
-                        <h1>COURSES</h1>
-                        {% for course_page in course_pages %}
-                        {% include "partials/catalog_card.html" with courseware_page=course_page object_type="course" tab="course" %}
-                        {% endfor %}
-                      </div>
+                      {% endif %}
+                      <h1>COURSES</h1>
+                      {% for course_page in course_pages %}
+                      {% include "partials/catalog_card.html" with courseware_page=course_page object_type="course" tab="course" %}
+                      {% endfor %}
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          {% endblock %}
-
-          {% block contact-us %}
-          {% if hubspot_new_courses_form_guid and hubspot_portal_id %}
-          {% include "subscription.html" %}
-          {% endif %}
-          {% endblock %}
         </div>
+        {% endblock %}
+
+        {% block contact-us %}
+        {% if hubspot_new_courses_form_guid and hubspot_portal_id %}
+        {% include "subscription.html" %}
+        {% endif %}
+        {% endblock %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5567

### Description (What does it do?)
Puts the catalog filtering functionality behind the feature flag

### Screenshots (if appropriate):
When `FEATURE_ENABLE_CATALOG_SORTING=True`
<img width="1136" alt="Screenshot 2024-09-27 at 3 51 45 PM" src="https://github.com/user-attachments/assets/ec5f1eb0-ab67-410e-b093-4f54c713548b">

When `FEATURE_ENABLE_CATALOG_SORTING=False` or the flag is not set
<img width="1136" alt="Screenshot 2024-09-27 at 3 48 18 PM" src="https://github.com/user-attachments/assets/d138a28c-0675-4f43-9500-406267d01a65">

### How can this be tested?
- Add `FEATURE_ENABLE_CATALOG_SORTING=True` in  your env file
- Run `docker-compose up` to restart the containers
- Visit `http://localhost:8053/catalog/`. You should see the catalog filter
- Set `FEATURE_ ENABLE_CATALOG_SORTING=False` and restart your containers
- Visit `http://localhost:8053/catalog/`. You should not see the catalog filter

