### PR TITLE
refactor: migrate FEATURE_ENROLLMENT_WELCOME_EMAIL to posthog

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -7,6 +7,7 @@ import pycountry
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
+from mitol.olposthog import features
 
 from courses.models import CourseRun
 from ecommerce.constants import BULK_ENROLLMENT_EMAIL_TAG, CYBERSOURCE_CARD_TYPES
@@ -200,8 +201,8 @@ def send_course_run_enrollment_welcome_email(enrollment):
     Args:
         enrollment (CourseRunEnrollment): the enrollment for which to send the welcome email
     """
-    if not settings.FEATURES.get("ENROLLMENT_WELCOME_EMAIL", False):
-        log.info("Feature ENROLLMENT_WELCOME_EMAIL is disabled.")
+    if not features.is_enabled("enrollment_welcome_email", default=False):
+        log.info("Feature `enrollment_welcome_email` is disabled.")
         return
     run_start_date, run_start_time = format_run_date(enrollment.run.start_date)
     run_end_date, _ = format_run_date(enrollment.run.end_date)

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -7,7 +7,7 @@ import pycountry
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
-from mitol.olposthog import features
+from mitol.olposthog.features import is_enabled
 
 from courses.models import CourseRun
 from ecommerce.constants import BULK_ENROLLMENT_EMAIL_TAG, CYBERSOURCE_CARD_TYPES
@@ -21,6 +21,7 @@ from mail.constants import (
     EMAIL_PRODUCT_ORDER_RECEIPT,
     EMAIL_WELCOME_COURSE_RUN_ENROLLMENT,
 )
+from mitxpro import features
 from mitxpro.utils import format_price
 
 log = logging.getLogger()
@@ -201,7 +202,7 @@ def send_course_run_enrollment_welcome_email(enrollment):
     Args:
         enrollment (CourseRunEnrollment): the enrollment for which to send the welcome email
     """
-    if not features.is_enabled("enrollment_welcome_email", default=False):
+    if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=False):
         log.info("Feature `enrollment_welcome_email` is disabled.")
         return
     run_start_date, run_start_time = format_run_date(enrollment.run.start_date)

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -151,7 +151,7 @@ def test_send_course_run_enrollment_email_error(mocker):
 @pytest.mark.parametrize("enabled", [True, False])
 def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
     """send_course_run_enrollment_welcome_email should send a welcome email for the given enrollment"""
-    settings.FEATURES["ENROLLMENT_WELCOME_EMAIL"] = enabled
+    mocker.patch("ecommerce.mail_api.features.is_enabled", return_value=enabled)
     mock_log = mocker.patch("ecommerce.mail_api.log")
     patched_mail_api = mocker.patch("ecommerce.mail_api.api")
     enrollment = CourseRunEnrollmentFactory.create()
@@ -168,7 +168,7 @@ def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
 
     if not enabled:
         mock_log.info.assert_called_once_with(
-            "Feature ENROLLMENT_WELCOME_EMAIL is disabled."
+            "Feature `enrollment_welcome_email` is disabled."
         )
     else:
         patched_mail_api.context_for_user.assert_called_once_with(

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -151,7 +151,7 @@ def test_send_course_run_enrollment_email_error(mocker):
 @pytest.mark.parametrize("enabled", [True, False])
 def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
     """send_course_run_enrollment_welcome_email should send a welcome email for the given enrollment"""
-    mocker.patch("ecommerce.mail_api.features.is_enabled", return_value=enabled)
+    mocker.patch("ecommerce.mail_api.is_enabled", return_value=enabled)
     mock_log = mocker.patch("ecommerce.mail_api.log")
     patched_mail_api = mocker.patch("ecommerce.mail_api.api")
     enrollment = CourseRunEnrollmentFactory.create()

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -1,0 +1,3 @@
+"""MIT xPRO features"""
+
+ENROLLMENT_WELCOME_EMAIL = "enrollment_welcome_email"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6371

### Description (What does it do?)
<!--- Describe your changes in detail -->
Migrates FEATURE_ENROLLMENT_WELCOME_EMAIL to posthog as `enrollment_welcome_email`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checks should pass
- Configure posthog by following https://github.com/mitodl/mitxpro/pull/3207. I used my personal posthog account and keys.
- Create a flag in PostHog named `enrollment_welcome_email`
- Go to shell and run:
```
from ecommerce.mail_api import send_course_run_enrollment_welcome_email
from courses.models import CourseRunEnrollment
e = CourseRunEnrollment.objects.last()
send_course_run_enrollment_welcome_email(e)
```
- It should send an email. Now set the flag to false and it shouldn't send email. NOTE: Due to caching to flag values, you might have to restart you containers.