### PR TITLE
feat: deactivate external course runs based on API data

### DIFF
--- a/courses/management/commands/sync_external_course_runs.py
+++ b/courses/management/commands/sync_external_course_runs.py
@@ -139,6 +139,9 @@ class Command(BaseCommand):
         self.log_style_success(
             f"External Course Codes: {stats.get('course_runs_expired') or 0}.\n"
         )
+        self.log_style_success(
+            f"Number of Course Runs Deleted {len(stats['course_runs_deleted'])}."
+        )
 
     def log_style_success(self, log_msg):
         """

--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -305,7 +305,12 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
         "course_runs_without_prices": set(),
         "certificates_created": set(),
         "certificates_updated": set(),
+        "deactivated_course_runs": set(),
     }
+
+    external_course_run_codes = [run["course_run_code"] for run in external_courses]
+    deactivated_course_run_codes = deactivate_removed_course_runs(external_course_run_codes, platform.name.lower())
+    stats["deactivated_course_runs"] = deactivated_course_run_codes
 
     for external_course_json in external_courses:
         external_course = ExternalCourse(external_course_json, keymap)
@@ -815,3 +820,20 @@ def create_course_overview_page(
     overview_page = CourseOverviewPage(overview=external_course.description)
     course_page.add_child(instance=overview_page)
     overview_page.save()
+
+def deactivate_removed_course_runs(external_course_run_codes, platform_name):
+    """
+    Deactivate the course runs in future that are not returned by external course sync.
+
+    Args:
+        external_course_run_codes (list): List of external course run codes.
+        platform_name (str): Name of the platform.
+    """
+    course_runs = CourseRun.objects.filter(course__platform__name__iexact=platform_name, start_date__gt=now_in_utc()).exclude(
+        external_course_run_id__in=external_course_run_codes
+    )  
+    course_runs.update(live=False)
+    log.info(
+        f"Deactivated {course_runs.count()} course runs for platform {platform_name}."
+    )
+    return set(course_runs.values_list("external_course_run_id", flat=True))


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6495

### Description (What does it do?)
This PR adds the functionality to deactivate the external course runs which were once sent by the APi and our daily task created those runs but later removed from the API data by the external course provider before the run's start date.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- From django admin, create a CourseRun for any external course with a dummy `external_course_run_id` and set the start date to future. Make sure to turn the `live` attribute on. 
- Open shell (`./manage.py shell`) and run the following code:
```
from courses.tasks import task_sync_external_course_runs
task_sync_external_course_runs.delay()
```
- Open the celery logs and verify the task executed without any errors
- In the django admin, go to the course run you created above. The live attribute value should be False.