### PR TITLE
refactor: migrate ENABLE_ENTERPRISE to posthog

### DIFF
--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -1,3 +1,4 @@
 """MIT xPRO features"""
 
+ENABLE_ENTERPRISE = "enable_enterprise"
 ENROLLMENT_WELCOME_EMAIL = "enrollment_welcome_email"

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -17,6 +17,8 @@ from django.http.response import HttpResponse
 from django.templatetags.static import static
 from rest_framework import status
 
+from mitxpro import features
+
 log = logging.getLogger(__name__)
 
 
@@ -581,6 +583,8 @@ def get_js_settings(request: HttpRequest):
     Returns:
         dict: the settings object
     """
+    from mitol.olposthog.features import is_enabled
+
     from ecommerce.api import is_tax_applicable
 
     return {
@@ -600,7 +604,7 @@ def get_js_settings(request: HttpRequest):
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "is_tax_applicable": is_tax_applicable(request),
-        "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
+        "enable_enterprise": is_enabled(features.ENABLE_ENTERPRISE, default=False),
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,
         "posthog_api_host": settings.POSTHOG_API_HOST,
     }

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -458,6 +458,13 @@ def test_request_get_with_timeout_retry(mocker):
 
 def test_get_js_settings(settings, rf, user, mocker):
     """Test get_js_settings"""
+
+    def posthog_is_enabled_side_effect(*args, **kwargs):
+        """
+        Side effect to return True/False for specific features while mocking posthog is_enabled.
+        """
+        return False
+
     settings.GA_TRACKING_ID = "fake"
     settings.GTM_TRACKING_ID = "fake"
     settings.ENVIRONMENT = "test"
@@ -471,7 +478,10 @@ def test_get_js_settings(settings, rf, user, mocker):
     }
     settings.FEATURES["DIGITAL_CREDENTIALS"] = True
     settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
-    settings.FEATURES["ENABLE_ENTERPRISE"] = False
+    mocker.patch(
+        "mitol.olposthog.features.is_enabled",
+        side_effect=posthog_is_enabled_side_effect,
+    )
     mocker.patch("ecommerce.api.is_tax_applicable", return_value=False)
 
     request = rf.get("/")
@@ -491,7 +501,7 @@ def test_get_js_settings(settings, rf, user, mocker):
         "digital_credentials": settings.FEATURES.get("DIGITAL_CREDENTIALS", False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "is_tax_applicable": is_tax_applicable(request),
-        "enable_enterprise": settings.FEATURES.get("ENABLE_ENTERPRISE", False),
+        "enable_enterprise": False,
         "posthog_api_token": settings.POSTHOG_PROJECT_API_KEY,
         "posthog_api_host": settings.POSTHOG_API_HOST,
     }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6373

### Description (What does it do?)
<!--- Describe your changes in detail -->
Migrates ENABLE_ENTERPRISE to Posthog

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Set up Posthog by following https://github.com/mitodl/mitxpro/pull/3207. I used my personal posthog account and keys.
- Create a flag in Posthog named enable_enterprise in Posthog and set to True
- Visit the xpro and you should see enterprise link in the header.
