### PR TITLE
Add a `configure_instance` management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **SECTIONS**
 
 1. [Initial Setup](#initial-setup)
-1. [Optional Setup](#optional-setup)
+2. [Optional Setup](#optional-setup)
 
 # Initial Setup
 
@@ -13,13 +13,10 @@ Run through those steps **including the addition of `/etc/hosts` aliases and the
 
 ### Configure xPro and Open edX
 
-1. See [Configure Open edX](docs/configure_open_edx.md)
-1. Add an alias to `/etc/hosts` for Open edX. We have standardized this alias
-   to `edx.odl.local`. Your `/etc/hosts` entry should look like this:
+See Configure Open edX:
 
-   ```
-   127.0.0.1       edx.odl.local
-   ```
+- [Using Tutor](https://github.com/mitodl/handbook/tree/master/openedx/MITx-edx-integration-tutor.md) (Recommended)
+- [Using Devstack](https://github.com/mitodl/handbook/tree/master/openedx/MITx-edx-integration-devstack.md) (Deprecated)
 
 ### Add settings values
 
@@ -31,27 +28,6 @@ MAILGUN_RECIPIENT_OVERRIDE=<your email address>
 # Ask a fellow developer for these values
 MAILGUN_SENDER_DOMAIN=
 MAILGUN_KEY=
-```
-
-OS-specific settings to add to your `.env` file:
-
-```
-### Linux
-# EDX_IP should be something like 172.22.0.1
-OPENEDX_API_BASE_URL=http://$EDX_IP:18000
-
-### OSX
-OPENEDX_API_BASE_URL=http://docker.for.mac.localhost:18000
-OPENEDX_BASE_REDIRECT_URL=http://edx.odl.local:18000
-```
-
-### Configure Wagtail (CMS)
-
-There are a few changes that must be made to the CMS for the site
-to be usable. You can apply all of those changes by running a management command:
-
-```
-docker-compose run --rm web ./manage.py configure_wagtail
 ```
 
 # Optional Setup
@@ -100,6 +76,7 @@ for running the app
 ### Seed data
 
 Seed data can be generated via management command. It's designed to be idempotent, so running it multiple times should not create multiple sets of data.
+**NOTE:** If you have run `configure_instance` command, it will also create seed data, you don't need to run `seed_data` command again
 
 ```
 docker-compose run --rm web ./manage.py seed_data

--- a/courseware/api.py
+++ b/courseware/api.py
@@ -825,15 +825,6 @@ def create_oauth_application():
     )
 
 
-def delete_oauth_application():
-    """Delete oAuth application"""
-
-    _, deleted_applications_count = Application.objects.filter(
-        name=settings.OPENEDX_OAUTH_APP_NAME
-    ).delete()
-    return _, deleted_applications_count
-
-
 def validate_name_with_edx(name):
     """
     Returns validation message after validating it with Open edX.

--- a/localdev/seed/api.py
+++ b/localdev/seed/api.py
@@ -33,7 +33,6 @@ from courses.models import (
     ProgramEnrollment,
     ProgramEnrollmentAudit,
 )
-from courseware.api import create_oauth_application, delete_oauth_application
 from ecommerce.api import create_coupons
 from ecommerce.models import (
     Basket,
@@ -672,7 +671,7 @@ class SeedDataLoader:
                 model_cls=CouponPayment, data=raw_coupon_data, parent=None
             )
 
-    def create_seed_data(self, raw_data):  # noqa: C901
+    def create_seed_data(self, raw_data):
         """
         Iterate over all objects described in the seed data spec, add/update them one-by-one, and return the results
         """
@@ -681,12 +680,6 @@ class SeedDataLoader:
         configure_wagtail()
 
         self.seed_result = SeedResult()
-        application, application_created = create_oauth_application()
-        if application_created:
-            self.seed_result.add_created(application)
-        else:
-            self.seed_result.add_ignored(application)
-
         for seed_data_spec in self.iter_seed_data(raw_data):
             if seed_data_spec.model_cls in [Program, Course, CourseRun]:
                 serializer_cls = self.SEED_DATA_DESERIALIZER[seed_data_spec.model_cls]
@@ -740,9 +733,6 @@ class SeedDataLoader:
         """Iterate over all objects described in the seed data spec, delete them one-by-one, and return the results"""
 
         self.seed_result = SeedResult()
-        _, deleted_applications_count = delete_oauth_application()
-        self.seed_result.add_deleted(deleted_applications_count)
-
         # Traversing in reverse since we want to delete 'leaf' objects first (e.g.: we want to delete CourseRuns
         # before deleting Courses)
         for seed_data_spec in reversed(list(self.iter_seed_data(raw_data))):

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -1,0 +1,164 @@
+"""
+Meta-command to help set up a freshly configured MITxPro instance.
+
+Running this will perform the following functions:
+- Configures a superuser account.
+- Creates the OAuth2 application record for edX (optionally with an existing
+  client ID and secret).
+
+If the --tutor/-T option is passed, the command will use the local.edly.io
+address for links to edX rather than edx.odl.local:18000.
+
+This uses other management commands to complete these tasks. So, if you just
+want to run part of this, use one of these commands:
+- createsuperuser to create the super user
+- configure_wagtail for initial setup of Wagtail assets
+
+There are some steps that this command won't do for you:
+- Completing the integration between MITxPro and devstack - there are still
+  steps that you need to take to finish that process
+
+"""
+
+from django.core.management import BaseCommand, call_command
+from oauth2_provider.models import Application
+
+
+class Command(BaseCommand):
+    """
+    Bootstraps a fresh MITxPro instance.
+    """
+
+    def add_arguments(self, parser):
+        """Parses command line arguments."""
+
+        parser.add_argument(
+            "platform",
+            help="Your platform (none, macos, or linux; defaults to none). None skips OAuth2 record creation.",
+            type=str,
+            choices=["none", "macos", "linux"],
+            nargs="?",
+            const="none",
+        )
+
+        parser.add_argument(
+            "--dont-create-superuser",
+            "-S",
+            help="Don't create a superuser account.",
+            action="store_false",
+            dest="superuser",
+        )
+
+        parser.add_argument(
+            "--edx-oauth-client",
+            help="Use the provided OAuth2 client ID, rather than making a new one.",
+            type=str,
+            nargs="?",
+        )
+
+        parser.add_argument(
+            "--edx-oauth-secret",
+            help="Use the provided OAuth2 client secret, rather than making a new one.",
+            type=str,
+            nargs="?",
+        )
+
+        parser.add_argument(
+            "--gateway",
+            help="Specify the gateway IP. (Required for Linux users.)",
+            type=str,
+            nargs="?",
+        )
+
+        parser.add_argument(
+            "--tutor",
+            "-T",
+            help="Configure for Tutor.",
+            action="store_true",
+            dest="tutor",
+        )
+
+        parser.add_argument(
+            "--tutor-dev",
+            help="Configure for Tutor Dev/Nightly.",
+            action="store_true",
+            dest="tutordev",
+        )
+
+    def determine_edx_hostport(self, *args, **kwargs):  # noqa: ARG002
+        """Returns a tuple of the edX host and port depending on what the user's passed in"""
+
+        if kwargs["tutor"]:
+            return ("local.edly.io", "")
+        elif kwargs["tutordev"]:
+            return ("local.edly.io:8000", ":8000")
+        else:
+            return ("edx.odl.local:18000", ":18000")
+
+    def handle(self, *args, **kwargs):  # noqa: ARG002
+        """Coordinates the other commands."""
+
+        (edx_host, edx_gateway_port) = self.determine_edx_hostport(**kwargs)
+
+        # Step 1: run createsuperuesr
+        if kwargs["superuser"]:
+            self.stdout.write(self.style.SUCCESS("Creating superuser..."))
+
+            call_command("createsuperuser")
+
+        # Step 2: create OAuth2 provider records
+        if kwargs["platform"] != "none":
+            self.stdout.write(self.style.SUCCESS("Creating OAuth2 app..."))
+
+            if kwargs["platform"] == "macos":
+                redirects = "\n".join(
+                    [
+                        f"http://{edx_host}/auth/complete/mitxpro-oauth2/",
+                        f"http://host.docker.internal{edx_gateway_port}/auth/complete/mitxpro-oauth2/",
+                    ]
+                )
+            else:
+                if kwargs["gateway"] is None:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Gateway required for platform type {kwargs['platform']}."
+                        )
+                    )
+                    exit(-1)  # noqa: PLR1722
+
+                redirects = "\n".join(
+                    [
+                        f"http://{edx_host}/auth/complete/mitxpro-oauth2/",
+                        f"http://{kwargs['gateway']}{edx_gateway_port}/auth/complete/mitxpro-oauth2/",
+                    ]
+                )
+
+            (oauth2_app, _) = Application.objects.get_or_create(
+                name="edx-oauth-app",
+                defaults={
+                    "client_type": "confidential",
+                    "authorization_grant_type": "authorization-code",
+                    "skip_authorization": True,
+                    "redirect_uris": redirects,
+                },
+            )
+
+            if kwargs["edx_oauth_client"] is not None:
+                oauth2_app.client_id = kwargs["edx_oauth_client"]
+
+            if kwargs["edx_oauth_secret"] is not None:
+                oauth2_app.client_secret = kwargs["edx_oauth_secret"]
+
+            oauth2_app.save()
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Created OAuth2 app {oauth2_app.name} for edX. Your client ID is \n{oauth2_app.client_id}\nand your secret is\n{oauth2_app.client_secret}\n\n"
+                )
+            )
+
+        self.stdout.write(self.style.SUCCESS("Configuring Wagtail..."))
+
+        call_command("configure_wagtail")
+
+        self.stdout.write(self.style.SUCCESS("Done!"))

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -5,7 +5,7 @@ Running this will perform the following functions:
 - Configures a superuser account
 - Creates the OAuth2 application record for edX (optionally with an existing
   client ID and secret)
-- Create seed data by using seed_data management command
+- Create seed data and configure wagtail by using seed_data management command
 
 If the --tutor/-T option is passed, the command will use the local.edly.io
 address for links to edX rather than edx.odl.local:18000.
@@ -13,8 +13,7 @@ address for links to edX rather than edx.odl.local:18000.
 This uses other management commands to complete these tasks. So, if you just
 want to run part of this, use one of these commands:
 - createsuperuser to create the super user
-- configure_wagtail for initial setup of Wagtail assets
-- seed_data to creating seed/dummy courses and programs
+- seed_data to configure wagtail and create seed/dummy courses and programs
 
 There are some steps that this command won't do for you:
 - Completing the integration between MITxPro and devstack - there are still
@@ -109,6 +108,7 @@ class Command(BaseCommand):
             call_command("createsuperuser")
 
         # Step 2: create OAuth2 provider records
+        oauth2_app = None
         if kwargs["platform"] != "none":
             self.stdout.write(self.style.SUCCESS("Creating OAuth2 app..."))
 
@@ -159,15 +159,19 @@ class Command(BaseCommand):
                 )
             )
 
-        self.stdout.write(self.style.SUCCESS("Configuring Wagtail..."))
-
-        # Step 3: configure wagtail
-        call_command("configure_wagtail")
-        self.stdout.write(self.style.SUCCESS("Wagtail Configured"))
-
+        # Step 3: create example course(s) and program(s)
         self.stdout.write(self.style.SUCCESS("Creating Seed Data..."))
-        # Step 4: create example course(s) and program(s)
         call_command("seed_data")
         self.stdout.write(self.style.SUCCESS("Seed Data Created"))
+
+        # Print OAuth2 app details at the end of the file for user convenience
+        # This allows the user to access their client ID and secret without needing to scroll up,
+        # making it easily accessible after the script completes execution.
+        if oauth2_app:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Created OAuth2 app {oauth2_app.name} for edX. Your client ID is \n{oauth2_app.client_id}\nand your secret is\n{oauth2_app.client_secret}\n\n"
+                )
+            )
 
         self.stdout.write(self.style.SUCCESS("Done!"))

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -5,7 +5,7 @@ Running this will perform the following functions:
 - Configures a superuser account
 - Creates the OAuth2 application record for edX (optionally with an existing
   client ID and secret)
-- Create seed data and configure wagtail by using seed_data management command
+- Configure wagtail and seed data by using seed_data management command
 
 If the --tutor/-T option is passed, the command will use the local.edly.io
 address for links to edX rather than edx.odl.local:18000.

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -7,7 +7,7 @@ Running this will perform the following functions:
   client ID and secret)
 - Configure wagtail and seed data by using seed_data management command
 
-If the --tutor/-T option is passed, the command will use the local.edly.io
+If the --tutor/-T option is passed, the command will use the local.openedx.io
 address for links to edX rather than edx.odl.local:18000.
 
 This uses other management commands to complete these tasks. So, if you just
@@ -90,9 +90,9 @@ class Command(BaseCommand):
         """Returns a tuple of the edX host and port depending on what the user's passed in"""
 
         if kwargs["tutor"]:
-            return ("local.edly.io", "")
+            return ("local.openedx.io", "")
         elif kwargs["tutordev"]:
-            return ("local.edly.io:8000", ":8000")
+            return ("local.openedx.io:8000", ":8000")
         else:
             return ("edx.odl.local:18000", ":18000")
 

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -2,9 +2,10 @@
 Meta-command to help set up a freshly configured MITxPro instance.
 
 Running this will perform the following functions:
-- Configures a superuser account.
+- Configures a superuser account
 - Creates the OAuth2 application record for edX (optionally with an existing
-  client ID and secret).
+  client ID and secret)
+- Create seed data by using seed_data management command
 
 If the --tutor/-T option is passed, the command will use the local.edly.io
 address for links to edX rather than edx.odl.local:18000.
@@ -13,6 +14,7 @@ This uses other management commands to complete these tasks. So, if you just
 want to run part of this, use one of these commands:
 - createsuperuser to create the super user
 - configure_wagtail for initial setup of Wagtail assets
+- seed_data to creating seed/dummy courses and programs
 
 There are some steps that this command won't do for you:
 - Completing the integration between MITxPro and devstack - there are still
@@ -159,6 +161,13 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS("Configuring Wagtail..."))
 
+        # Step 3: configure wagtail
         call_command("configure_wagtail")
+        self.stdout.write(self.style.SUCCESS("Wagtail Configured"))
+
+        self.stdout.write(self.style.SUCCESS("Creating Seed Data..."))
+        # Step 4: create example course(s) and program(s)
+        call_command("seed_data")
+        self.stdout.write(self.style.SUCCESS("Seed Data Created"))
 
         self.stdout.write(self.style.SUCCESS("Done!"))

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -108,7 +108,6 @@ class Command(BaseCommand):
             call_command("createsuperuser")
 
         # Step 2: create OAuth2 provider records
-        oauth2_app = None
         if kwargs["platform"] != "none":
             self.stdout.write(self.style.SUCCESS("Creating OAuth2 app..."))
 
@@ -167,10 +166,10 @@ class Command(BaseCommand):
         # Print OAuth2 app details at the end of the file for user convenience
         # This allows the user to access their client ID and secret without needing to scroll up,
         # making it easily accessible after the script completes execution.
-        if oauth2_app:
+        if kwargs["platform"] != "none":
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Created OAuth2 app {oauth2_app.name} for edX. Your client ID is \n{oauth2_app.client_id}\nand your secret is\n{oauth2_app.client_secret}\n\n"
+                    f"== edX OAuth2 Application Details ==\nClient ID: {oauth2_app.client_id}\nSecret: {oauth2_app.client_secret}\n\n"
                 )
             )
 

--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -161,7 +161,7 @@ class Command(BaseCommand):
         # Step 3: create example course(s) and program(s)
         self.stdout.write(self.style.SUCCESS("Creating Seed Data..."))
         call_command("seed_data")
-        self.stdout.write(self.style.SUCCESS("Seed Data Created"))
+        self.stdout.write(self.style.SUCCESS("Seed Data Created\n\n"))
 
         # Print OAuth2 app details at the end of the file for user convenience
         # This allows the user to access their client ID and secret without needing to scroll up,


### PR DESCRIPTION
### What are the relevant tickets?
fixes https://github.com/mitodl/hq/issues/5772

### Description (What does it do?)
- Add a `configure_instance` management command to partially automate the MITxPro configuration process
    - Create superuser
    - Create Application entry for OAuth Provider
    - Configures wagtail by running `configure_wagtail` management command
- **Syntax**
    - `configure_instance <platform> [--dont-create-superuser|-S] [--edx-oauth-client <client id>] [--edx-oauth-secret <client secret>] [--gateway <ip>] [--tutor|-T] [--tutor-dev]`

- **Options**
    -  `<platform>` - One of macos, linux, or none. Specifying none will additionally stop creation of the OAuth2 application record for edX. Defaults to none.
    - `--dont-create-superuser|-S` - Don't create a superuser account.
    - `--gateway <ip>` - The Docker gateway IP. Required on Linux.
        - Linux users: The gateway IP of the docker-compose networking setup for xPro as found via `docker network inspect mitxpro_default | grep Gateway`
        - OSX users: Use `host.docker.internal`
    - `--edx-oauth-client <client id>` - Use the specified client ID for the edX OAuth2 client. (Useful if you're redoing your MITx Pro instance and you've already created the corresponding record in edX, since you're not allowed to edit it there.)
    - `--edx-oauth-secret <client secret>` - Use the specified client secret for the edX OAuth2 client. (Useful if you're redoing your MITx Pro instance and you've already created the corresponding record in edX, since you're not allowed to edit it there.)
    - `--tutor|-T` - Configure the instance for use with a Tutor edX deployment.
    - `--tutor-dev` - Configure the instance for use with Tutor dev or nightly.

**NOTE:** It will not create application if it already exists with name `edx-oauth-app`

### Additional Context:
- `seed_data` command is also added configure_instance to add dummy courses and programs
- Application creation removed from `seed_data` management command as it should only be responsible  to create dummy data

### Checklist:
- [x] `configure_instance` management command added to automate configuration process
