### PR TITLE
config: changed default backend to ol-oauth

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1073,13 +1073,13 @@ MITOL_AUTHENTICATION_REPLY_TO_EMAIL = MITXPRO_REPLY_TO_ADDRESS
 
 OPENEDX_OAUTH_PROVIDER = get_string(
     name="OPENEDX_OAUTH_PROVIDER",
-    default="mitxpro-oauth2",
+    default="ol-oauth2",
     description="Social auth oauth provider backend name",
 )
 
 OPENEDX_SOCIAL_LOGIN_PATH = get_string(
     name="OPENEDX_SOCIAL_LOGIN_PATH",
-    default="/auth/login/mitxpro-oauth2/?auth_entry=login",
+    default="/auth/login/ol-oauth2/?auth_entry=login",
     description="Open edX social auth login url",
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
We have completely switched to using the new `ol-social-auth `package for authentication with edX in all of our environments. This PR changes the default backend in mitxpro from `mitxpro-oauth2` to `ol-oauth2`

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
