### PR TITLE
revert: node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 20.16.0
+          node-version: 20.18.0
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     extra_hosts: *default-extra-hosts
 
   watch:
-    image: node:22.11.0
+    image: node:20.18.0
     working_dir: /src
     command: >
       /bin/bash -c './webpack_dev_server.sh --install'

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "yup": "^1.0.0"
   },
   "engines": {
-    "node": "22.11.0"
+    "node": "20.18.0"
   },
   "scripts": {
     "postinstall": "./webpack_if_prod.sh",

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -3,13 +3,13 @@ TMP_FILE=$(mktemp)
 export TMP_FILE
 
 if [[ -n $COVERAGE ]]; then
-	export CMD="node --no-experimental-detect-module ./node_modules/nyc/bin/nyc.js --reporter=html mocha"
+	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=html mocha"
 elif [[ -n $CODECOV ]]; then
-	export CMD="node --no-experimental-detect-module ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
+	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
 elif [[ -n $WATCH ]]; then
-	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha --watch"
+	export CMD="node ./node_modules/mocha/bin/_mocha --watch"
 else
-	export CMD="node --no-experimental-detect-module ./node_modules/mocha/bin/_mocha"
+	export CMD="node ./node_modules/mocha/bin/_mocha"
 fi
 
 export FILE_PATTERN=${1:-'"static/**/*/*_test.js"'}


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR pins node version to 20.18.0 in both CI and docker image

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Tests should pass locally and in CI

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
