### PR TITLE
feat(api): prerequisites field added in courses and programs API

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -114,6 +114,16 @@ class CourseSerializer(serializers.ModelSerializer):
     platform = serializers.SerializerMethodField()
     marketing_hubspot_form_id = serializers.SerializerMethodField()
     availability = serializers.SerializerMethodField()
+    prerequisites = serializers.SerializerMethodField()
+
+    def get_prerequisites(self, instance):  # noqa: ARG002
+        """Get course prerequisites"""
+
+        # This is a hard coded value because the consumers of the API need this field.
+        # In an ideal situation the prerequisites could be list of courses.
+        # Since in xPRO we don't have support for prerequisites
+        # so we will not get/check for prerequisites
+        return []
 
     def get_availability(self, instance):  # noqa: ARG002
         """Get course availability"""
@@ -228,6 +238,7 @@ class CourseSerializer(serializers.ModelSerializer):
             "is_external",
             "platform",
             "availability",
+            "prerequisites",
         ]
 
 
@@ -292,6 +303,16 @@ class ProgramSerializer(serializers.ModelSerializer):
     credits = serializers.SerializerMethodField()
     platform = serializers.SerializerMethodField()
     availability = serializers.SerializerMethodField()
+    prerequisites = serializers.SerializerMethodField()
+
+    def get_prerequisites(self, instance):  # noqa: ARG002
+        """Get course prerequisites"""
+
+        # This is a hard coded value because the consumers of the API need this field.
+        # In an ideal situation the prerequisites could be list of courses.
+        # Since in xPRO we don't have support for prerequisites
+        # so we will not get/check for prerequisites
+        return []
 
     def get_availability(self, instance):  # noqa: ARG002
         """Get program availability"""
@@ -433,6 +454,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             "is_external",
             "platform",
             "availability",
+            "prerequisites",
         ]
 
 

--- a/courses/serializers_test.py
+++ b/courses/serializers_test.py
@@ -162,6 +162,7 @@ def test_serialize_program(  # noqa: PLR0913
             "marketing_hubspot_form_id": marketing_hubspot_form_id,
             "platform": program.platform.name,
             "availability": "dated",
+            "prerequisites": [],
         },
     )
     assert data["end_date"] != non_live_run.end_date.strftime(datetime_millis_format)
@@ -298,6 +299,7 @@ def test_serialize_course(  # noqa: PLR0913
             ),
             "platform": course.platform.name,
             "availability": "dated",
+            "prerequisites": [],
         },
     )
 


### PR DESCRIPTION
New field prerequisites added in courses and programs API for MIT Learn

### What are the relevant tickets?
closes: https://github.com/mitodl/hq/issues/5752

### Description (What does it do?)
New field prerequisites added in courses and programs API

### How can this be tested?
1. Check courses and program APIs
    a. /api/programs/
    b. /api/courses/
2. `prerequisites` field should be in the response

Example response:
```
[
    {
        "id": 2,
        "title": "SEED Architecture of Complex Systems",
        "description": "<p>Course 1 of 4 that comprises the Architecture and Systems Engineering Professional Certificate Program.</p>",
        "url": "http://localhost/courses/course-v1:xPRO+SysEngxB1/",
        "external_marketing_url": null,
        "marketing_hubspot_form_id": "",
        "thumbnail_url": "http://xpro.odl.local:8053/static/images/mit-dome.png",
        "readable_id": "course-v1:xPRO+SysEngxB1",
        "courseruns": [],
        "next_run_id": null,
        "topics": [
            {
                "name": "systems engineering"
            }
        ],
        "time_commitment": null,
        "duration": null,
        "video_url": null,
        "format": "Online",
        "credits": null,
        "is_external": false,
        "platform": "xPRO",
        "availability": "dated",
        "prerequisites": []
    },
]
```

### Checklist:
- [x] New field prerequisites added in courses and programs API 
