### PR TITLE
feat: make course searchable in courseRun admin

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -92,6 +92,7 @@ class CourseRunAdmin(TimestampedModelAdmin):
     )
     list_filter = ["live", "course__platform", "course"]
     list_select_related = ["course", "course__platform"]
+    autocomplete_fields = ["course"]
 
     formfield_overrides = {
         models.CharField: {"widget": TextInput(attrs={"size": "80"})}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6330

### Description (What does it do?)
This PR makes the course key searchable in CourseRun Admin

### Screenshots (if appropriate):
<img width="1188" alt="Image" src="https://github.com/user-attachments/assets/0a937735-57c0-499b-8cd1-ad4da868637d" />

### How can this be tested?
1. Go to xpro admin `/admin`
2. Add entry for `courseRun` `/admin/courses/courserun/add/`
3. click on course filed drop drown and search course
