### PR TITLE
fix: external sync when there is no platform with passed name

### DIFF
--- a/courses/management/commands/sync_external_course_runs.py
+++ b/courses/management/commands/sync_external_course_runs.py
@@ -35,12 +35,19 @@ class Command(BaseCommand):
         """Handle command execution"""
         vendor_name = options["vendor_name"]
         keymap = EXTERNAL_COURSE_VENDOR_KEYMAPS.get(vendor_name.lower())
-        if not keymap:
+        platform = Platform.objects.filter(name__iexact=vendor_name).first()
+
+        if not platform:
             self.stdout.write(self.style.ERROR(f"Unknown vendor name {vendor_name}."))
             return
 
-        platform = Platform.objects.filter(name__iexact=vendor_name).first()
-        if platform and not platform.enable_sync and not options.get("force"):
+        if not keymap:
+            self.stdout.write(
+                self.style.ERROR(f"Mapping does not exist for {vendor_name}.")
+            )
+            return
+
+        if not platform.enable_sync and not options.get("force"):
             self.stdout.write(
                 self.style.ERROR(
                     f"Course sync is off for {vendor_name}. Please enable it before syncing."


### PR DESCRIPTION
### What are the relevant tickets?
None, Noticecd this issue while working on another ticket.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)

Fixes a bug when we run the command with a non-existent platform name (i.e. exists in the platform mapping but doesn't exist in the system). The command would bypass the missing platform in the system, and the sync flag and run right away.

I've separated the errors to be clearer in stating what problem occurred while running the command. 1. Is the database record missing? 2) Is the mapping missing 3) Is the sync off

<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

1. Run the command with a non-existent platform and you should see the platform missing error
2. Run the command with the existing platform but which is not present in the internal platform mapping, you should see the missing mapping error
3. Run the command with a platform that exists in the system as well as in the mapping, but disable the platform sync flag through Django admin, you should see the sync disabled error
4. Run the comment with point#3, except this time enable the platform sync flag, the command should run successfully
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
