### PR TITLE
fix: language not available in course draft pages

### DIFF
--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -632,7 +632,7 @@ def create_or_update_external_course_page(  # noqa: C901
             is_updated = True
 
         # If the language is different from the course page language, update the language.
-        if latest_revision.language != course_language:
+        if getattr(latest_revision, "language", None) != course_language:
             latest_revision.language = course_language
             is_updated = True
 


### PR DESCRIPTION
### What are the relevant tickets?
None. Fixes an edge case with language in draft page mode in RC. [Sentry Link](https://mit-office-of-digital-learning.sentry.io/issues/6213376094/?alert_rule_id=15045794&alert_type=issue&notification_uuid=a84b1ef7-90b2-4d1d-b9d7-663d64f2988b&project=1413655&referrer=slack)
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
The language update in external course sync was failing for courses that were in draft mode and since the language field is new they didn't have the language field in them. This PR aims to fix that by adding an additional condition on checking if a page has language field to not,.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- Somehow create course where you draft an external page who's language is Spanish (You can achieve this by setting up on a previous commit before. Language field was added. Then, sync external course runs and identify the course that had Spanish in language key in external API. Draft this page)
- Shift to master, run migrations. Now run the external sync command again and you will notice this issue.
- Now shift to this branch and run the command again, it should successfully set the language 