### PR TITLE
feat: add emeritus api list view

### DIFF
--- a/courses/urls.py
+++ b/courses/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path, re_path
 from rest_framework import routers
 
 from courses.views import v1
+from courses.views.v1 import EmeritusCourseListView
 
 router = routers.SimpleRouter()
 router.register(r"programs", v1.ProgramViewSet, basename="programs_api")
@@ -28,5 +29,10 @@ urlpatterns = [
     path("api/", include(router.urls)),
     re_path(
         r"^api/enrollments/", v1.UserEnrollmentsView.as_view(), name="user-enrollments"
+    ),
+    path(
+        "api/emeritus_courses/",
+        EmeritusCourseListView.as_view(),
+        name="emeritus_courses",
     ),
 ]

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -4,7 +4,7 @@ from django.db.models import Prefetch, Q
 from mitol.digitalcredentials.mixins import DigitalCredentialsRequestViewSetMixin
 from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -210,13 +210,12 @@ class EmeritusCourseListView(APIView):
     ReadOnly View to list Emeritus courses.
     """
 
+    permission_classes = [IsAdminUser]
+
     def get(self, request, *args, **kwargs):  # noqa: ARG002
         """
         Get Emeritus courses list from the Emeritus API and return it.
         """
-        if not request.user.is_authenticated or not request.user.is_superuser:
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
-
         try:
             data = fetch_emeritus_courses()
             return Response(data, status=status.HTTP_200_OK)

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -1,5 +1,7 @@
 """Course views verson 1"""
 
+import logging
+
 from django.db.models import Prefetch, Q
 from mitol.digitalcredentials.mixins import DigitalCredentialsRequestViewSetMixin
 from rest_framework import status, viewsets
@@ -29,6 +31,8 @@ from courses.serializers import (
 )
 from courses.sync_external_courses.emeritus_api import fetch_emeritus_courses
 from ecommerce.models import Product
+
+log = logging.getLogger(__name__)
 
 
 class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
@@ -219,7 +223,8 @@ class EmeritusCourseListView(APIView):
         try:
             data = fetch_emeritus_courses()
             return Response(data, status=status.HTTP_200_OK)
-        except Exception:  # noqa: BLE001
+        except Exception:
+            log.exception("Some error occurred fetching Emeritus courses")
             return Response(
                 {"error": "Some error occurred."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -27,6 +27,7 @@ from courses.serializers import (
     ProgramEnrollmentSerializer,
     ProgramSerializer,
 )
+from courses.sync_external_courses.emeritus_api import fetch_emeritus_courses
 from ecommerce.models import Product
 
 
@@ -202,3 +203,22 @@ class CourseTopicViewSet(viewsets.ReadOnlyModelViewSet):
         Returns parent topics with course count > 0.
         """
         return CourseTopic.parent_topics_with_courses()
+
+
+class EmeritusCourseListView(APIView):
+    """
+    ReadOnly View to list Emeritus courses.
+    """
+
+    def get(self, request, *args, **kwargs):  # noqa: ARG002
+        """
+        Get Emeritus courses list from the Emeritus API and return it.
+        """
+        try:
+            data = fetch_emeritus_courses()
+            return Response(data, status=status.HTTP_200_OK)
+        except Exception:  # noqa: BLE001
+            return Response(
+                {"error": "Some error occurred."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -214,6 +214,9 @@ class EmeritusCourseListView(APIView):
         """
         Get Emeritus courses list from the Emeritus API and return it.
         """
+        if not request.user.is_authenticated or not request.user.is_superuser:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
         try:
             data = fetch_emeritus_courses()
             return Response(data, status=status.HTTP_200_OK)

--- a/courses/views/v1/__init__.py
+++ b/courses/views/v1/__init__.py
@@ -1,7 +1,5 @@
 """Course views verson 1"""
 
-import logging
-
 from django.db.models import Prefetch, Q
 from mitol.digitalcredentials.mixins import DigitalCredentialsRequestViewSetMixin
 from rest_framework import status, viewsets
@@ -31,8 +29,6 @@ from courses.serializers import (
 )
 from courses.sync_external_courses.emeritus_api import fetch_emeritus_courses
 from ecommerce.models import Product
-
-log = logging.getLogger(__name__)
 
 
 class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
@@ -223,9 +219,8 @@ class EmeritusCourseListView(APIView):
         try:
             data = fetch_emeritus_courses()
             return Response(data, status=status.HTTP_200_OK)
-        except Exception:
-            log.exception("Some error occurred fetching Emeritus courses")
+        except Exception as e:  # noqa: BLE001
             return Response(
-                {"error": "Some error occurred."},
+                {"error": "Some error occurred.", "details": str(e)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/courses/views_test.py
+++ b/courses/views_test.py
@@ -634,7 +634,10 @@ def test_emeritus_course_list_view(admin_drf_client, mocker, expected_status_cod
             "courses.views.v1.fetch_emeritus_courses",
             side_effect=Exception("Some error occurred."),
         )
-        mocked_response = {"error": "Some error occurred."}
+        mocked_response = {
+            "error": "Some error occurred.",
+            "details": "Some error occurred.",
+        }
 
     response = admin_drf_client.get(reverse("emeritus_courses"))
     assert response.json() == mocked_response


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/mitxpro/issues/3328

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds an API to list the Emeritus Course data.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Test that the new API view returns the data at `api/emeritus_courses/`