### PR TITLE
refactor: migrate DIGITAL_CREDENTIALS flag to posthog

### DIFF
--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -1,4 +1,5 @@
 """MIT xPRO features"""
 
+DIGITAL_CREDENTIALS = "digital_credentials"
 ENABLE_ENTERPRISE = "enable_enterprise"
 ENROLLMENT_WELCOME_EMAIL = "enrollment_welcome_email"

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -601,7 +601,7 @@ def get_js_settings(request: HttpRequest):
             "help_widget_enabled": settings.ZENDESK_CONFIG.get("HELP_WIDGET_ENABLED"),
             "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),
         },
-        "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
+        "digital_credentials": is_enabled(features.DIGITAL_CREDENTIALS, default=False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "is_tax_applicable": is_tax_applicable(request),
         "enable_enterprise": is_enabled(features.ENABLE_ENTERPRISE, default=False),

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -11,6 +11,7 @@ from rest_framework import status
 
 from ecommerce.api import is_tax_applicable
 from ecommerce.models import Order
+from mitxpro import features
 from mitxpro.test_utils import MockResponse
 from mitxpro.utils import (
     all_equal,
@@ -463,6 +464,8 @@ def test_get_js_settings(settings, rf, user, mocker):
         """
         Side effect to return True/False for specific features while mocking posthog is_enabled.
         """
+        if args[0] == features.DIGITAL_CREDENTIALS:  # noqa: SIM103
+            return True
         return False
 
     settings.GA_TRACKING_ID = "fake"
@@ -476,7 +479,6 @@ def test_get_js_settings(settings, rf, user, mocker):
         "HELP_WIDGET_ENABLED": False,
         "HELP_WIDGET_KEY": "fake_key",
     }
-    settings.FEATURES["DIGITAL_CREDENTIALS"] = True
     settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
     mocker.patch(
         "mitol.olposthog.features.is_enabled",
@@ -498,7 +500,7 @@ def test_get_js_settings(settings, rf, user, mocker):
         "support_email": settings.EMAIL_SUPPORT,
         "site_name": settings.SITE_NAME,
         "zendesk_config": {"help_widget_enabled": False, "help_widget_key": "fake_key"},
-        "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
+        "digital_credentials": True,
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "is_tax_applicable": is_tax_applicable(request),
         "enable_enterprise": False,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6372

### Description (What does it do?)
<!--- Describe your changes in detail -->
Migrates DIGITAL_CREDENTIALS flag to Posthog

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Set up Posthog by following https://github.com/mitodl/mitxpro/pull/3207. I used my personal posthog account and keys.
- Create a flag in Posthog named `digital_credentials`
- Enroll in a course run locally and create a certificate
  - Create a certificate CMS page and then a certificate object in admin.
- Add course run id to DIGITAL_CREDENTIALS_SUPPORTED_RUNS in settings list
- Go to the dashboard and you should see `View Certificate` and `Digital Credential` links against the enrollment.