### PR TITLE
fix: strip emeritus course title during sync

### DIFF
--- a/courses/sync_external_courses/emeritus_api.py
+++ b/courses/sync_external_courses/emeritus_api.py
@@ -72,7 +72,8 @@ class EmeritusCourse:
     """
 
     def __init__(self, emeritus_course_json):
-        self.course_title = emeritus_course_json.get("program_name", None)
+        program_name = emeritus_course_json.get("program_name", None)
+        self.course_title = program_name.strip() if program_name else None
         self.course_code = emeritus_course_json.get("course_code")
 
         # Emeritus course code format is `MO-<COURSE_TAG>`, where course tag can contain `.`,

--- a/courses/sync_external_courses/emeritus_api_test.py
+++ b/courses/sync_external_courses/emeritus_api_test.py
@@ -744,7 +744,7 @@ def test_save_page_revision(is_draft_page, has_unpublished_changes):
     ("title", "course_code", "course_run_code", "is_valid"),
     [
         (
-            "Internet of Things (IoT): Design and Applications",
+            "Internet of Things (IoT): Design and Applications     ",
             "MO-DBIP",
             "MO-DBIP.ELE-99-07#1",
             True,
@@ -752,13 +752,13 @@ def test_save_page_revision(is_draft_page, has_unpublished_changes):
         ("", "MO-DBIP", "MO-DBIP.ELE-99-07#1", False),
         (None, "MO-DBIP", "MO-DBIP.ELE-99-07#1", False),
         (
-            "Internet of Things (IoT): Design and Applications",
+            "    Internet of Things (IoT): Design and Applications   ",
             "",
             "MO-DBIP.ELE-99-07#1",
             False,
         ),
         (
-            "Internet of Things (IoT): Design and Applications",
+            "    Internet of Things (IoT): Design and Applications",
             None,
             "MO-DBIP.ELE-99-07#1",
             False,
@@ -776,7 +776,7 @@ def test_emeritus_course_validate_required_fields(
     Tests that EmeritusCourse.validate_required_fields validates required fields.
     """
     emeritus_course = EmeritusCourse(emeritus_course_data)
-    emeritus_course.course_title = title
+    emeritus_course.course_title = title.strip() if title else title
     emeritus_course.course_code = course_code
     emeritus_course.course_run_code = course_run_code
     assert emeritus_course.validate_required_fields() == is_valid


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/5991

### Description (What does it do?)
<!--- Describe your changes in detail -->
Strip the Emeritus course titles to avoid trailing spaces in the course titles.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Not sure if there is any bad data in the API. You can test the changes manually.
