### PR TITLE
fix: coupon code download view permissions

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -73,7 +73,6 @@ from mitxpro.utils import (
 )
 from mitxpro.views import get_base_context
 
-
 log = logging.getLogger(__name__)
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -73,6 +73,7 @@ from mitxpro.utils import (
 )
 from mitxpro.views import get_base_context
 
+
 log = logging.getLogger(__name__)
 
 
@@ -405,7 +406,7 @@ def ecommerce_restricted(request):
 
 def coupon_code_csv_view(request, version_id):
     """View for returning a csv file of coupon codes"""
-    if not (request.user and request.user.is_staff):
+    if not (request.user and request.user.has_perm(COUPON_ADD_PERMISSION)):
         raise PermissionDenied
     coupon_payment_version = get_object_or_404(CouponPaymentVersion, id=version_id)
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
While testing the release, I came across this issue that downloading the coupon codes after creation requires staff permission. This PR updates the permission to allow users with the `Add Coupons` permission to download the coupons  csv.

### How can this be tested?
- Give a test user `Can add coupon` permission from the django admin
- Login with the test user account and visit `/ecommerce/admin`
- Create new coupons in the `Coupon Codes` tab
- On success page, click the `Download coupon codes` link
- A CSV file should be downloaded successfully
