### PR TITLE
Install lxml and xmlsec without binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$POETRY_HOME/bin:$PATH"
 
 # Install project packages
 COPY pyproject.toml /src
+COPY poetry.toml /src
 COPY poetry.lock /src
 RUN chown -R mitodl:mitodl /src
 RUN mkdir ${VIRTUAL_ENV} && chown -R mitodl:mitodl ${VIRTUAL_ENV}

--- a/apt.txt
+++ b/apt.txt
@@ -2,6 +2,7 @@
 git
 curl
 libjpeg-dev
+libxmlsec1-dev
 zlib1g-dev
 net-tools
 pkg-config

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[installer]
+no-binary = ["xmlsec", "lxml"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-django/pull/175

### Description (What does it do?)
This PR adds `lxml` and `xmlsec` in no-binary config