### PR TITLE
fix: npm tests locally

### DIFF
--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -9,7 +9,7 @@ elif [[ -n $CODECOV ]]; then
 elif [[ -n $WATCH ]]; then
 	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha --watch"
 else
-	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha "
+	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha"
 fi
 
 export FILE_PATTERN=${1:-'"static/**/*/*_test.js"'}

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -3,13 +3,13 @@ TMP_FILE=$(mktemp)
 export TMP_FILE
 
 if [[ -n $COVERAGE ]]; then
-	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=html mocha"
+	export CMD="node --no-experimental-detect-module ./node_modules/nyc/bin/nyc.js --reporter=html mocha"
 elif [[ -n $CODECOV ]]; then
-	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
+	export CMD="node --no-experimental-detect-module ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
 elif [[ -n $WATCH ]]; then
-	export CMD="node ./node_modules/mocha/bin/_mocha --watch"
+	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha --watch"
 else
-	export CMD="node ./node_modules/mocha/bin/_mocha"
+	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha "
 fi
 
 export FILE_PATTERN=${1:-'"static/**/*/*_test.js"'}


### PR DESCRIPTION
### What are the relevant tickets?
JS tests were not running locally and throwing error:
```
Exception during run: SyntaxError[ @/src/static/js/components/B2BPurchaseSummary_test.js ]: Unexpected token '<'
```

### Description (What does it do?)
The tests were failing to run locally and were throwing the error mentioned above. After investigation, it was identified that the issue began following the merge of the Node.js upgrade PR ([#3244](https://github.com/mitodl/mitxpro/pull/3244)), which upgraded Node.js to version 22.11.0. The root cause of the issue was the `--experimental-detect-module` flag, which is enabled by default starting from Node.js v22.7.0 ([Reference](https://nodejs.org/en/blog/release/v22.7.0#2024-08-22-version-2270-current-rafaelgss)).

This PR resolves the issue by explicitly disabling the `--experimental-detect-module` flag, ensuring that tests can run on local setups without errors.

Note: A deprecation warning for the punycode module still appears when running the tests. This will be addressed in a separate PR.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- On master branch, in the watch container shell, run `npm run test`
- You will encounter the error mentioned above
- Checkout to this branch and run the command again
- The tests will start to run

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
