### PR TITLE
refactor: enhance topic assignment command to ignore course pages without course

### DIFF
--- a/courses/management/commands/manage_topics.py
+++ b/courses/management/commands/manage_topics.py
@@ -183,11 +183,16 @@ def perform_assign_topics(file_path):  # noqa: C901
                         if sub_topic2:
                             skipped_topics_stats.append(sub_topic2.name)
 
-                    save_page_revision(course_page, latest_revision)
+                    if latest_revision.course:
+                        save_page_revision(course_page, latest_revision)
+                        stats.append(
+                            f"{platform_name} : {course_title}  |  Topics Assigned: {', '.join(assigned_topics_stats)}  |  Topics Skipped: {', '.join(skipped_topics_stats) or None}"
+                        )
+                    else:
+                        errors.append(
+                            f"Course page has no course: {platform_name} : {course_title}"
+                        )
 
-                    stats.append(
-                        f"{platform_name} : {course_title}  |  Topics Assigned: {', '.join(assigned_topics_stats)}  |  Topics Skipped: {', '.join(skipped_topics_stats) or None}"
-                    )
             else:
                 errors.append(f"Course not found: {platform_name} : {course_title}")
     return errors, stats


### PR DESCRIPTION

### What are the relevant tickets?

None, Enhancement for https://github.com/mitodl/mitxpro/pull/3216

### Description (What does it do?)
-  The PR enhances the topics assignment command to ignore course pages that doesn't have course objects associated with them


### How can this be tested?
- If you could somehow create some course pages without course object you should
- The add these course page titles in the sheet
- Run the command, it should ignore those course pages that doesn't have a course object associated with them
