### PR TITLE
refactor: remove ENABLE_BLOG & WEBINARS feature flags

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1640,7 +1640,6 @@ class NewsAndEventsPage(DisableSitemapURLMixin, Page):
         "ExternalCoursePage",
         "CoursePage",
         "ProgramPage",
-        "HomePage",
         "ExternalProgramPage",
     ]
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -856,17 +856,6 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
         return self._get_child_page_of_type(UserTestimonialsPage)
 
     @property
-    def news_and_events(self):
-        """
-        Gets the news and events section subpage
-        """
-        webinars_enabled = settings.FEATURES.get("WEBINARS", False)
-        if webinars_enabled:
-            return None
-
-        return self._get_child_page_of_type(NewsAndEventsPage)
-
-    @property
     def upcoming_courseware(self):
         """
         Gets the upcoming courseware section subpage
@@ -909,7 +898,6 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
             "image_carousel_section": self.image_carousel_section,
             "inquiry_section": self.inquiry_section,
             "learning_experience": self.learning_experience,
-            "news_and_events": self.news_and_events,
             "testimonials": self.testimonials,
             "upcoming_courseware": self.upcoming_courseware,
         }

--- a/cms/models.py
+++ b/cms/models.py
@@ -860,10 +860,8 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
         """
         Gets the news and events section subpage
         """
-        webinar_or_blog_enabled = settings.FEATURES.get(
-            "WEBINARS", False
-        ) or settings.FEATURES.get("ENABLE_BLOG", False)
-        if webinar_or_blog_enabled:
+        webinars_enabled = settings.FEATURES.get("WEBINARS", False)
+        if webinars_enabled:
             return None
 
         return self._get_child_page_of_type(NewsAndEventsPage)

--- a/cms/models.py
+++ b/cms/models.py
@@ -828,7 +828,6 @@ class HomePage(RoutablePageMixin, MetadataPageMixin, WagtailCachedPageMixin, Pag
         "CoursesInProgramPage",
         "LearningTechniquesPage",
         "UserTestimonialsPage",
-        "NewsAndEventsPage",
         "ForTeamsPage",
         "TextVideoSection",
         "ResourcePage",

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -351,27 +351,6 @@ def test_home_page_testimonials():
         assert testimonial.value.get("quote") == "quote"
 
 
-def test_home_page_news_and_events():
-    """
-    NewsAndEvents subpage should provide expected values
-    """
-    home_page = HomePageFactory.create()
-    assert not home_page.news_and_events
-
-    del home_page.child_pages
-
-    news_and_events_page = create_news_and_events(parent=home_page)
-    assert home_page.news_and_events == news_and_events_page
-    assert news_and_events_page.heading == "heading"
-    for count, news_and_events in enumerate(news_and_events_page.items):
-        assert news_and_events.value.get("content_type") == f"content_type-{count}"
-        assert news_and_events.value.get("title") == f"title-{count}"
-        assert news_and_events.value.get("image").title == f"image-{count}"
-        assert news_and_events.value.get("content") == f"content-{count}"
-        assert news_and_events.value.get("call_to_action") == f"call_to_action-{count}"
-        assert news_and_events.value.get("action_url") == f"action_url-{count}"
-
-
 def test_home_page_inquiry_section():
     """
     inquiry_section property should return expected values

--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -42,9 +42,6 @@
 {% if testimonials %}
 {% include "partials/testimonial-carousel.html" with page=testimonials %}
 {% endif %}
-{% if news_and_events %}
-{% include "partials/news-and-events-carousel.html" with page=news_and_events %}
-{% endif %}
 {% if inquiry_section %}
 {% include "partials/for-teams.html" with page=inquiry_section %}
 {% endif %}

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -600,7 +600,6 @@ def get_js_settings(request: HttpRequest):
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "webinars": settings.FEATURES.get("WEBINARS", False),
-        "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
         "is_tax_applicable": is_tax_applicable(request),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -599,7 +599,6 @@ def get_js_settings(request: HttpRequest):
         },
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
-        "webinars": settings.FEATURES.get("WEBINARS", False),
         "is_tax_applicable": is_tax_applicable(request),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -472,7 +472,6 @@ def test_get_js_settings(settings, rf, user, mocker):
     settings.FEATURES["DIGITAL_CREDENTIALS"] = True
     settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
     settings.FEATURES["WEBINARS"] = False
-    settings.FEATURES["ENABLE_BLOG"] = False
     settings.FEATURES["ENABLE_ENTERPRISE"] = False
     mocker.patch("ecommerce.api.is_tax_applicable", return_value=False)
 
@@ -494,7 +493,6 @@ def test_get_js_settings(settings, rf, user, mocker):
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "webinars": settings.FEATURES.get("WEBINARS", False),
         "is_tax_applicable": is_tax_applicable(request),
-        "enable_blog": settings.FEATURES.get("ENABLE_BLOG", False),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,
         "posthog_api_host": settings.POSTHOG_API_HOST,

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -471,7 +471,6 @@ def test_get_js_settings(settings, rf, user, mocker):
     }
     settings.FEATURES["DIGITAL_CREDENTIALS"] = True
     settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
-    settings.FEATURES["WEBINARS"] = False
     settings.FEATURES["ENABLE_ENTERPRISE"] = False
     mocker.patch("ecommerce.api.is_tax_applicable", return_value=False)
 
@@ -491,7 +490,6 @@ def test_get_js_settings(settings, rf, user, mocker):
         "zendesk_config": {"help_widget_enabled": False, "help_widget_key": "fake_key"},
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
-        "webinars": settings.FEATURES.get("WEBINARS", False),
         "is_tax_applicable": is_tax_applicable(request),
         "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -85,13 +85,11 @@ const TopAppBar = ({
                 </a>
               </li>
             ) : null}
-            {SETTINGS.enable_blog ? (
-              <li>
-                <a href={routes.blog} className="blog-link" aria-label="blog">
-                  Blog
-                </a>
-              </li>
-            ) : null}
+            <li>
+              <a href={routes.blog} className="blog-link" aria-label="blog">
+                Blog
+              </a>
+            </li>
             {shouldShowLoginSignup(location) ? (
               currentUser && currentUser.is_authenticated ? (
                 <li>

--- a/static/js/components/TopAppBar.js
+++ b/static/js/components/TopAppBar.js
@@ -74,17 +74,15 @@ const TopAppBar = ({
                 </a>
               </li>
             ) : null}
-            {SETTINGS.webinars ? (
-              <li>
-                <a
-                  href={routes.webinars}
-                  className="webinar-link"
-                  aria-label="webinars"
-                >
-                  Webinars
-                </a>
-              </li>
-            ) : null}
+            <li>
+              <a
+                href={routes.webinars}
+                className="webinar-link"
+                aria-label="webinars"
+              >
+                Webinars
+              </a>
+            </li>
             <li>
               <a href={routes.blog} className="blog-link" aria-label="blog">
                 Blog

--- a/static/js/components/TopAppBar_test.js
+++ b/static/js/components/TopAppBar_test.js
@@ -125,19 +125,6 @@ describe("TopAppBar component", () => {
           .find("CatalogMenu")
           .exists(),
       );
-      assert.isNotOk(
-        shallow(
-          <TopAppBar
-            currentUser={user}
-            location={null}
-            errorPageHeader={null}
-            courseTopics={courseTopics}
-          />,
-        )
-          .find("a")
-          .at(1)
-          .exists(),
-      );
       assert.equal(
         shallow(
           <TopAppBar
@@ -148,7 +135,7 @@ describe("TopAppBar component", () => {
           />,
         )
           .find("a")
-          .at(2)
+          .at(1)
           .prop("href"),
         routes.webinars,
       );
@@ -162,7 +149,7 @@ describe("TopAppBar component", () => {
           />,
         )
           .find("a")
-          .at(3)
+          .at(2)
           .prop("href"),
         routes.blog,
       );

--- a/static/js/components/TopAppBar_test.js
+++ b/static/js/components/TopAppBar_test.js
@@ -112,34 +112,60 @@ describe("TopAppBar component", () => {
           .exists(),
       );
     });
-    [true, false].forEach((courseDropdown) => {
-      it("has a CatalogMenu component", () => {
-        assert.isOk(
-          shallow(
-            <TopAppBar
-              currentUser={user}
-              location={null}
-              errorPageHeader={null}
-              courseTopics={courseTopics}
-            />,
-          )
-            .find("CatalogMenu")
-            .exists(),
-        );
-        assert.isNotOk(
-          shallow(
-            <TopAppBar
-              currentUser={user}
-              location={null}
-              errorPageHeader={null}
-              courseTopics={courseTopics}
-            />,
-          )
-            .find("a")
-            .at(1)
-            .exists(),
-        );
-      });
+    it("has a CatalogMenu component", () => {
+      assert.isOk(
+        shallow(
+          <TopAppBar
+            currentUser={user}
+            location={null}
+            errorPageHeader={null}
+            courseTopics={courseTopics}
+          />,
+        )
+          .find("CatalogMenu")
+          .exists(),
+      );
+      assert.isNotOk(
+        shallow(
+          <TopAppBar
+            currentUser={user}
+            location={null}
+            errorPageHeader={null}
+            courseTopics={courseTopics}
+          />,
+        )
+          .find("a")
+          .at(1)
+          .exists(),
+      );
+      assert.equal(
+        shallow(
+          <TopAppBar
+            currentUser={user}
+            location={null}
+            errorPageHeader={null}
+            courseTopics={courseTopics}
+          />,
+        )
+          .find("a")
+          .at(2)
+          .prop("href"),
+        routes.webinars,
+      );
+      assert.equal(
+        shallow(
+          <TopAppBar
+            currentUser={user}
+            location={null}
+            errorPageHeader={null}
+            courseTopics={courseTopics}
+          />,
+        )
+          .find("a")
+          .at(3)
+          .prop("href"),
+        routes.blog,
+      );
     });
 
     it("does have a button to collapse the menu", () => {

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -19,7 +19,6 @@ declare type Settings = {
   digital_credentials: boolean,
   digital_credentials_supported_runs: Array<string>,
   webinars: boolean,
-  enable_blog: boolean,
   is_tax_applicable: boolean,
   enable_enterprise: boolean,
   posthog_api_token: ?string,

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -18,7 +18,6 @@ declare type Settings = {
   },
   digital_credentials: boolean,
   digital_credentials_supported_runs: Array<string>,
-  webinars: boolean,
   is_tax_applicable: boolean,
   enable_enterprise: boolean,
   posthog_api_token: ?string,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6366 & https://github.com/mitodl/hq/issues/6367

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes the ENABLE_BLOG, and WEBINARS feature flags as it has been active for some time now.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Check out this branch. The blog and webinar links in the header should work. The links should not depend on any flag.