### PR TITLE
refactor: remove ENABLE_TAXES_DISPLAY feature flag

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -157,9 +157,9 @@ def calculate_tax(
     return (0, "", item_price)
 
 
-def display_taxes(request):
+def is_tax_applicable(request):
     """
-    Returns a boolean to manage the taxes display.
+    Returns a boolean to indicate whether the user is tax applicable.
 
     Args:
         request(HttpRequest): Request object

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -21,7 +21,6 @@ from django.db.models import Count, F, Max, Prefetch, Q, Subquery
 from django.http import HttpRequest
 from django.urls import reverse
 from ipware import get_client_ip
-from mitol.olposthog.features import is_enabled
 from rest_framework.exceptions import ValidationError
 
 import sheets.tasks
@@ -70,7 +69,6 @@ from ecommerce.models import (
 from ecommerce.utils import positive_or_zero
 from hubspot_xpro.task_helpers import sync_hubspot_deal
 from maxmind.api import ip_to_country_code
-from mitxpro import features
 from mitxpro.utils import case_insensitive_equal, first_or_none, now_in_utc
 
 log = logging.getLogger(__name__)
@@ -167,13 +165,10 @@ def display_taxes(request):
         request(HttpRequest): Request object
 
     Returns:
-        Boolean: True if flag and taxes are enabled for the specific country.
+        Boolean: True if taxes are enabled for the specific country.
     """
     visitor_country = determine_visitor_country(request)
-    return (
-        is_enabled(features.ENABLE_TAXES_DISPLAY, default=True)
-        and TaxRate.objects.filter(active=True, country_code=visitor_country).exists()
-    )
+    return TaxRate.objects.filter(active=True, country_code=visitor_country).exists()
 
 
 def generate_cybersource_sa_signature(payload):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -21,6 +21,7 @@ from django.db.models import Count, F, Max, Prefetch, Q, Subquery
 from django.http import HttpRequest
 from django.urls import reverse
 from ipware import get_client_ip
+from mitol.olposthog.features import is_enabled
 from rest_framework.exceptions import ValidationError
 
 import sheets.tasks
@@ -69,6 +70,7 @@ from ecommerce.models import (
 from ecommerce.utils import positive_or_zero
 from hubspot_xpro.task_helpers import sync_hubspot_deal
 from maxmind.api import ip_to_country_code
+from mitxpro import features
 from mitxpro.utils import case_insensitive_equal, first_or_none, now_in_utc
 
 log = logging.getLogger(__name__)
@@ -169,7 +171,7 @@ def display_taxes(request):
     """
     visitor_country = determine_visitor_country(request)
     return (
-        settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False)
+        is_enabled(features.ENABLE_TAXES_DISPLAY, default=True)
         and TaxRate.objects.filter(active=True, country_code=visitor_country).exists()
     )
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -39,7 +39,6 @@ from ecommerce.api import (
     complete_order,
     create_coupons,
     create_unfulfilled_order,
-    display_taxes,
     enroll_user_in_order_items,
     fetch_and_serialize_unused_coupons,
     generate_cybersource_sa_payload,
@@ -52,6 +51,7 @@ from ecommerce.api import (
     get_product_version_price_with_discount,
     get_readable_id,
     get_valid_coupon_versions,
+    is_tax_applicable,
     latest_coupon_version,
     latest_product_version,
     make_receipt_url,
@@ -1885,7 +1885,7 @@ def test_tax_country_and_no_ip_tax(user):
         (False, "US", "US", "US", False, False, False),
     ],
 )
-def test_display_taxes(  # noqa: PLR0913
+def test_is_tax_applicable(  # noqa: PLR0913
     is_force_profile_country_flag_enabled,
     user_profile_country,
     user_determined_country,
@@ -1896,7 +1896,7 @@ def test_display_taxes(  # noqa: PLR0913
     mocker,
 ):
     """
-    Tests that `display_taxes` returns the expected display status.
+    Tests that `is_tax_applicable` returns the expected display status.
     """
     mocker.patch(
         "ecommerce.api.determine_visitor_country", return_value=user_determined_country
@@ -1909,4 +1909,4 @@ def test_display_taxes(  # noqa: PLR0913
     if tax_rate_created:
         TaxRateFactory.create(country_code=tax_rate_country, active=tax_rate_enabled)
 
-    assert display_taxes(request) == expected_taxes_display
+    assert is_tax_applicable(request) == expected_taxes_display

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1903,7 +1903,7 @@ def test_display_taxes(  # noqa: PLR0913
     mocker.patch(
         "ecommerce.api.determine_visitor_country", return_value=user_determined_country
     )
-    settings.FEATURES["ENABLE_TAXES_DISPLAY"] = is_taxes_display_flag_enabled
+    mocker.patch("ecommerce.api.is_enabled", return_value=is_taxes_display_flag_enabled)
     settings.ECOMMERCE_FORCE_PROFILE_COUNTRY = is_force_profile_country_flag_enabled
     user = UserFactory.create(legal_address__country=user_profile_country)
     request = FakeRequest()

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -1866,7 +1866,6 @@ def test_tax_country_and_no_ip_tax(user):
 
 @pytest.mark.parametrize(
     (
-        "is_taxes_display_flag_enabled",
         "is_force_profile_country_flag_enabled",
         "user_profile_country",
         "user_determined_country",
@@ -1876,18 +1875,17 @@ def test_tax_country_and_no_ip_tax(user):
         "expected_taxes_display",
     ),
     [
-        (True, True, "US", "US", "US", True, True, True),
-        (True, True, "US", "US", "PK", True, True, False),
-        (True, False, "US", "US", "US", True, True, True),
-        (True, False, "PK", "US", "US", True, True, True),
-        (True, False, "PK", "US", "PK", True, True, False),
-        (True, False, "US", "US", "US", True, False, False),
-        (True, False, "PK", "US", "US", True, False, False),
-        (True, False, "US", "US", "US", False, False, False),
+        (True, "US", "US", "US", True, True, True),
+        (True, "US", "US", "PK", True, True, False),
+        (False, "US", "US", "US", True, True, True),
+        (False, "PK", "US", "US", True, True, True),
+        (False, "PK", "US", "PK", True, True, False),
+        (False, "US", "US", "US", True, False, False),
+        (False, "PK", "US", "US", True, False, False),
+        (False, "US", "US", "US", False, False, False),
     ],
 )
 def test_display_taxes(  # noqa: PLR0913
-    is_taxes_display_flag_enabled,
     is_force_profile_country_flag_enabled,
     user_profile_country,
     user_determined_country,
@@ -1903,7 +1901,6 @@ def test_display_taxes(  # noqa: PLR0913
     mocker.patch(
         "ecommerce.api.determine_visitor_country", return_value=user_determined_country
     )
-    mocker.patch("ecommerce.api.is_enabled", return_value=is_taxes_display_flag_enabled)
     settings.ECOMMERCE_FORCE_PROFILE_COUNTRY = is_force_profile_country_flag_enabled
     user = UserFactory.create(legal_address__country=user_profile_country)
     request = FakeRequest()

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -357,7 +357,7 @@ def send_ecommerce_order_receipt(order, cyber_source_provided_email=None):
                                     "company": purchaser.get("company"),
                                     "vat_id": purchaser.get("vat_id"),
                                 },
-                                "enable_taxes_display": bool(order["tax_rate"]),
+                                "is_tax_applicable": bool(order["tax_rate"]),
                                 "support_email": settings.EMAIL_SUPPORT,
                             },
                         ),

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -260,7 +260,7 @@ def test_send_b2b_receipt_email_error(mocker):
 )
 def test_send_ecommerce_order_receipt(mocker, receipt_data, settings):
     """send_ecommerce_order_receipt should send a receipt email"""
-    settings.FEATURES["ENABLE_TAXES_DISPLAY"] = False
+    mocker.patch("ecommerce.api.display_taxes", return_value=False)
     patched_mail_api = mocker.patch("ecommerce.mail_api.api")
     date = datetime.datetime(2010, 1, 1, 0, tzinfo=datetime.UTC)
     user = UserFactory.create(

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -260,7 +260,7 @@ def test_send_b2b_receipt_email_error(mocker):
 )
 def test_send_ecommerce_order_receipt(mocker, receipt_data, settings):
     """send_ecommerce_order_receipt should send a receipt email"""
-    mocker.patch("ecommerce.api.display_taxes", return_value=False)
+    mocker.patch("ecommerce.api.is_tax_applicable", return_value=False)
     patched_mail_api = mocker.patch("ecommerce.mail_api.api")
     date = datetime.datetime(2010, 1, 1, 0, tzinfo=datetime.UTC)
     user = UserFactory.create(
@@ -344,7 +344,7 @@ def test_send_ecommerce_order_receipt(mocker, receipt_data, settings):
                 "company": user.profile.company,
                 "vat_id": "AT12349876",
             },
-            "enable_taxes_display": False,
+            "is_tax_applicable": False,
             "support_email": settings.EMAIL_SUPPORT,
         },
     )

--- a/mail/templates/product_order_receipt/body.html
+++ b/mail/templates/product_order_receipt/body.html
@@ -21,7 +21,7 @@
       <br />
       Cambridge, MA 02139 USA
       <br />
-      {% if enable_taxes_display %}
+      {% if is_tax_applicable %}
       GSTIN: 9923USA29055OSB
       <br />
       {% endif %}
@@ -51,7 +51,7 @@
             {% for line in lines %}
             <p>
                 <strong style="font-weight: 700;">Order Item:</strong> {{ line.content_title }}<br>
-                {% if enable_taxes_display %}
+                {% if is_tax_applicable %}
                 <strong style="font-weight: 700;">HSN:</strong> 9992<br>
                 {% endif %}
                 <strong style="font-weight: 700;">Product Number:</strong> {{ line.readable_id }}<br>
@@ -61,7 +61,7 @@
                 <strong style="font-weight: 700;">Quantity:</strong>  {{ line.quantity }}<br>
                 <strong style="font-weight: 700;">Unit Price:</strong> ${{ line.price }}<br>
                 <strong style="font-weight: 700;">Discount:</strong> {{ line.discount|format_discount }}<br>
-                {% if enable_taxes_display %}
+                {% if is_tax_applicable %}
                 <strong style="font-weight: 700;">Total Before Tax:</strong> ${{ line.total_before_tax|floatformat:2 }}<br>
                 <strong style="font-weight: 700;">Tax ({{ order.tax_rate|floatformat:"-2" }}%):</strong> ${{ line.tax_paid|floatformat:2 }}<br>
                 {% endif %}

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -1,3 +1,1 @@
 """MIT xPro feature flags"""
-
-ENABLE_TAXES_DISPLAY = "ENABLE_TAXES_DISPLAY"

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -1,0 +1,3 @@
+"""MIT xPro feature flags"""
+
+ENABLE_TAXES_DISPLAY = "ENABLE_TAXES_DISPLAY"

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -1,1 +1,0 @@
-"""MIT xPro feature flags"""

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -581,7 +581,7 @@ def get_js_settings(request: HttpRequest):
     Returns:
         dict: the settings object
     """
-    from ecommerce.api import display_taxes
+    from ecommerce.api import is_tax_applicable
 
     return {
         "gtmTrackingID": settings.GTM_TRACKING_ID,
@@ -602,7 +602,7 @@ def get_js_settings(request: HttpRequest):
         "course_dropdown": settings.FEATURES.get("COURSE_DROPDOWN", False),
         "webinars": settings.FEATURES.get("WEBINARS", False),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
-        "enable_taxes_display": display_taxes(request),
+        "is_tax_applicable": is_tax_applicable(request),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,
         "posthog_api_host": settings.POSTHOG_API_HOST,

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 from rest_framework import status
 
-from ecommerce.api import display_taxes
+from ecommerce.api import is_tax_applicable
 from ecommerce.models import Order
 from mitxpro.test_utils import MockResponse
 from mitxpro.utils import (
@@ -475,7 +475,7 @@ def test_get_js_settings(settings, rf, user, mocker):
     settings.FEATURES["WEBINARS"] = False
     settings.FEATURES["ENABLE_BLOG"] = False
     settings.FEATURES["ENABLE_ENTERPRISE"] = False
-    mocker.patch("ecommerce.api.display_taxes", return_value=False)
+    mocker.patch("ecommerce.api.is_tax_applicable", return_value=False)
 
     request = rf.get("/")
     request.user = user
@@ -495,7 +495,7 @@ def test_get_js_settings(settings, rf, user, mocker):
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "course_dropdown": settings.FEATURES.get("COURSE_DROPDOWN", False),
         "webinars": settings.FEATURES.get("WEBINARS", False),
-        "enable_taxes_display": display_taxes(request),
+        "is_tax_applicable": is_tax_applicable(request),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 from rest_framework import status
 
+from ecommerce.api import display_taxes
 from ecommerce.models import Order
 from mitxpro.test_utils import MockResponse
 from mitxpro.utils import (
@@ -455,7 +456,7 @@ def test_request_get_with_timeout_retry(mocker):
     assert result == mock_response
 
 
-def test_get_js_settings(settings, rf, user):
+def test_get_js_settings(settings, rf, user, mocker):
     """Test get_js_settings"""
     settings.GA_TRACKING_ID = "fake"
     settings.GTM_TRACKING_ID = "fake"
@@ -472,9 +473,9 @@ def test_get_js_settings(settings, rf, user):
     settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
     settings.FEATURES["COURSE_DROPDOWN"] = False
     settings.FEATURES["WEBINARS"] = False
-    settings.FEATURES["ENABLE_TAXES_DISPLAY"] = False
     settings.FEATURES["ENABLE_BLOG"] = False
     settings.FEATURES["ENABLE_ENTERPRISE"] = False
+    mocker.patch("ecommerce.api.display_taxes", return_value=False)
 
     request = rf.get("/")
     request.user = user
@@ -494,7 +495,7 @@ def test_get_js_settings(settings, rf, user):
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "course_dropdown": settings.FEATURES.get("COURSE_DROPDOWN", False),
         "webinars": settings.FEATURES.get("WEBINARS", False),
-        "enable_taxes_display": settings.FEATURES.get("ENABLE_TAXES_DISPLAY", False),
+        "enable_taxes_display": display_taxes(request),
         "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,

--- a/static/js/components/forms/CheckoutForm.js
+++ b/static/js/components/forms/CheckoutForm.js
@@ -345,7 +345,7 @@ export class InnerCheckoutForm extends React.Component<InnerProps, InnerState> {
                     </span>
                   </div>
                 ) : null}
-                {SETTINGS.enable_taxes_display ? (
+                {SETTINGS.is_tax_applicable ? (
                   <div>
                     <div className="bar" />
                     <div className="flex-row total-before-tax-row">

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -114,7 +114,7 @@ describe("CheckoutForm", () => {
   });
   [true, false].forEach((taxDisplayEnabled) => {
     it(`handles basket tax details display as per feature flag`, async () => {
-      SETTINGS.enable_taxes_display = taxDisplayEnabled;
+      SETTINGS.is_tax_applicable = taxDisplayEnabled;
 
       const inner = await renderForm();
 
@@ -136,7 +136,7 @@ describe("CheckoutForm", () => {
     it(`Calculates and displayes the tax correctly ${
       hasCoupon ? "with" : "without"
     } a coupon`, async () => {
-      SETTINGS.enable_taxes_display = true;
+      SETTINGS.is_tax_applicable = true;
       basket.tax_info.tax_rate = taxRate;
 
       const inner = await renderForm({

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -21,7 +21,7 @@ declare type Settings = {
   course_dropdown: boolean,
   webinars: boolean,
   enable_blog: boolean,
-  enable_taxes_display: boolean,
+  is_tax_applicable: boolean,
   enable_enterprise: boolean,
   posthog_api_token: ?string,
   posthog_api_host: ?string


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6369

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes ENABLE_TAXES_DISPLAY feature flag.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Enable ECOMMERCE_FORCE_PROFILE_COUNTRY and add TaxRate for your profile country in the admin.
- Checkout any product and see that taxes are displayed and applied at the checkout, email receipt and dashboard receipt.
- Now disable the tax rate and see that taxes are not visible.