### PR TITLE
fix: changed the default value of sorting featureflag

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -638,7 +638,7 @@ class CatalogPage(Page):
                 for sorting_option in CatalogSorting
             ],
             enable_catalog_sorting=settings.FEATURES.get(
-                "ENABLE_CATALOG_SORTING", False
+                "ENABLE_CATALOG_SORTING", True
             ),
         )
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5567#issuecomment-2385853303

### Description (What does it do?)
Set the catalog sorting feature flag to True by default

### How can this be tested?
- Remove `FEATURE_ENABLE_CATALOG_SORTING` from your env file if present.
- Run `docker-compose up web -d`
- Visit http://localhost:8053/catalog
- You should see the catalog filter

