### PR TITLE
 feat: added interaface for processing product coupon assignment sheets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -214,7 +214,7 @@
         "filename": "static/js/constants.js",
         "hashed_secret": "f99d98e85f9064a9b39c10c0d10fa2151df4a764",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 128
       }
     ],
     "static/js/lib/auth.js": [
@@ -261,5 +261,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-13T12:49:44Z"
+  "generated_at": "2025-03-07T10:52:47Z"
 }

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -384,43 +384,34 @@ def ecommerce_restricted(request):
     """
     Views accessible only to users with permissions to create or modify coupons.
     """
-    has_coupon_add_permission = request.user.has_perm(COUPON_ADD_PERMISSION)
-    has_coupon_update_permission = request.user.has_perm(COUPON_UPDATE_PERMISSION)
-    has_coupon_product_assignment_permission = request.user.has_perm(
-        COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION
-    ) and request.user.has_perm(COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION)
+    user = request.user
+    permissions = {
+        "has_coupon_create_permission": user.has_perm(COUPON_ADD_PERMISSION),
+        "has_coupon_update_permission": user.has_perm(COUPON_UPDATE_PERMISSION),
+        "has_coupon_product_assignment_permission": (
+            user.has_perm(COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION)
+            and user.has_perm(COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION)
+        ),
+    }
 
-    if not (
-        has_coupon_add_permission
-        or has_coupon_update_permission
-        or has_coupon_product_assignment_permission
-    ):
+    # Deny access if the user lacks all relevant permissions
+    if not any(permissions.values()):
         raise PermissionDenied
 
-    if (
-        (
-            request.path.startswith("/ecommerce/admin/coupons")
-            and not has_coupon_add_permission
-        )
-        or (
-            request.path.startswith("/ecommerce/admin/deactivate-coupons")
-            and not has_coupon_update_permission
-        )
-        or (
-            request.path.startswith("/ecommerce/admin/process-coupon-assignment-sheets")
-            and not has_coupon_product_assignment_permission
-        )
-    ):
-        raise PermissionDenied
+    # Define path-based permission checks
+    restricted_paths = {
+        "/ecommerce/admin/coupons": "has_coupon_create_permission",
+        "/ecommerce/admin/deactivate-coupons": "has_coupon_update_permission",
+        "/ecommerce/admin/process-coupon-assignment-sheets": "has_coupon_product_assignment_permission",
+    }
+
+    for path, perm in restricted_paths.items():
+        if request.path.startswith(path) and not permissions[perm]:
+            raise PermissionDenied
 
     context = get_base_context(request)
-    context["user_permissions"] = json.dumps(
-        {
-            "has_coupon_create_permission": has_coupon_add_permission,
-            "has_coupon_update_permission": has_coupon_update_permission,
-            "has_coupon_product_assignment_permission": has_coupon_product_assignment_permission,
-        }
-    )
+    context["user_permissions"] = json.dumps(permissions)
+
     return render(request, "index.html", context=context)
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -386,23 +386,30 @@ def ecommerce_restricted(request):
     """
     has_coupon_add_permission = request.user.has_perm(COUPON_ADD_PERMISSION)
     has_coupon_update_permission = request.user.has_perm(COUPON_UPDATE_PERMISSION)
-    has_coupon_product_assignment_permission = (
-        request.user.has_perm(COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION) and 
-        request.user.has_perm(COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION)
-    )
+    has_coupon_product_assignment_permission = request.user.has_perm(
+        COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION
+    ) and request.user.has_perm(COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION)
 
-    if not (has_coupon_add_permission or has_coupon_update_permission or has_coupon_product_assignment_permission):
+    if not (
+        has_coupon_add_permission
+        or has_coupon_update_permission
+        or has_coupon_product_assignment_permission
+    ):
         raise PermissionDenied
 
     if (
-        request.path.startswith("/ecommerce/admin/coupons")
-        and not has_coupon_add_permission
-    ) or (
-        request.path.startswith("/ecommerce/admin/deactivate-coupons")
-        and not has_coupon_update_permission
-    ) or (
-        request.path.startswith("/ecommerce/admin/process-coupon-assignment-sheets")
-        and not has_coupon_product_assignment_permission
+        (
+            request.path.startswith("/ecommerce/admin/coupons")
+            and not has_coupon_add_permission
+        )
+        or (
+            request.path.startswith("/ecommerce/admin/deactivate-coupons")
+            and not has_coupon_update_permission
+        )
+        or (
+            request.path.startswith("/ecommerce/admin/process-coupon-assignment-sheets")
+            and not has_coupon_product_assignment_permission
+        )
     ):
         raise PermissionDenied
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1237,24 +1237,32 @@ def test_create_coupon_permission(user_drf_client, promo_coupon_json):
     (
         "add_coupon",
         "change_coupon",
+        "add_and_update_product_assignment",
         "expected_admin_status",
         "expected_coupons_status",
         "expected_deactivate_status",
+        "expected_product_assignment_status",
     ),
     [
-        (True, False, 200, 200, 403),
-        (False, True, 200, 403, 200),
-        (False, False, 403, 403, 403),
-        (True, True, 200, 200, 200),
+        (True, False, False, 200, 200, 403, 403),
+        (False, True, False, 200, 403, 200, 403),
+        (False, False, False, 403, 403, 403, 403),
+        (True, True, False, 200, 200, 200, 403),
+        (False, False, True, 200, 403, 403, 200),  # Product assignment only
+        (True, False, True, 200, 200, 403, 200),  # Coupon + Product assignment
+        (False, True, True, 200, 403, 200, 200),  # Change Coupon + Product assignment
+        (True, True, True, 200, 200, 200, 200),  # All permissions
     ],
 )
-def test_ecommerce_restricted_view(  # noqa: PLR0913
+def test_ecommerce_restricted_view(
     user,
     add_coupon,
     change_coupon,
+    add_and_update_product_assignment,
     expected_admin_status,
     expected_coupons_status,
     expected_deactivate_status,
+    expected_product_assignment_status,
 ):
     """Test that the ecommerce restricted view is only accessible with the right permissions."""
 
@@ -1263,6 +1271,9 @@ def test_ecommerce_restricted_view(  # noqa: PLR0913
         user.user_permissions.add(Permission.objects.get(codename="add_coupon"))
     if change_coupon:
         user.user_permissions.add(Permission.objects.get(codename="change_coupon"))
+    if add_and_update_product_assignment:
+        user.user_permissions.add(Permission.objects.get(codename="add_productcouponassignment"))
+        user.user_permissions.add(Permission.objects.get(codename="change_productcouponassignment"))
 
     client = Client()
     client.force_login(user)
@@ -1270,11 +1281,12 @@ def test_ecommerce_restricted_view(  # noqa: PLR0913
     ecommerce_admin_url = reverse("ecommerce-admin")
     add_coupons_url = ecommerce_admin_url + "coupons"
     deactivate_coupons_url = ecommerce_admin_url + "deactivate-coupons"
+    product_assignment_url = ecommerce_admin_url + "process-coupon-assignment-sheets"
 
     assert client.get(ecommerce_admin_url).status_code == expected_admin_status
     assert client.get(add_coupons_url).status_code == expected_coupons_status
     assert client.get(deactivate_coupons_url).status_code == expected_deactivate_status
-
+    assert client.get(product_assignment_url).status_code == expected_product_assignment_status
 
 def test_deactivate_coupons(mocker, admin_drf_client):
     """Test that the API successfully deactivates coupons based on coupon codes or payment names"""

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1272,8 +1272,12 @@ def test_ecommerce_restricted_view(
     if change_coupon:
         user.user_permissions.add(Permission.objects.get(codename="change_coupon"))
     if add_and_update_product_assignment:
-        user.user_permissions.add(Permission.objects.get(codename="add_productcouponassignment"))
-        user.user_permissions.add(Permission.objects.get(codename="change_productcouponassignment"))
+        user.user_permissions.add(
+            Permission.objects.get(codename="add_productcouponassignment")
+        )
+        user.user_permissions.add(
+            Permission.objects.get(codename="change_productcouponassignment")
+        )
 
     client = Client()
     client.force_login(user)
@@ -1286,7 +1290,11 @@ def test_ecommerce_restricted_view(
     assert client.get(ecommerce_admin_url).status_code == expected_admin_status
     assert client.get(add_coupons_url).status_code == expected_coupons_status
     assert client.get(deactivate_coupons_url).status_code == expected_deactivate_status
-    assert client.get(product_assignment_url).status_code == expected_product_assignment_status
+    assert (
+        client.get(product_assignment_url).status_code
+        == expected_product_assignment_status
+    )
+
 
 def test_deactivate_coupons(mocker, admin_drf_client):
     """Test that the API successfully deactivates coupons based on coupon codes or payment names"""

--- a/sheets/constants.py
+++ b/sheets/constants.py
@@ -64,3 +64,5 @@ UNSENT_EMAIL_STATUSES = {
     MAILGUN_FAILED,
     UNKNOWN_EMAIL_ERROR_STATUS,
 }
+COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION = "ecommerce.add_productcouponassignment"
+COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION = "ecommerce.change_productcouponassignment"

--- a/sheets/exceptions.py
+++ b/sheets/exceptions.py
@@ -40,3 +40,7 @@ class FailedBatchRequestException(Exception):  # noqa: N818
     """
     General exception for a failure during a Google batch API request
     """
+
+
+class CouponAssignmentError(Exception):
+    """Custom exception for coupon assignment errors."""

--- a/sheets/management/commands/process_coupon_assignment_sheet.py
+++ b/sheets/management/commands/process_coupon_assignment_sheet.py
@@ -6,6 +6,7 @@ based on the sheet data, and sends a message to all recipients who received a co
 from django.core.management import BaseCommand, CommandError
 
 from sheets.management.utils import assign_coupons_from_spreadsheet
+from sheets.exceptions import CouponAssignmentError
 
 
 class Command(BaseCommand):
@@ -63,8 +64,8 @@ class Command(BaseCommand):
                 )
             )
 
-        except CommandError as e:
-            raise CommandError(str(e))
+        except CouponAssignmentError as e:
+            raise  CommandError(str(e))
 
         except Exception as e:
             raise CommandError(f"An unexpected error occurred: {e}")

--- a/sheets/management/commands/process_coupon_assignment_sheet.py
+++ b/sheets/management/commands/process_coupon_assignment_sheet.py
@@ -52,8 +52,10 @@ class Command(BaseCommand):
         value = sheet_id if use_sheet_id else title
 
         try:
-            spreadsheet, num_created, num_removed, bulk_assignment_id = assign_coupons_from_spreadsheet(
-                use_sheet_id=use_sheet_id, value=value, force=options.get("force")
+            spreadsheet, num_created, num_removed, bulk_assignment_id = (
+                assign_coupons_from_spreadsheet(
+                    use_sheet_id=use_sheet_id, value=value, force=options.get("force")
+                )
             )
 
             self.stdout.write(
@@ -65,7 +67,7 @@ class Command(BaseCommand):
             )
 
         except CouponAssignmentError as e:
-            raise  CommandError(str(e))
+            raise CommandError(str(e))
 
         except Exception as e:
             raise CommandError(f"An unexpected error occurred: {e}")

--- a/sheets/management/commands/process_coupon_assignment_sheet.py
+++ b/sheets/management/commands/process_coupon_assignment_sheet.py
@@ -5,7 +5,7 @@ based on the sheet data, and sends a message to all recipients who received a co
 
 from django.core.management import BaseCommand, CommandError
 
-from sheets.management.utils import assign_coupons_from_spreadsheet
+from sheets.utils import assign_coupons_from_spreadsheet
 from sheets.exceptions import CouponAssignmentError
 
 

--- a/sheets/management/utils.py
+++ b/sheets/management/utils.py
@@ -1,9 +1,10 @@
 """Sheets app management command utils"""
 
-from django.core.management import CommandError
-
 from sheets.coupon_assign_api import CouponAssignmentHandler
-
+from sheets.exceptions import CouponAssignmentError
+from sheets.api import ExpandedSheetsClient, get_authorized_pygsheets_client
+from sheets.utils import google_date_string_to_datetime, spreadsheet_repr
+from ecommerce.models import BulkCouponAssignment
 
 def get_assignment_spreadsheet_by_title(pygsheets_client, title):
     """
@@ -24,8 +25,61 @@ def get_assignment_spreadsheet_by_title(pygsheets_client, title):
         )
     )
     if len(matching_spreadsheets) != 1:
-        raise CommandError(
+        raise CouponAssignmentError(
             f"There should be 1 coupon assignment sheet that matches the given title ('{title}'). "  # noqa: EM102
             f"{len(matching_spreadsheets)} were found."
         )
     return matching_spreadsheets[0]
+
+
+def assign_coupons_from_spreadsheet(use_sheet_id: bool, value: str, force: bool = False):
+    """
+    Fetches and processes a coupon assignment spreadsheet using either the sheet ID or title.
+
+    Args:
+        use_sheet_id (bool): If True, 'value' represents the spreadsheet ID; otherwise, it represents the title.
+        value (str): The spreadsheet ID or title.
+
+    Returns:
+        dict: A dictionary containing the result of the processing.
+    """
+
+    if not value:
+        raise CouponAssignmentError("Spreadsheet identifier (ID or Title) is required.")
+    
+    pygsheets_client = get_authorized_pygsheets_client()
+
+    # Fetch the correct spreadsheet
+    if use_sheet_id:
+        spreadsheet = pygsheets_client.open_by_key(value)
+    else:
+        spreadsheet = get_assignment_spreadsheet_by_title(pygsheets_client, value)
+
+    expanded_sheets_client = ExpandedSheetsClient(pygsheets_client)
+    metadata = expanded_sheets_client.get_drive_file_metadata(
+        file_id=spreadsheet.id, fields="modifiedTime"
+    )
+    sheet_last_modified = google_date_string_to_datetime(metadata["modifiedTime"])
+
+    bulk_assignment, created = BulkCouponAssignment.objects.get_or_create(
+        assignment_sheet_id=spreadsheet.id
+    )
+
+    if (
+        bulk_assignment.sheet_last_modified_date
+        and sheet_last_modified <= bulk_assignment.sheet_last_modified_date
+        and not force
+    ):
+        raise CouponAssignmentError(
+            f"Spreadsheet is unchanged since last processed ({spreadsheet_repr(spreadsheet)}, last modified: {sheet_last_modified.isoformat()})."
+        )
+
+    coupon_assignment_handler = CouponAssignmentHandler(
+        spreadsheet_id=spreadsheet.id, bulk_assignment=bulk_assignment
+    )
+
+    bulk_assignment, num_created, num_removed = coupon_assignment_handler.process_assignment_spreadsheet()
+    bulk_assignment.sheet_last_modified_date = sheet_last_modified
+    bulk_assignment.save()
+
+    return spreadsheet_repr(spreadsheet), num_created, num_removed, bulk_assignment.id

--- a/sheets/management/utils.py
+++ b/sheets/management/utils.py
@@ -6,6 +6,7 @@ from sheets.api import ExpandedSheetsClient, get_authorized_pygsheets_client
 from sheets.utils import google_date_string_to_datetime, spreadsheet_repr
 from ecommerce.models import BulkCouponAssignment
 
+
 def get_assignment_spreadsheet_by_title(pygsheets_client, title):
     """
     Fetches a coupon assignment spreadsheet object that matches the full or partial title provided.
@@ -32,7 +33,9 @@ def get_assignment_spreadsheet_by_title(pygsheets_client, title):
     return matching_spreadsheets[0]
 
 
-def assign_coupons_from_spreadsheet(use_sheet_id: bool, value: str, force: bool = False):
+def assign_coupons_from_spreadsheet(
+    use_sheet_id: bool, value: str, force: bool = False
+):
     """
     Fetches and processes a coupon assignment spreadsheet using either the sheet ID or title.
 
@@ -46,7 +49,7 @@ def assign_coupons_from_spreadsheet(use_sheet_id: bool, value: str, force: bool 
 
     if not value:
         raise CouponAssignmentError("Spreadsheet identifier (ID or Title) is required.")
-    
+
     pygsheets_client = get_authorized_pygsheets_client()
 
     # Fetch the correct spreadsheet
@@ -78,7 +81,9 @@ def assign_coupons_from_spreadsheet(use_sheet_id: bool, value: str, force: bool 
         spreadsheet_id=spreadsheet.id, bulk_assignment=bulk_assignment
     )
 
-    bulk_assignment, num_created, num_removed = coupon_assignment_handler.process_assignment_spreadsheet()
+    bulk_assignment, num_created, num_removed = (
+        coupon_assignment_handler.process_assignment_spreadsheet()
+    )
     bulk_assignment.sheet_last_modified_date = sheet_last_modified
     bulk_assignment.save()
 

--- a/sheets/management/utils.py
+++ b/sheets/management/utils.py
@@ -2,9 +2,6 @@
 
 from sheets.coupon_assign_api import CouponAssignmentHandler
 from sheets.exceptions import CouponAssignmentError
-from sheets.api import ExpandedSheetsClient, get_authorized_pygsheets_client
-from sheets.utils import google_date_string_to_datetime, spreadsheet_repr
-from ecommerce.models import BulkCouponAssignment
 
 
 def get_assignment_spreadsheet_by_title(pygsheets_client, title):
@@ -31,60 +28,3 @@ def get_assignment_spreadsheet_by_title(pygsheets_client, title):
             f"{len(matching_spreadsheets)} were found."
         )
     return matching_spreadsheets[0]
-
-
-def assign_coupons_from_spreadsheet(
-    use_sheet_id: bool, value: str, force: bool = False
-):
-    """
-    Fetches and processes a coupon assignment spreadsheet using either the sheet ID or title.
-
-    Args:
-        use_sheet_id (bool): If True, 'value' represents the spreadsheet ID; otherwise, it represents the title.
-        value (str): The spreadsheet ID or title.
-
-    Returns:
-        dict: A dictionary containing the result of the processing.
-    """
-
-    if not value:
-        raise CouponAssignmentError("Spreadsheet identifier (ID or Title) is required.")
-
-    pygsheets_client = get_authorized_pygsheets_client()
-
-    # Fetch the correct spreadsheet
-    if use_sheet_id:
-        spreadsheet = pygsheets_client.open_by_key(value)
-    else:
-        spreadsheet = get_assignment_spreadsheet_by_title(pygsheets_client, value)
-
-    expanded_sheets_client = ExpandedSheetsClient(pygsheets_client)
-    metadata = expanded_sheets_client.get_drive_file_metadata(
-        file_id=spreadsheet.id, fields="modifiedTime"
-    )
-    sheet_last_modified = google_date_string_to_datetime(metadata["modifiedTime"])
-
-    bulk_assignment, created = BulkCouponAssignment.objects.get_or_create(
-        assignment_sheet_id=spreadsheet.id
-    )
-
-    if (
-        bulk_assignment.sheet_last_modified_date
-        and sheet_last_modified <= bulk_assignment.sheet_last_modified_date
-        and not force
-    ):
-        raise CouponAssignmentError(
-            f"Spreadsheet is unchanged since last processed ({spreadsheet_repr(spreadsheet)}, last modified: {sheet_last_modified.isoformat()})."
-        )
-
-    coupon_assignment_handler = CouponAssignmentHandler(
-        spreadsheet_id=spreadsheet.id, bulk_assignment=bulk_assignment
-    )
-
-    bulk_assignment, num_created, num_removed = (
-        coupon_assignment_handler.process_assignment_spreadsheet()
-    )
-    bulk_assignment.sheet_last_modified_date = sheet_last_modified
-    bulk_assignment.save()
-
-    return spreadsheet_repr(spreadsheet), num_created, num_removed, bulk_assignment.id

--- a/sheets/management/utils_test.py
+++ b/sheets/management/utils_test.py
@@ -1,18 +1,11 @@
 """Tests for sheets.management.utils"""
 
-from unittest.mock import MagicMock, patch
-
 import pytest
-from datetime import timedelta
+
+from unittest.mock import MagicMock
 
 from sheets.management import utils
-from mitxpro.utils import now_in_utc
-
-from sheets.management.utils import (
-    assign_coupons_from_spreadsheet,
-    CouponAssignmentError,
-)
-from ecommerce.factories import BulkCouponAssignmentFactory
+from sheets.management.utils import CouponAssignmentError
 
 
 @pytest.fixture(name="valid_enum_rows")
@@ -58,112 +51,3 @@ def test_get_assignment_sheet_by_title_multiple():
     )
     with pytest.raises(CouponAssignmentError):
         utils.get_assignment_spreadsheet_by_title(mock_pygsheets_client, "fake")
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "use_sheet_id, value, force, sheet_modified_offset, existing_modified_offset, expect_error, force_processing",
-    [
-        (
-            True,
-            "sheet-id-123",
-            False,
-            timedelta(days=-1),
-            timedelta(days=-2),
-            False,
-            True,
-        ),  # Valid, modified after last
-        (
-            False,
-            "fake-title",
-            False,
-            timedelta(days=-2),
-            timedelta(days=-1),
-            True,
-            False,
-        ),  # No modification
-        (
-            True,
-            "sheet-id-123",
-            True,
-            timedelta(days=-2),
-            timedelta(days=-1),
-            False,
-            True,
-        ),  # Forced processing
-        (
-            False,
-            "",
-            False,
-            None,
-            None,
-            True,
-            False,
-        ),  # Missing value should raise an error
-    ],
-)
-@patch("sheets.management.utils.get_authorized_pygsheets_client")
-@patch("sheets.management.utils.get_assignment_spreadsheet_by_title")
-@patch("sheets.management.utils.google_date_string_to_datetime")
-@patch("sheets.management.utils.CouponAssignmentHandler")
-def test_assign_coupons_from_spreadsheet(
-    mock_coupon_assignment_handler,
-    mock_google_date_string_to_datetime,
-    mock_get_assignment_sheet_by_title,
-    mock_get_authorized_pygsheets_client,
-    use_sheet_id,
-    value,
-    force,
-    sheet_modified_offset,
-    existing_modified_offset,
-    expect_error,
-    force_processing,
-):
-    """Test assign_coupons_from_spreadsheet with different conditions."""
-
-    mock_pygsheets_client = MagicMock()
-    mock_get_authorized_pygsheets_client.return_value = mock_pygsheets_client
-
-    mock_spreadsheet = MagicMock()
-
-    # Title and ID should be assigned to assert the returning value of assign_coupons_from_spreadsheet
-    mock_spreadsheet.title = "fake-title"
-    mock_spreadsheet.id = "sheet-id-123"
-
-    if use_sheet_id:
-        mock_pygsheets_client.open_by_key.return_value = mock_spreadsheet
-    else:
-        mock_get_assignment_sheet_by_title.return_value = mock_spreadsheet
-
-    sheet_last_modified = (
-        now_in_utc() + sheet_modified_offset if sheet_modified_offset else None
-    )
-    mock_google_date_string_to_datetime.return_value = sheet_last_modified
-
-    bulk_assignment = BulkCouponAssignmentFactory.create(
-        assignment_sheet_id="sheet-id-123",
-        sheet_last_modified_date=now_in_utc() + existing_modified_offset
-        if existing_modified_offset
-        else None,
-    )
-
-    if expect_error:
-        with pytest.raises(CouponAssignmentError):
-            assign_coupons_from_spreadsheet(use_sheet_id, value, force)
-    else:
-        mock_process_assignment = (
-            mock_coupon_assignment_handler.return_value.process_assignment_spreadsheet
-        )
-        mock_process_assignment.return_value = (bulk_assignment, 5, 2)
-
-        result = assign_coupons_from_spreadsheet(use_sheet_id, value, force)
-        if force_processing:
-            assert result == (
-                "'fake-title', id: sheet-id-123",
-                5,
-                2,
-                bulk_assignment.id,
-            )
-            mock_process_assignment.assert_called_once()
-        else:
-            mock_process_assignment.assert_not_called()

--- a/sheets/management/utils_test.py
+++ b/sheets/management/utils_test.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.core.management import CommandError
 from datetime import timedelta
 
 from sheets.management import utils
@@ -87,11 +86,9 @@ def test_assign_coupons_from_spreadsheet(
 ):
     """Test assign_coupons_from_spreadsheet with different conditions."""
 
-    # Mock authorized pygsheets client
     mock_pygsheets_client = MagicMock()
     mock_get_authorized_pygsheets_client.return_value = mock_pygsheets_client
 
-    # Mock spreadsheet
     mock_spreadsheet = MagicMock()
 
     # Title and ID should be assigned to assert the returning value of assign_coupons_from_spreadsheet
@@ -103,7 +100,6 @@ def test_assign_coupons_from_spreadsheet(
     else:
         mock_get_assignment_sheet_by_title.return_value = mock_spreadsheet
 
-    # Mock modification time
     sheet_last_modified = now_in_utc() + sheet_modified_offset if sheet_modified_offset else None
     mock_google_date_string_to_datetime.return_value = sheet_last_modified
 

--- a/sheets/management/utils_test.py
+++ b/sheets/management/utils_test.py
@@ -1,11 +1,16 @@
 """Tests for sheets.management.utils"""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import CommandError
+from datetime import timedelta
 
 from sheets.management import utils
+from mitxpro.utils import now_in_utc
+
+from sheets.management.utils import assign_coupons_from_spreadsheet, CouponAssignmentError
+from ecommerce.factories import BulkCouponAssignmentFactory
 
 
 @pytest.fixture(name="valid_enum_rows")
@@ -49,5 +54,74 @@ def test_get_assignment_sheet_by_title_multiple():
     mock_pygsheets_client = MagicMock(
         open_all=MagicMock(return_value=["mock-sheet-obj", "mock-second-sheet-obj"])
     )
-    with pytest.raises(CommandError):
+    with pytest.raises(CouponAssignmentError):
         utils.get_assignment_spreadsheet_by_title(mock_pygsheets_client, "fake")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "use_sheet_id, value, force, sheet_modified_offset, existing_modified_offset, expect_error, force_processing",
+    [
+        (True, "sheet-id-123", False, timedelta(days=-1), timedelta(days=-2), False, True),  # Valid, modified after last
+        (False, "fake-title", False, timedelta(days=-2), timedelta(days=-1), True, False),  # No modification
+        (True, "sheet-id-123", True, timedelta(days=-2), timedelta(days=-1), False, True),  # Forced processing
+        (False, "", False, None, None, True, False),  # Missing value should raise an error
+    ],
+)
+@patch("sheets.management.utils.get_authorized_pygsheets_client")
+@patch("sheets.management.utils.get_assignment_spreadsheet_by_title")
+@patch("sheets.management.utils.google_date_string_to_datetime")
+@patch("sheets.management.utils.CouponAssignmentHandler")
+def test_assign_coupons_from_spreadsheet(
+    mock_coupon_assignment_handler,
+    mock_google_date_string_to_datetime,
+    mock_get_assignment_sheet_by_title,
+    mock_get_authorized_pygsheets_client,
+    use_sheet_id,
+    value,
+    force,
+    sheet_modified_offset,
+    existing_modified_offset,
+    expect_error,
+    force_processing,
+):
+    """Test assign_coupons_from_spreadsheet with different conditions."""
+
+    # Mock authorized pygsheets client
+    mock_pygsheets_client = MagicMock()
+    mock_get_authorized_pygsheets_client.return_value = mock_pygsheets_client
+
+    # Mock spreadsheet
+    mock_spreadsheet = MagicMock()
+
+    # Title and ID should be assigned to assert the returning value of assign_coupons_from_spreadsheet
+    mock_spreadsheet.title = "fake-title" 
+    mock_spreadsheet.id = "sheet-id-123"
+
+    if use_sheet_id:
+        mock_pygsheets_client.open_by_key.return_value = mock_spreadsheet
+    else:
+        mock_get_assignment_sheet_by_title.return_value = mock_spreadsheet
+
+    # Mock modification time
+    sheet_last_modified = now_in_utc() + sheet_modified_offset if sheet_modified_offset else None
+    mock_google_date_string_to_datetime.return_value = sheet_last_modified
+
+    bulk_assignment = BulkCouponAssignmentFactory.create(
+        assignment_sheet_id="sheet-id-123",
+        sheet_last_modified_date = now_in_utc() + existing_modified_offset if existing_modified_offset else None
+    )
+
+    if expect_error:
+        with pytest.raises(CouponAssignmentError):
+            assign_coupons_from_spreadsheet(use_sheet_id, value, force)
+    else:
+        mock_process_assignment = mock_coupon_assignment_handler.return_value.process_assignment_spreadsheet
+        mock_process_assignment.return_value = (bulk_assignment, 5, 2)
+
+        result = assign_coupons_from_spreadsheet(use_sheet_id, value, force)
+        if force_processing:
+            assert result == ("'fake-title', id: sheet-id-123", 5, 2, bulk_assignment.id)
+            mock_process_assignment.assert_called_once()
+        else:
+            mock_process_assignment.assert_not_called()

--- a/sheets/permissions.py
+++ b/sheets/permissions.py
@@ -1,7 +1,10 @@
-
 from rest_framework.permissions import BasePermission
 
-from sheets.constants import COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION, COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION
+from sheets.constants import (
+    COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION,
+    COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION,
+)
+
 
 class HasCouponProductAssignmentPermission(BasePermission):
     """
@@ -10,12 +13,10 @@ class HasCouponProductAssignmentPermission(BasePermission):
     """
 
     def has_permission(self, request, view):  # noqa: ARG002
-        return (
-            all(
-                request.user.has_perm(perm)
-                for perm in [
-                    COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION,
-                    COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION,
-                ]
-            )
+        return all(
+            request.user.has_perm(perm)
+            for perm in [
+                COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION,
+                COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION,
+            ]
         )

--- a/sheets/permissions.py
+++ b/sheets/permissions.py
@@ -1,0 +1,21 @@
+
+from rest_framework.permissions import BasePermission
+
+from sheets.constants import COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION, COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION
+
+class HasCouponProductAssignmentPermission(BasePermission):
+    """
+    Custom permission to check if the user has both add and update permissions
+    for coupon product assignments.
+    """
+
+    def has_permission(self, request, view):  # noqa: ARG002
+        return (
+            all(
+                request.user.has_perm(perm)
+                for perm in [
+                    COUPON_PRODUCT_ASSIGNMENT_ADD_PERMISSION,
+                    COUPON_PRODUCT_ASSIGNMENT_UPDATE_PERMISSION,
+                ]
+            )
+        )

--- a/sheets/urls.py
+++ b/sheets/urls.py
@@ -19,4 +19,9 @@ urlpatterns = [
         views.handle_watched_sheet_update,
         name="handle-watched-sheet-update",
     ),
+    re_path(
+        r"^api/sheets/process_coupon_sheet_assignment/",
+        views.ProcessCouponSheetAssignmentView.as_view(),
+        name="process-coupon-sheet-assignment",
+)
 ]

--- a/sheets/urls.py
+++ b/sheets/urls.py
@@ -23,5 +23,5 @@ urlpatterns = [
         r"^api/sheets/process_coupon_sheet_assignment/",
         views.ProcessCouponSheetAssignmentView.as_view(),
         name="process-coupon-sheet-assignment",
-)
+    ),
 ]

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.urls import reverse
 
 from mitxpro.utils import matching_item_index
+# from sheets.api import ExpandedSheetsClient, get_authorized_pygsheets_client
 from sheets.constants import (
     ASSIGNMENT_SHEET_PREFIX,
     GOOGLE_AUTH_PROVIDER_X509_CERT_URL,

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.urls import reverse
 
 from mitxpro.utils import matching_item_index
-# from sheets.api import ExpandedSheetsClient, get_authorized_pygsheets_client
 from sheets.constants import (
     ASSIGNMENT_SHEET_PREFIX,
     GOOGLE_AUTH_PROVIDER_X509_CERT_URL,

--- a/sheets/utils_test.py
+++ b/sheets/utils_test.py
@@ -8,6 +8,14 @@ from sheets.constants import (
     GOOGLE_AUTH_URI,
     GOOGLE_TOKEN_URI,
 )
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datetime import timedelta
+
+from mitxpro.utils import now_in_utc
+from ecommerce.factories import BulkCouponAssignmentFactory
+from sheets.exceptions import CouponAssignmentError
 
 
 def test_generate_google_client_config(settings):
@@ -41,3 +49,112 @@ def test_get_data_rows(mocker):
     )
     data_rows = list(utils.get_data_rows(mocked_worksheet))
     assert data_rows == non_header_rows
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "use_sheet_id, value, force, sheet_modified_offset, existing_modified_offset, expect_error, force_processing",
+    [
+        (
+            True,
+            "sheet-id-123",
+            False,
+            timedelta(days=-1),
+            timedelta(days=-2),
+            False,
+            True,
+        ),  # Valid, modified after last
+        (
+            False,
+            "fake-title",
+            False,
+            timedelta(days=-2),
+            timedelta(days=-1),
+            True,
+            False,
+        ),  # No modification
+        (
+            True,
+            "sheet-id-123",
+            True,
+            timedelta(days=-2),
+            timedelta(days=-1),
+            False,
+            True,
+        ),  # Forced processing
+        (
+            False,
+            "",
+            False,
+            None,
+            None,
+            True,
+            False,
+        ),  # Missing value should raise an error
+    ],
+)
+@patch("sheets.api.get_authorized_pygsheets_client")
+@patch("sheets.management.utils.get_assignment_spreadsheet_by_title")
+@patch("sheets.utils.google_date_string_to_datetime")
+@patch("sheets.coupon_assign_api.CouponAssignmentHandler")
+def test_assign_coupons_from_spreadsheet(
+    mock_coupon_assignment_handler,
+    mock_google_date_string_to_datetime,
+    mock_get_assignment_sheet_by_title,
+    mock_get_authorized_pygsheets_client,
+    use_sheet_id,
+    value,
+    force,
+    sheet_modified_offset,
+    existing_modified_offset,
+    expect_error,
+    force_processing,
+):
+    """Test assign_coupons_from_spreadsheet with different conditions."""
+
+    mock_pygsheets_client = MagicMock()
+    mock_get_authorized_pygsheets_client.return_value = mock_pygsheets_client
+
+    mock_spreadsheet = MagicMock()
+
+    # Title and ID should be assigned to assert the returning value of assign_coupons_from_spreadsheet
+    mock_spreadsheet.title = "fake-title"
+    mock_spreadsheet.id = "sheet-id-123"
+
+    if use_sheet_id:
+        mock_pygsheets_client.open_by_key.return_value = mock_spreadsheet
+    else:
+        mock_get_assignment_sheet_by_title.return_value = mock_spreadsheet
+
+    sheet_last_modified = (
+        now_in_utc() + sheet_modified_offset if sheet_modified_offset else None
+    )
+    mock_google_date_string_to_datetime.return_value = sheet_last_modified
+
+    bulk_assignment = BulkCouponAssignmentFactory.create(
+        assignment_sheet_id="sheet-id-123",
+        sheet_last_modified_date=now_in_utc() + existing_modified_offset
+        if existing_modified_offset
+        else None,
+    )
+
+    if expect_error:
+        with pytest.raises(CouponAssignmentError):
+            utils.assign_coupons_from_spreadsheet(use_sheet_id, value, force)
+    else:
+        mock_process_assignment = (
+            mock_coupon_assignment_handler.return_value.process_assignment_spreadsheet
+        )
+        mock_process_assignment.return_value = (bulk_assignment, 5, 2)
+
+        result = utils.assign_coupons_from_spreadsheet(use_sheet_id, value, force)
+        if force_processing:
+            assert result == (
+                "'fake-title', id: sheet-id-123",
+                5,
+                2,
+                bulk_assignment.id,
+            )
+            mock_process_assignment.assert_called_once()
+        else:
+            mock_process_assignment.assert_not_called()

--- a/sheets/views.py
+++ b/sheets/views.py
@@ -163,9 +163,10 @@ class ProcessCouponSheetAssignmentView(APIView):
     """
     API view to handle the assignment of coupons from a sheet (by ID or Title).
     """
+
     permission_classes = (HasCouponProductAssignmentPermission,)
     authentication_classes = (SessionAuthentication,)
-    
+
     def post(self, request):
         """Handles the assignment of coupons from a sheet (by ID or Title)."""
         sheet_identifier_type = request.data.get("sheet_identifier_type")
@@ -174,14 +175,18 @@ class ProcessCouponSheetAssignmentView(APIView):
 
         if sheet_identifier_type is None or not sheet_identifier_value:
             return Response(
-                {"error": "Both 'sheet_identifier_type' and 'sheet_value' are required."},
+                {
+                    "error": "Both 'sheet_identifier_type' and 'sheet_value' are required."
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             # Call the updated utility function for coupon assignment
-            spreadsheet_repr, num_created, num_removed, bulk_assignment_id = assign_coupons_from_spreadsheet(
-                sheet_identifier_type=="id", sheet_identifier_value, force
+            spreadsheet_repr, num_created, num_removed, bulk_assignment_id = (
+                assign_coupons_from_spreadsheet(
+                    sheet_identifier_type == "id", sheet_identifier_value, force
+                )
             )
 
             # Return success response with relevant data
@@ -198,7 +203,7 @@ class ProcessCouponSheetAssignmentView(APIView):
         except CouponAssignmentError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
-        except Exception as e:
+        except Exception:
             return Response(
                 {"error": "An error occurred while processing the coupon sheet."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/sheets/views.py
+++ b/sheets/views.py
@@ -28,8 +28,7 @@ from sheets.constants import (
 )
 from sheets.exceptions import CouponAssignmentError
 from sheets.models import GoogleApiAuth, GoogleFileWatch
-from sheets.utils import generate_google_client_config
-from sheets.management.utils import assign_coupons_from_spreadsheet
+from sheets.utils import generate_google_client_config, assign_coupons_from_spreadsheet
 from sheets.permissions import HasCouponProductAssignmentPermission
 
 log = logging.getLogger(__name__)
@@ -171,7 +170,7 @@ class ProcessCouponSheetAssignmentView(APIView):
         """Handles the assignment of coupons from a sheet (by ID or Title)."""
         sheet_identifier_type = request.data.get("sheet_identifier_type")
         sheet_identifier_value = request.data.get("sheet_identifier_value")
-        force = request.data.get("force", True)
+        force = request.data.get("force", False)
 
         if sheet_identifier_type is None or not sheet_identifier_value:
             return Response(

--- a/sheets/views_test.py
+++ b/sheets/views_test.py
@@ -7,6 +7,7 @@ from pytest_lazy_fixtures import lf as lazy
 from rest_framework import status
 
 from mitxpro.test_utils import set_request_session
+from sheets.exceptions import CouponAssignmentError
 from sheets.factories import GoogleApiAuthFactory, GoogleFileWatchFactory
 from sheets.models import GoogleApiAuth
 from sheets.views import complete_google_auth
@@ -116,3 +117,53 @@ def test_handle_coupon_request_sheet_update(mocker, settings):
         HTTP_X_GOOG_CHANNEL_ID="file-watch-channel",
     )
     patched_tasks.handle_unprocessed_coupon_requests.delay.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "request_data, mock_return, expected_status, expected_response",
+    [
+        # Valid request
+        (
+            {"sheet_identifier_type": "id", "sheet_identifier_value": "valid_sheet", "force": False},
+            ("Spreadsheet1", 10, 5, "bulk_id_123"),
+            status.HTTP_200_OK,
+            {
+                "message": "Successfully processed coupon assignment sheet (Spreadsheet1).",
+                "num_created": 10,
+                "num_removed": 5,
+                "bulk_assignment_id": "bulk_id_123",
+            },
+        ),
+        # Missing required fields
+        (
+            {"sheet_identifier_type": "id"},
+            None,
+            status.HTTP_400_BAD_REQUEST,
+            {"error": "Both 'sheet_identifier_type' and 'sheet_value' are required."},
+        ),
+        # CouponAssignmentError exception
+        (
+            {"sheet_identifier_type": "id", "sheet_identifier_value": "invalid_sheet"},
+            CouponAssignmentError("Invalid sheet"),
+            status.HTTP_400_BAD_REQUEST,
+            {"error": "Invalid sheet"},
+        ),
+        # Unexpected exception
+        (
+            {"sheet_identifier_type": "id", "sheet_identifier_value": "error_sheet"},
+            Exception("Unexpected error"),
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            {"error": "An error occurred while processing the coupon sheet."},
+        ),
+    ],
+)
+def test_process_coupon_sheet_assignment(mocker, admin_drf_client, request_data, mock_return, expected_status, expected_response):
+    """Test the ProcessCouponSheetAssignmentView post method"""
+    url = reverse("process-coupon-sheet-assignment")
+    if isinstance(mock_return, Exception):
+        mocker.patch("sheets.views.assign_coupons_from_spreadsheet", side_effect=mock_return)
+    else:
+        mocker.patch("sheets.views.assign_coupons_from_spreadsheet", return_value=mock_return)
+    response = admin_drf_client.post(url, request_data, format="json")
+    assert response.status_code == expected_status
+    assert response.json() == expected_response

--- a/sheets/views_test.py
+++ b/sheets/views_test.py
@@ -124,7 +124,11 @@ def test_handle_coupon_request_sheet_update(mocker, settings):
     [
         # Valid request
         (
-            {"sheet_identifier_type": "id", "sheet_identifier_value": "valid_sheet", "force": False},
+            {
+                "sheet_identifier_type": "id",
+                "sheet_identifier_value": "valid_sheet",
+                "force": False,
+            },
             ("Spreadsheet1", 10, 5, "bulk_id_123"),
             status.HTTP_200_OK,
             {
@@ -157,13 +161,24 @@ def test_handle_coupon_request_sheet_update(mocker, settings):
         ),
     ],
 )
-def test_process_coupon_sheet_assignment(mocker, admin_drf_client, request_data, mock_return, expected_status, expected_response):
+def test_process_coupon_sheet_assignment(
+    mocker,
+    admin_drf_client,
+    request_data,
+    mock_return,
+    expected_status,
+    expected_response,
+):
     """Test the ProcessCouponSheetAssignmentView post method"""
     url = reverse("process-coupon-sheet-assignment")
     if isinstance(mock_return, Exception):
-        mocker.patch("sheets.views.assign_coupons_from_spreadsheet", side_effect=mock_return)
+        mocker.patch(
+            "sheets.views.assign_coupons_from_spreadsheet", side_effect=mock_return
+        )
     else:
-        mocker.patch("sheets.views.assign_coupons_from_spreadsheet", return_value=mock_return)
+        mocker.patch(
+            "sheets.views.assign_coupons_from_spreadsheet", return_value=mock_return
+        )
     response = admin_drf_client.post(url, request_data, format="json")
     assert response.status_code == expected_status
     assert response.json() == expected_response

--- a/static/js/components/forms/CouponSheetProcessForm.js
+++ b/static/js/components/forms/CouponSheetProcessForm.js
@@ -1,3 +1,4 @@
+// @flow
 import React from "react";
 import { Formik, Field, Form, ErrorMessage } from "formik";
 import * as yup from "yup";
@@ -11,72 +12,91 @@ type CouponSheetProcessFormProps = {
 };
 
 const couponValidations = yup.object().shape({
-  sheet_identifier_value: yup
-    .string()
-    .when("sheet_identifier_type", {
-      is: SHEET_IDENTIFIER_ID,
-      then: () => yup
+  sheet_identifier_value: yup.string().when("sheet_identifier_type", {
+    is: SHEET_IDENTIFIER_ID,
+    then: () =>
+      yup
         .string()
         .required("Sheet ID is required")
-        .matches(/^[\w-]+$/, "Only letters, numbers, underscores, and hyphens allowed (no spaces)"),
-      otherwise: () => yup
+        .matches(
+          /^[\w-]+$/,
+          "Only letters, numbers, underscores, and hyphens allowed (no spaces)",
+        ),
+    otherwise: () =>
+      yup
         .string()
         .required("Sheet Title is required")
-        .matches(/^[\w\s-]+$/, "Only letters, numbers, spaces, underscores, and hyphens allowed"),
-    }),
+        .matches(
+          /^[\w\s-]+$/,
+          "Only letters, numbers, spaces, underscores, and hyphens allowed",
+        ),
+  }),
 });
 
-export const CouponSheetProcessForm = ({ onSubmit }: CouponSheetProcessFormProps) => {
-  return (
-    <Formik
-      onSubmit={onSubmit}
-      validationSchema={couponValidations}
-      initialValues={{
-        sheet_identifier_value: "",
-        sheet_identifier_type: SHEET_IDENTIFIER_ID,
-      }}
-      render={({ isSubmitting, setFieldValue, values }) => (
-        <Form className="coupon-form">
-          <div>
-            <div className="flex">
-              <div>
-                <Field
-                  type="radio"
-                  name="sheet_identifier_type"
-                  value={SHEET_IDENTIFIER_ID}
-                  onClick={() => setFieldValue("sheet_identifier_type", SHEET_IDENTIFIER_ID)}
-                  checked={values.sheet_identifier_type===SHEET_IDENTIFIER_ID}
-                />
-                <label htmlFor="sheet_identifier_type">Use Sheet ID</label>
-              </div>
-              <div>
-                <Field
-                  type="radio"
-                  name="sheet_identifier_type"
-                  value={SHEET_IDENTIFIER_TITLE}
-                  onClick={() => setFieldValue("sheet_identifier_type", SHEET_IDENTIFIER_TITLE)}
-                  checked={values.sheet_identifier_type===SHEET_IDENTIFIER_TITLE}
-                />
-                <label htmlFor="sheet_identifier_type">Use Sheet Title</label>
-                </div>
+export const CouponSheetProcessForm = ({
+  onSubmit,
+}: CouponSheetProcessFormProps) => (
+  <Formik
+    onSubmit={onSubmit}
+    validationSchema={couponValidations}
+    initialValues={{
+      sheet_identifier_value: "",
+      sheet_identifier_type: SHEET_IDENTIFIER_ID,
+    }}
+    render={({ isSubmitting, setFieldValue, values }) => (
+      <Form className="coupon-form">
+        <div>
+          <div className="flex">
+            <div>
+              <Field
+                type="radio"
+                name="sheet_identifier_type"
+                value={SHEET_IDENTIFIER_ID}
+                onClick={() =>
+                  setFieldValue("sheet_identifier_type", SHEET_IDENTIFIER_ID)
+                }
+                checked={values.sheet_identifier_type === SHEET_IDENTIFIER_ID}
+              />
+              <label htmlFor="sheet_identifier_type">Use Sheet ID</label>
             </div>
-
-            <div className="block text-area-div">
-              <label htmlFor="sheet_identifier_value">
-                {values.sheet_identifier_type===SHEET_IDENTIFIER_ID ? "Sheet ID*" : "Sheet Title*"}
-                <Field name="sheet_identifier_value" component="textarea" rows="2" cols="40" />
-              </label>
-              <ErrorMessage name="sheet_identifier_value" component={FormError} />
+            <div>
+              <Field
+                type="radio"
+                name="sheet_identifier_type"
+                value={SHEET_IDENTIFIER_TITLE}
+                onClick={() =>
+                  setFieldValue("sheet_identifier_type", SHEET_IDENTIFIER_TITLE)
+                }
+                checked={
+                  values.sheet_identifier_type === SHEET_IDENTIFIER_TITLE
+                }
+              />
+              <label htmlFor="sheet_identifier_type">Use Sheet Title</label>
             </div>
           </div>
 
-          <div>
-            <button type="submit" disabled={isSubmitting}>
-              Process Coupon Sheet
-            </button>
+          <div className="block text-area-div">
+            <label htmlFor="sheet_identifier_value">
+              {values.sheet_identifier_type === SHEET_IDENTIFIER_ID
+                ? "Sheet ID*"
+                : "Sheet Title*"}
+              <Field
+                name="sheet_identifier_value"
+                component="textarea"
+                rows="2"
+                cols="40"
+              />
+            </label>
+            <ErrorMessage name="sheet_identifier_value" component={FormError} />
           </div>
-        </Form>
-      )}
-    />
-  );
-};
+        </div>
+
+        <div>
+          <button type="submit" disabled={isSubmitting}>
+            Process Coupon Sheet
+          </button>
+        </div>
+      </Form>
+    )}
+  />
+);

--- a/static/js/components/forms/CouponSheetProcessForm.js
+++ b/static/js/components/forms/CouponSheetProcessForm.js
@@ -31,6 +31,7 @@ const couponValidations = yup.object().shape({
           "Only letters, numbers, spaces, underscores, and hyphens allowed",
         ),
   }),
+  force: yup.boolean(),
 });
 
 export const CouponSheetProcessForm = ({
@@ -42,6 +43,7 @@ export const CouponSheetProcessForm = ({
     initialValues={{
       sheet_identifier_value: "",
       sheet_identifier_type: SHEET_IDENTIFIER_ID,
+      force: false,
     }}
     render={({ isSubmitting, setFieldValue, values }) => (
       <Form className="coupon-form">
@@ -88,6 +90,20 @@ export const CouponSheetProcessForm = ({
               />
             </label>
             <ErrorMessage name="sheet_identifier_value" component={FormError} />
+          </div>
+
+          <div className="checkbox-div">
+            <Field
+              type="checkbox"
+              name="force"
+              value={values.force}
+              onClick={() => setFieldValue("force", !values.force)}
+            />
+            <label htmlFor="force">Force</label>
+            <p className="small-text">
+              Check to force processing the sheet even if unchanged since the
+              last process.
+            </p>
           </div>
         </div>
 

--- a/static/js/components/forms/CouponSheetProcessForm.js
+++ b/static/js/components/forms/CouponSheetProcessForm.js
@@ -1,0 +1,76 @@
+import React from "react";
+import { Formik, Field, Form, ErrorMessage } from "formik";
+import * as yup from "yup";
+
+import FormError from "./elements/FormError";
+
+import { SHEET_IDENTIFIER_ID, SHEET_IDENTIFIER_TITLE } from "../../constants";
+
+type CouponSheetProcessFormProps = {
+  onSubmit: Function,
+};
+
+const couponValidations = yup.object().shape({
+  sheet_identifier_value: yup
+    .string()
+    .required("Sheet ID or Title is required")
+    .matches(
+      /^[\w\n\s-]+$/,
+      "Only letters, numbers, spaces, underscores, and hyphens allowed"
+    ),
+});
+
+export const CouponSheetProcessForm = ({ onSubmit }: CouponSheetProcessFormProps) => {
+  return (
+    <Formik
+      onSubmit={onSubmit}
+      validationSchema={couponValidations}
+      initialValues={{
+        sheet_identifier_value: "",
+        sheet_identifier_type: SHEET_IDENTIFIER_ID,
+      }}
+      render={({ isSubmitting, setFieldValue, values }) => (
+        <Form className="coupon-form">
+          <div>
+            <div className="flex">
+              <div>
+                <Field
+                  type="radio"
+                  name="sheet_identifier_type"
+                  value={SHEET_IDENTIFIER_ID}
+                  onClick={() => setFieldValue("sheet_identifier_type", SHEET_IDENTIFIER_ID)}
+                  checked={values.sheet_identifier_type===SHEET_IDENTIFIER_ID}
+                />
+                <label htmlFor="sheet_identifier_type">Use Sheet ID</label>
+              </div>
+              <div>
+                <Field
+                  type="radio"
+                  name="sheet_identifier_type"
+                  value={SHEET_IDENTIFIER_TITLE}
+                  onClick={() => setFieldValue("sheet_identifier_type", SHEET_IDENTIFIER_TITLE)}
+                  checked={values.sheet_identifier_type===SHEET_IDENTIFIER_TITLE}
+                />
+                <label htmlFor="sheet_identifier_type">Use Sheet Title</label>
+                </div>
+            </div>
+
+            <div className="block text-area-div">
+              <label htmlFor="sheet_identifier_value">
+                {values.sheet_identifier_type===SHEET_IDENTIFIER_ID ? "Sheet ID*" : "Sheet Title*"}
+                <Field name="sheet_identifier_value" component="textarea" rows="2" cols="40" />
+              </label>
+              <ErrorMessage name="sheet_identifier_value" component={FormError} />
+            </div>
+          </div>
+
+          <div>
+            <button type="submit" disabled={isSubmitting}>
+              Process Coupon Sheet
+            </button>
+          </div>
+        </Form>
+      )}
+    />
+  );
+};

--- a/static/js/components/forms/CouponSheetProcessForm.js
+++ b/static/js/components/forms/CouponSheetProcessForm.js
@@ -13,11 +13,17 @@ type CouponSheetProcessFormProps = {
 const couponValidations = yup.object().shape({
   sheet_identifier_value: yup
     .string()
-    .required("Sheet ID or Title is required")
-    .matches(
-      /^[\w\n\s-]+$/,
-      "Only letters, numbers, spaces, underscores, and hyphens allowed"
-    ),
+    .when("sheet_identifier_type", {
+      is: SHEET_IDENTIFIER_ID,
+      then: () => yup
+        .string()
+        .required("Sheet ID is required")
+        .matches(/^[\w-]+$/, "Only letters, numbers, underscores, and hyphens allowed (no spaces)"),
+      otherwise: () => yup
+        .string()
+        .required("Sheet Title is required")
+        .matches(/^[\w\s-]+$/, "Only letters, numbers, spaces, underscores, and hyphens allowed"),
+    }),
 });
 
 export const CouponSheetProcessForm = ({ onSubmit }: CouponSheetProcessFormProps) => {

--- a/static/js/components/forms/CouponSheetProcessForm_test.js
+++ b/static/js/components/forms/CouponSheetProcessForm_test.js
@@ -1,0 +1,86 @@
+// @flow
+import React from "react";
+import sinon from "sinon";
+import { assert } from "chai";
+import { mount } from "enzyme";
+import wait from "waait";
+
+import { CouponSheetProcessForm } from "./CouponSheetProcessForm";
+
+import {
+  findFormikFieldByName,
+  findFormikErrorByName,
+} from "../../lib/test_utils";
+
+import { SHEET_IDENTIFIER_ID, SHEET_IDENTIFIER_TITLE } from "../../constants";
+
+describe("CouponSheetProcessForm", () => {
+  let sandbox, onSubmitStub;
+
+  const renderForm = () =>
+    mount(<CouponSheetProcessForm onSubmit={onSubmitStub} />);
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    onSubmitStub = sandbox.stub();
+  });
+
+  it("passes onSubmit to Formik", () => {
+    const wrapper = renderForm();
+    assert.equal(wrapper.find("Formik").props().onSubmit, onSubmitStub);
+  });
+
+  it("renders the form", () => {
+    const wrapper = renderForm();
+    const form = wrapper.find("Formik");
+    assert.ok(findFormikFieldByName(form, "sheet_identifier_value").exists());
+    assert.ok(form.find("button[type='submit']").exists());
+  });
+
+  [
+    ["sheet_identifier_value", "", "Sheet ID or Title is required"],
+    ["sheet_identifier_value", "Valid_name", ""],
+    [
+      "sheet_identifier_value",
+      "Invalid+value",
+      "Only letters, numbers, spaces, underscores, and hyphens allowed",
+    ],
+  ].forEach(([name, value, errorMessage]) => {
+    it(`validates the field name=${name}, value=${JSON.stringify(
+      value
+    )} and expects error=${JSON.stringify(errorMessage)}`, async () => {
+      const wrapper = renderForm();
+      const input = wrapper.find(`textarea[name="${name}"]`);
+      input.simulate("change", { persist: () => {}, target: { name, value } });
+      input.simulate("blur");
+      await wait();
+      wrapper.update();
+      assert.deepEqual(
+        findFormikErrorByName(wrapper, name).text(),
+        errorMessage
+      );
+    });
+  });
+
+  it("changes label text based on selected identifier type", async () => {
+    const wrapper = renderForm();
+
+    const getLabelText = () => wrapper.find("label[htmlFor='sheet_identifier_value']").text();
+    
+    assert.equal(getLabelText(), "Sheet ID*");
+    
+    const sheetTitleRadio = wrapper.find(`input[name='sheet_identifier_type'][value='${SHEET_IDENTIFIER_TITLE}']`);
+    sheetTitleRadio.simulate("click");
+    await wait();
+    wrapper.update();
+
+    assert.equal(getLabelText(), "Sheet Title*");
+    
+    const sheetIdRadio = wrapper.find(`input[name='sheet_identifier_type'][value='${SHEET_IDENTIFIER_ID}']`);
+    sheetIdRadio.simulate("click");
+    await wait();
+    wrapper.update();
+
+    assert.equal(getLabelText(), "Sheet ID*");
+  });
+});

--- a/static/js/components/forms/CouponSheetProcessForm_test.js
+++ b/static/js/components/forms/CouponSheetProcessForm_test.js
@@ -114,4 +114,32 @@ describe("CouponSheetProcessForm", () => {
 
     assert.equal(getLabelText(), "Sheet ID*");
   });
+
+  it("toggles the force checkbox", async () => {
+    const wrapper = renderForm();
+
+    const checkbox = wrapper.find("input[name='force']");
+    assert.isFalse(
+      checkbox.props().value,
+      "Checkbox should be unchecked initially",
+    );
+
+    checkbox.simulate("click");
+    await wait();
+    wrapper.update();
+
+    assert.isTrue(
+      wrapper.find("input[name='force']").props().value,
+      "Checkbox should be checked after change",
+    );
+
+    checkbox.simulate("click");
+    await wait();
+    wrapper.update();
+
+    assert.isFalse(
+      wrapper.find("input[name='force']").props().value,
+      "Checkbox should be unchecked after change",
+    );
+  });
 });

--- a/static/js/components/forms/CouponSheetProcessForm_test.js
+++ b/static/js/components/forms/CouponSheetProcessForm_test.js
@@ -39,7 +39,12 @@ describe("CouponSheetProcessForm", () => {
 
   [
     // Sheet Title validation (allows spaces)
-    ["sheet_identifier_value", "", "Sheet Title is required", SHEET_IDENTIFIER_TITLE],
+    [
+      "sheet_identifier_value",
+      "",
+      "Sheet Title is required",
+      SHEET_IDENTIFIER_TITLE,
+    ],
     ["sheet_identifier_value", "Valid Name", "", SHEET_IDENTIFIER_TITLE],
     [
       "sheet_identifier_value",
@@ -47,7 +52,7 @@ describe("CouponSheetProcessForm", () => {
       "Only letters, numbers, spaces, underscores, and hyphens allowed",
       SHEET_IDENTIFIER_TITLE,
     ],
-  
+
     // Sheet ID validation (no spaces allowed)
     ["sheet_identifier_value", "", "Sheet ID is required", SHEET_IDENTIFIER_ID],
     ["sheet_identifier_value", "Valid_Name", "", SHEET_IDENTIFIER_ID],
@@ -59,13 +64,17 @@ describe("CouponSheetProcessForm", () => {
     ],
   ].forEach(([name, value, errorMessage, identifierType]) => {
     it(`validates the field name=${name}, value=${JSON.stringify(
-      value
+      value,
     )}, identifierType=${identifierType} and expects error=${JSON.stringify(errorMessage)}`, async () => {
       const wrapper = renderForm();
-      
-      const radio = wrapper.find(`input[name="sheet_identifier_type"][value="${identifierType}"]`);
-      radio.simulate("change", { target: { name: "sheet_identifier_type", value: identifierType } });
-  
+
+      const radio = wrapper.find(
+        `input[name="sheet_identifier_type"][value="${identifierType}"]`,
+      );
+      radio.simulate("change", {
+        target: { name: "sheet_identifier_type", value: identifierType },
+      });
+
       const input = wrapper.find(`textarea[name="${name}"]`);
       input.simulate("change", { persist: () => {}, target: { name, value } });
       input.simulate("blur");
@@ -74,7 +83,7 @@ describe("CouponSheetProcessForm", () => {
 
       assert.deepEqual(
         findFormikErrorByName(wrapper, name).text(),
-        errorMessage
+        errorMessage,
       );
     });
   });
@@ -82,18 +91,23 @@ describe("CouponSheetProcessForm", () => {
   it("changes label text based on selected identifier type", async () => {
     const wrapper = renderForm();
 
-    const getLabelText = () => wrapper.find("label[htmlFor='sheet_identifier_value']").text();
-    
+    const getLabelText = () =>
+      wrapper.find("label[htmlFor='sheet_identifier_value']").text();
+
     assert.equal(getLabelText(), "Sheet ID*");
-    
-    const sheetTitleRadio = wrapper.find(`input[name='sheet_identifier_type'][value='${SHEET_IDENTIFIER_TITLE}']`);
+
+    const sheetTitleRadio = wrapper.find(
+      `input[name='sheet_identifier_type'][value='${SHEET_IDENTIFIER_TITLE}']`,
+    );
     sheetTitleRadio.simulate("click");
     await wait();
     wrapper.update();
 
     assert.equal(getLabelText(), "Sheet Title*");
-    
-    const sheetIdRadio = wrapper.find(`input[name='sheet_identifier_type'][value='${SHEET_IDENTIFIER_ID}']`);
+
+    const sheetIdRadio = wrapper.find(
+      `input[name='sheet_identifier_type'][value='${SHEET_IDENTIFIER_ID}']`,
+    );
     sheetIdRadio.simulate("click");
     await wait();
     wrapper.update();

--- a/static/js/components/forms/CouponSheetProcessForm_test.js
+++ b/static/js/components/forms/CouponSheetProcessForm_test.js
@@ -38,23 +38,40 @@ describe("CouponSheetProcessForm", () => {
   });
 
   [
-    ["sheet_identifier_value", "", "Sheet ID or Title is required"],
-    ["sheet_identifier_value", "Valid_name", ""],
+    // Sheet Title validation (allows spaces)
+    ["sheet_identifier_value", "", "Sheet Title is required", SHEET_IDENTIFIER_TITLE],
+    ["sheet_identifier_value", "Valid Name", "", SHEET_IDENTIFIER_TITLE],
     [
       "sheet_identifier_value",
       "Invalid+value",
       "Only letters, numbers, spaces, underscores, and hyphens allowed",
+      SHEET_IDENTIFIER_TITLE,
     ],
-  ].forEach(([name, value, errorMessage]) => {
+  
+    // Sheet ID validation (no spaces allowed)
+    ["sheet_identifier_value", "", "Sheet ID is required", SHEET_IDENTIFIER_ID],
+    ["sheet_identifier_value", "Valid_Name", "", SHEET_IDENTIFIER_ID],
+    [
+      "sheet_identifier_value",
+      "Invalid Name",
+      "Only letters, numbers, underscores, and hyphens allowed (no spaces)",
+      SHEET_IDENTIFIER_ID,
+    ],
+  ].forEach(([name, value, errorMessage, identifierType]) => {
     it(`validates the field name=${name}, value=${JSON.stringify(
       value
-    )} and expects error=${JSON.stringify(errorMessage)}`, async () => {
+    )}, identifierType=${identifierType} and expects error=${JSON.stringify(errorMessage)}`, async () => {
       const wrapper = renderForm();
+      
+      const radio = wrapper.find(`input[name="sheet_identifier_type"][value="${identifierType}"]`);
+      radio.simulate("change", { target: { name: "sheet_identifier_type", value: identifierType } });
+  
       const input = wrapper.find(`textarea[name="${name}"]`);
       input.simulate("change", { persist: () => {}, target: { name, value } });
       input.simulate("blur");
       await wait();
       wrapper.update();
+
       assert.deepEqual(
         findFormikErrorByName(wrapper, name).text(),
         errorMessage

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -10,6 +10,9 @@ export const ENROLLABLE_ITEM_ID_SEPARATOR = "+";
 export const PRODUCT_TYPE_PROGRAM = "program";
 export const PRODUCT_TYPE_COURSERUN = "courserun";
 
+export const SHEET_IDENTIFIER_ID = "id";
+export const SHEET_IDENTIFIER_TITLE = "title";
+
 export const GENDER_CHOICES = [
   ["m", "Male"],
   ["f", "Female"],

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -119,6 +119,8 @@ export const CHECKOUT_PAGE_TITLE = "Checkout";
 export const DASHBOARD_PAGE_TITLE = "Dashboard";
 export const CREATE_COUPON_PAGE_TITLE = "Create Coupon";
 export const DEACTIVATE_COUPONS_PAGE_TITLE = "Deactivate Coupons";
+export const PROCESS_COUPON_ASSIGNMENT_SHEET_PAGE_TITLE =
+  "Process Coupon Assignment Sheet";
 
 export const LOGIN_EMAIL_PAGE_TITLE = "Sign In";
 export const LOGIN_PASSWORD_PAGE_TITLE = LOGIN_EMAIL_PAGE_TITLE;

--- a/static/js/containers/pages/admin/DeactivateCouponPage.js
+++ b/static/js/containers/pages/admin/DeactivateCouponPage.js
@@ -130,9 +130,12 @@ export class DeactivateCouponPage extends React.Component<Props, State> {
           {isDeactivated ? (
             <div className="coupon-success-div">
               {numOfCouponsDeactivated > 0 && (
-              <div className="form-message form-success">
-                <p className="message-text">Coupon(s) successfully deactivated.</p>
-              </div>)}
+                <div className="form-message form-success">
+                  <p className="message-text">
+                    Coupon(s) successfully deactivated.
+                  </p>
+                </div>
+              )}
               {skippedCodes.length > 0 && (
                 <div className="form-message form-warning">
                   <div className="message-div">

--- a/static/js/containers/pages/admin/DeactivateCouponPage.js
+++ b/static/js/containers/pages/admin/DeactivateCouponPage.js
@@ -130,18 +130,18 @@ export class DeactivateCouponPage extends React.Component<Props, State> {
           {isDeactivated ? (
             <div className="coupon-success-div">
               {numOfCouponsDeactivated > 0 && (
-                <p>Coupon(s) successfully deactivated.</p>
-              )}
-
+              <div className="form-message form-success">
+                <p className="message-text">Coupon(s) successfully deactivated.</p>
+              </div>)}
               {skippedCodes.length > 0 && (
-                <div className="skipped-warning">
-                  <div className="warning-div">
-                    <p className="warning-icon">⚠️</p>
-                    <p className="warning-text">
+                <div className="form-message form-warning">
+                  <div className="message-div">
+                    <p className="message-icon">⚠️</p>
+                    <p className="message-text">
                       WARNING: The following coupon code(s) are incorrect.
                     </p>
                   </div>
-                  <ul className="warning-list">
+                  <ul className="message-list">
                     {skippedCodes.map((code) => (
                       <li key={code}>{code}</li>
                     ))}

--- a/static/js/containers/pages/admin/EcommerceAdminPages.js
+++ b/static/js/containers/pages/admin/EcommerceAdminPages.js
@@ -2,6 +2,7 @@
 declare var USER_PERMISSIONS: {
   has_coupon_create_permission: boolean,
   has_coupon_update_permission: boolean,
+  has_coupon_product_assignment_permission: boolean,
 };
 import React from "react";
 import { Redirect, Route, Switch, Link } from "react-router-dom";
@@ -28,9 +29,13 @@ const EcommerceAdminIndexPage = () => (
           </Link>
         </li>
       )}
-      <li>
-        <Link to={routes.ecommerceAdmin.processSheets}>Process Coupon Assignment Sheet</Link>
-      </li>
+      {USER_PERMISSIONS.has_coupon_product_assignment_permission && (
+        <li>
+          <Link to={routes.ecommerceAdmin.processSheets}>
+            Process Coupon Assignment Sheet
+          </Link>
+        </li>
+      )}
     </ul>
   </div>
 );

--- a/static/js/containers/pages/admin/EcommerceAdminPages.js
+++ b/static/js/containers/pages/admin/EcommerceAdminPages.js
@@ -10,6 +10,7 @@ import { routes } from "../../../lib/urls";
 
 import CouponCreationPage from "./CreateCouponPage";
 import DeactivateCouponPage from "./DeactivateCouponPage";
+import ProcessCouponAssignmentSheetPage from "./ProcessCouponAssignmentSheetPage";
 
 const EcommerceAdminIndexPage = () => (
   <div className="ecommerce-admin-body">
@@ -27,6 +28,9 @@ const EcommerceAdminIndexPage = () => (
           </Link>
         </li>
       )}
+      <li>
+        <Link to={routes.ecommerceAdmin.processSheets}>Process Coupon Assignment Sheet</Link>
+      </li>
     </ul>
   </div>
 );
@@ -48,6 +52,11 @@ const EcommerceAdminPages = () => (
         exact
         path={routes.ecommerceAdmin.deactivate}
         component={DeactivateCouponPage}
+      />
+      <Route
+        exact
+        path={routes.ecommerceAdmin.processSheets}
+        component={ProcessCouponAssignmentSheetPage}
       />
       <Redirect to={routes.ecommerceAdmin.index} />
     </Switch>

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage.js
@@ -1,0 +1,127 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react";
+import DocumentTitle from "react-document-title";
+import { DEACTIVATE_COUPONS_PAGE_TITLE } from "../../../constants";
+import { mutateAsync } from "redux-query";
+import { compose } from "redux";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
+
+import { CouponSheetProcessForm } from "../../../components/forms/CouponSheetProcessForm";
+import queries from "../../../lib/queries";
+import { routes } from "../../../lib/urls";
+
+import type { Response } from "redux-query";
+import { createStructuredSelector } from "reselect";
+
+type State = {
+  submitting: ?boolean,
+  isProcessed: ?boolean,
+  responseMsg: string,
+  errorMsg: string,
+};
+
+type DispatchProps = {|
+  assignSheetCoupons: (payload: Object) => Promise<Response<any>>,
+|};
+
+type Props = {|
+  ...DispatchProps,
+|};
+
+export class ProcessCouponAssignmentSheetPage extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      submitting: false,
+      isProcessed: false,
+      responseMsg: "",
+      errorMsg: ""
+    };
+  }
+
+  onSubmit = async (formData: Object, { setSubmitting }: Object) => {
+    console.log("formData", formData);
+    // await this.setState({ ...this.state, formData: formData });
+    const result = await this.props.assignSheetCoupons(formData);
+    await this.setState({
+      submitting: false,
+      isProcessed: true,
+      responseMsg: result.body.message,
+      errorMsg: result.body.error,
+    })
+    setSubmitting(false);
+  };
+
+  clearSuccess = async () => {
+    await this.setState({
+      submitting: false,
+      isProcessed: false,
+      responseMsg: "",
+      errorMsg: "",
+    });
+  };
+
+  render() {
+    const {
+      isProcessed,
+      responseMsg,
+      errorMsg
+    } = this.state;
+    return (
+      <DocumentTitle
+        title={`${SETTINGS.site_name} | ${DEACTIVATE_COUPONS_PAGE_TITLE}`}
+      >
+        <div className="ecommerce-admin-body">
+          <p>
+            <Link to={routes.ecommerceAdmin.index}>
+              Back to Ecommerce Admin
+            </Link>
+          </p>
+          <h3>Process Coupon Assignment Sheets</h3>
+          {isProcessed ? (
+            <div className="coupon-result-div">
+              {responseMsg ? (
+                  <div className="form-message form-success">
+                      <p className="message-text">{responseMsg}</p>
+                  </div>
+
+              ):(
+              <div className="form-message form-warning">
+                <p className="message-text">{errorMsg}</p>
+              </div>
+            )}
+
+              <div>
+                <input
+                  type="button"
+                  value="Process more sheets"
+                  onClick={this.clearSuccess}
+                />
+              </div>
+            </div>
+          ) : (
+            <CouponSheetProcessForm onSubmit={this.onSubmit} />
+          )}
+        </div>
+      </DocumentTitle>
+    );
+  }
+}
+
+const assignSheetCoupons = (payload: Object) =>
+  mutateAsync(queries.ecommerce.sheetCouponsAssignment(payload));
+
+const mapStateToProps = createStructuredSelector({});
+
+const mapDispatchToProps = {
+  assignSheetCoupons: assignSheetCoupons,
+};
+
+export default compose(
+  connect<Props, _, _, DispatchProps, _, _>(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+)(ProcessCouponAssignmentSheetPage);

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage.js
@@ -2,7 +2,7 @@
 /* global SETTINGS: false */
 import React from "react";
 import DocumentTitle from "react-document-title";
-import { DEACTIVATE_COUPONS_PAGE_TITLE } from "../../../constants";
+import { PROCESS_COUPON_ASSIGNMENT_SHEET_PAGE_TITLE } from "../../../constants";
 import { mutateAsync } from "redux-query";
 import { compose } from "redux";
 import { connect } from "react-redux";
@@ -30,14 +30,17 @@ type Props = {|
   ...DispatchProps,
 |};
 
-export class ProcessCouponAssignmentSheetPage extends React.Component<Props, State> {
+export class ProcessCouponAssignmentSheetPage extends React.Component<
+  Props,
+  State,
+> {
   constructor(props: Props) {
     super(props);
     this.state = {
       submitting: false,
       isProcessed: false,
       responseMsg: "",
-      errorMsg: ""
+      errorMsg: "",
     };
   }
 
@@ -50,7 +53,7 @@ export class ProcessCouponAssignmentSheetPage extends React.Component<Props, Sta
       isProcessed: true,
       responseMsg: result.body.message,
       errorMsg: result.body.error,
-    })
+    });
     setSubmitting(false);
   };
 
@@ -64,14 +67,10 @@ export class ProcessCouponAssignmentSheetPage extends React.Component<Props, Sta
   };
 
   render() {
-    const {
-      isProcessed,
-      responseMsg,
-      errorMsg
-    } = this.state;
+    const { isProcessed, responseMsg, errorMsg } = this.state;
     return (
       <DocumentTitle
-        title={`${SETTINGS.site_name} | ${DEACTIVATE_COUPONS_PAGE_TITLE}`}
+        title={`${SETTINGS.site_name} | ${PROCESS_COUPON_ASSIGNMENT_SHEET_PAGE_TITLE}`}
       >
         <div className="ecommerce-admin-body">
           <p>
@@ -83,15 +82,14 @@ export class ProcessCouponAssignmentSheetPage extends React.Component<Props, Sta
           {isProcessed ? (
             <div className="coupon-result-div">
               {responseMsg ? (
-                  <div className="form-message form-success">
-                      <p className="message-text">{responseMsg}</p>
-                  </div>
-
-              ):(
-              <div className="form-message form-warning">
-                <p className="message-text">{errorMsg}</p>
-              </div>
-            )}
+                <div className="form-message form-success">
+                  <p className="message-text">{responseMsg}</p>
+                </div>
+              ) : (
+                <div className="form-message form-warning">
+                  <p className="message-text">{errorMsg}</p>
+                </div>
+              )}
 
               <div>
                 <input

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage.js
@@ -19,6 +19,8 @@ type State = {
   submitting: ?boolean,
   isProcessed: ?boolean,
   responseMsg: string,
+  numCreated: number,
+  numRemoved: number,
   errorMsg: string,
 };
 
@@ -40,18 +42,20 @@ export class ProcessCouponAssignmentSheetPage extends React.Component<
       submitting: false,
       isProcessed: false,
       responseMsg: "",
+      numCreated: 0,
+      numRemoved: 0,
       errorMsg: "",
     };
   }
 
   onSubmit = async (formData: Object, { setSubmitting }: Object) => {
-    console.log("formData", formData);
-    // await this.setState({ ...this.state, formData: formData });
     const result = await this.props.assignSheetCoupons(formData);
     await this.setState({
       submitting: false,
       isProcessed: true,
       responseMsg: result.body.message,
+      numCreated: result.body.num_created,
+      numRemoved: result.body.num_removed,
       errorMsg: result.body.error,
     });
     setSubmitting(false);
@@ -62,12 +66,15 @@ export class ProcessCouponAssignmentSheetPage extends React.Component<
       submitting: false,
       isProcessed: false,
       responseMsg: "",
+      numCreated: 0,
+      numRemoved: 0,
       errorMsg: "",
     });
   };
 
   render() {
-    const { isProcessed, responseMsg, errorMsg } = this.state;
+    const { isProcessed, responseMsg, numCreated, numRemoved, errorMsg } =
+      this.state;
     return (
       <DocumentTitle
         title={`${SETTINGS.site_name} | ${PROCESS_COUPON_ASSIGNMENT_SHEET_PAGE_TITLE}`}
@@ -84,6 +91,14 @@ export class ProcessCouponAssignmentSheetPage extends React.Component<
               {responseMsg ? (
                 <div className="form-message form-success">
                   <p className="message-text">{responseMsg}</p>
+                  <p className="message-text">
+                    Number of Coupon Assignment created:{" "}
+                    <strong>{numCreated}</strong>
+                  </p>
+                  <p className="message-text">
+                    Number of Coupon Assignment removed:{" "}
+                    <strong>{numRemoved}</strong>
+                  </p>
                 </div>
               ) : (
                 <div className="form-message form-warning">

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage_test.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheetPage_test.js
@@ -35,10 +35,16 @@ describe("ProcessCouponAssignmentSheetPage", () => {
 
     // Success Case
     const successMsg = `Successfully processed coupon assignment sheet.`;
-    await inner
-      .instance()
-      .setState({ isProcessed: true, responseMsg: successMsg });
-    assert.equal(inner.find(".coupon-result-div").text(), successMsg);
+    await inner.instance().setState({
+      isProcessed: true,
+      responseMsg: successMsg,
+      numCreated: 4,
+      numRemoved: 2,
+    });
+    assert.equal(
+      inner.find(".coupon-result-div").text(),
+      `${successMsg}Number of Coupon Assignment created: 4Number of Coupon Assignment removed: 2`,
+    );
 
     // Error Case
     const errorMsg = "Error processing coupon assignment sheet.";

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheet_test.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheet_test.js
@@ -38,26 +38,26 @@ describe("ProcessCouponAssignmentSheetPage", () => {
     const successMsg = `Successfully processed coupon assignment sheet.`;
     await inner
       .instance()
-      .setState({ isProcessed: true, responseMsg : successMsg });
+      .setState({ isProcessed: true, responseMsg: successMsg });
     assert.equal(inner.find(".coupon-result-div").text(), successMsg);
 
     // Error Case
     const errorMsg = "Error processing coupon assignment sheet.";
     inner
       .instance()
-      .setState({ isProcessed: true, responseMsg :"", errorMsg: errorMsg });
+      .setState({ isProcessed: true, responseMsg: "", errorMsg: errorMsg });
     assert.equal(inner.find(".coupon-result-div").text(), errorMsg);
-
   });
 
   it("sets state.isProcessed if submission is successful", async () => {
     const testPayloadData = {
-      sheet_identifier_type : "id",
-      sheet_identifier_value : "123",
+      sheet_identifier_type: "id",
+      sheet_identifier_value: "123",
     };
     helper.handleRequestStub.returns({
       body: {
-        message: "Successfully processed coupon assignment sheet  ('abc', id: 123).",
+        message:
+          "Successfully processed coupon assignment sheet  ('abc', id: 123).",
       },
     });
     const { inner } = await renderProcessCouponAssignmentSheetPage();
@@ -68,13 +68,18 @@ describe("ProcessCouponAssignmentSheetPage", () => {
     sinon.assert.calledWith(setSubmittingStub, false);
 
     await wait;
-    sinon.assert.calledWith(helper.handleRequestStub, "/api/sheets/process_coupon_sheet_assignment/", "POST", {
-      body: testPayloadData,
-      headers: {
-        "X-CSRFTOKEN": null,
+    sinon.assert.calledWith(
+      helper.handleRequestStub,
+      "/api/sheets/process_coupon_sheet_assignment/",
+      "POST",
+      {
+        body: testPayloadData,
+        headers: {
+          "X-CSRFTOKEN": null,
+        },
+        credentials: undefined,
       },
-      credentials: undefined,
-    });
+    );
   });
 
   it("clearSuccess() changes state.isProcessed", async () => {

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheet_test.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheet_test.js
@@ -7,7 +7,6 @@ import ProcessCouponAssignmentSheetPage, {
 } from "./ProcessCouponAssignmentSheetPage";
 
 import IntegrationTestHelper from "../../../util/integration_test_helper";
-import { Modal } from "reactstrap";
 import wait from "waait";
 
 describe("ProcessCouponAssignmentSheetPage", () => {

--- a/static/js/containers/pages/admin/ProcessCouponAssignmentSheet_test.js
+++ b/static/js/containers/pages/admin/ProcessCouponAssignmentSheet_test.js
@@ -1,0 +1,87 @@
+// @flow
+import { assert } from "chai";
+import * as sinon from "sinon";
+
+import ProcessCouponAssignmentSheetPage, {
+  ProcessCouponAssignmentSheetPage as InnerProcessCouponAssignmentSheetPage,
+} from "./ProcessCouponAssignmentSheetPage";
+
+import IntegrationTestHelper from "../../../util/integration_test_helper";
+import { Modal } from "reactstrap";
+import wait from "waait";
+
+describe("ProcessCouponAssignmentSheetPage", () => {
+  let helper, renderProcessCouponAssignmentSheetPage, setSubmittingStub;
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+    setSubmittingStub = helper.sandbox.stub();
+    renderProcessCouponAssignmentSheetPage = helper.configureHOCRenderer(
+      ProcessCouponAssignmentSheetPage,
+      InnerProcessCouponAssignmentSheetPage,
+    );
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it("displays a coupon sheet process form on the page", async () => {
+    const { inner } = await renderProcessCouponAssignmentSheetPage();
+    assert.isTrue(inner.find("CouponSheetProcessForm").exists());
+  });
+
+  it("displays a success message on the page", async () => {
+    const { inner } = await renderProcessCouponAssignmentSheetPage();
+
+    // Success Case
+    const successMsg = `Successfully processed coupon assignment sheet.`;
+    await inner
+      .instance()
+      .setState({ isProcessed: true, responseMsg : successMsg });
+    assert.equal(inner.find(".coupon-result-div").text(), successMsg);
+
+    // Error Case
+    const errorMsg = "Error processing coupon assignment sheet.";
+    inner
+      .instance()
+      .setState({ isProcessed: true, responseMsg :"", errorMsg: errorMsg });
+    assert.equal(inner.find(".coupon-result-div").text(), errorMsg);
+
+  });
+
+  it("sets state.isProcessed if submission is successful", async () => {
+    const testPayloadData = {
+      sheet_identifier_type : "id",
+      sheet_identifier_value : "123",
+    };
+    helper.handleRequestStub.returns({
+      body: {
+        message: "Successfully processed coupon assignment sheet  ('abc', id: 123).",
+      },
+    });
+    const { inner } = await renderProcessCouponAssignmentSheetPage();
+
+    await inner.instance().onSubmit(testPayloadData, {
+      setSubmitting: setSubmittingStub,
+    });
+    sinon.assert.calledWith(setSubmittingStub, false);
+
+    await wait;
+    sinon.assert.calledWith(helper.handleRequestStub, "/api/sheets/process_coupon_sheet_assignment/", "POST", {
+      body: testPayloadData,
+      headers: {
+        "X-CSRFTOKEN": null,
+      },
+      credentials: undefined,
+    });
+  });
+
+  it("clearSuccess() changes state.isProcessed", async () => {
+    const { inner } = await renderProcessCouponAssignmentSheetPage();
+    inner.instance().setState({ isProcessed: true });
+    assert.equal(inner.state().isProcessed, true);
+    inner.instance().clearSuccess();
+    assert.equal(inner.state().isProcessed, false);
+  });
+});

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -117,6 +117,15 @@ export default {
       ...DEFAULT_POST_OPTIONS,
     },
   }),
+  sheetCouponsAssignment: (payload: Object) => ({
+    queryKey: "couponsAssignment",
+    url: "/api/sheets/process_coupon_sheet_assignment/",
+    body: payload,
+    options: {
+      method: "POST",
+      ...DEFAULT_POST_OPTIONS,
+    },
+  }),
   b2bCheckoutMutation: (payload: B2BCheckoutPayload) => ({
     queryKey: "b2bCheckoutMutation",
     url: "/api/b2b/checkout/",

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -48,7 +48,7 @@ export const routes = {
     index: "",
     coupons: "coupons/",
     deactivate: "deactivate-coupons/",
-    processSheets: "process-sheets/",
+    processSheets: "process-coupon-assignment-sheets/",
   }),
 
   ecommerceBulk: include("/ecommerce/bulk/", {

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -48,6 +48,7 @@ export const routes = {
     index: "",
     coupons: "coupons/",
     deactivate: "deactivate-coupons/",
+    processSheets: "process-sheets/",
   }),
 
   ecommerceBulk: include("/ecommerce/bulk/", {

--- a/static/scss/ecommerce-admin.scss
+++ b/static/scss/ecommerce-admin.scss
@@ -49,7 +49,6 @@
   }
 }
 
-
 .modal-title {
   font-size: 28px;
 }

--- a/static/scss/ecommerce-admin.scss
+++ b/static/scss/ecommerce-admin.scss
@@ -18,29 +18,37 @@
   }
 }
 
-.skipped-warning {
+.form-message {
   border-radius: 5px;
-  background-color: $warning-background;
   color: $white;
   padding: 15px;
   margin-bottom: 16px;
 
-  .warning-div {
+  .message-div {
     display: flex;
   }
 
-  .warning-icon {
+  .message-icon {
     margin: 0 10px 0 0;
   }
 
-  .warning-text {
+  .message-text {
     margin: 0;
   }
 
-  .warning-list {
+  .message-list {
     margin: 0 0 0 10px;
   }
+
+  &.form-success {
+    background-color: $success-background;
+  }
+
+  &.form-warning {
+    background-color: $warning-background;
+  }
 }
+
 
 .modal-title {
   font-size: 28px;

--- a/static/scss/ecommerce-admin.scss
+++ b/static/scss/ecommerce-admin.scss
@@ -162,3 +162,12 @@ button.btn.btn-gradient-white-to-blue:hover {
     max-width: 600px;
   }
 }
+
+.checkbox-div {
+  padding: 0 !important;
+
+  label {
+    padding-left: 5px;
+    margin: 0;
+  }
+}

--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -35,3 +35,4 @@ $close-hover-background: #f9f2f3;
 $hs-form-field-border: #ced4da;
 $hs-form-field-label: #495057;
 $warning-background: #ef5350;
+$success-background: #66bb6a;


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6582

### Description (What does it do?)
This PR adds the interface for processing product coupon assignment sheets in `ecommerce admin`. The UI will only be accessible to people having permissions to add and update [ProductCouponAssignment](https://github.com/mitodl/mitxpro/blob/b358a1b21b9c53804f2b5cd589705667509684a2/ecommerce/models.py#L840) model.

### Screenshots (if appropriate):
#### Users with only adding and deleting a coupon permissions
<img width="1015" alt="Screenshot 2025-02-19 at 4 58 47 PM" src="https://github.com/user-attachments/assets/0045027b-4c15-4cf0-920c-4abce368000b" />

<img width="1559" alt="Screenshot 2025-02-19 
at 5 00 01 PM" src="https://github.com/user-attachments/assets/f9768519-864f-41c5-b40f-ae496582a6ed" />

<img width="1559" alt="Screenshot 2025-02-19 at 5 01 26 PM" src="https://github.com/user-attachments/assets/e074714d-f05b-476d-b545-ae24a6ad3eb5" />

#### Users with adding **and** changing ProductCouponAssignment model permissions
<img width="1055" alt="Screenshot 2025-02-19 at 5 04 07 PM" src="https://github.com/user-attachments/assets/bc55729b-ce34-4c41-b692-27cd5415d2bc" />

<img width="1465" alt="Screenshot 2025-02-19 at 5 05 08 PM" src="https://github.com/user-attachments/assets/94bdad73-01fb-46f6-bc99-c33e71cc0ebf" />

<img width="1465" alt="Screenshot 2025-02-19 at 5 04 45 PM" src="https://github.com/user-attachments/assets/bd390dd8-df8d-4898-81b6-ec32aa510656" />

#### Form Validations when using ID
<img width="1465" alt="Screenshot 2025-02-19 at 5 06 42 PM" src="https://github.com/user-attachments/assets/95689e96-fd1e-4439-a5d5-39376b51bc93" />

<img width="1465" alt="Screenshot 2025-02-19 at 5 07 04 PM" src="https://github.com/user-attachments/assets/290c3b84-6ad2-47f5-9a76-631cc3891609" />

#### Form Validations when using Title
<img width="1465" alt="Screenshot 2025-02-19 at 5 08 37 PM" src="https://github.com/user-attachments/assets/771e2aff-4468-4a23-ba21-fcef96909042" />
<img width="1465" alt="Screenshot 2025-02-19 at 5 09 20 PM" src="https://github.com/user-attachments/assets/c7ed672c-576a-4df6-a6f1-961ff8b46016" />
<img width="1465" alt="Screenshot 2025-02-19 at 5 09 35 PM" src="https://github.com/user-attachments/assets/58fd8d07-9d5b-4aca-b95b-106b33e86dff" />

#### Success response from API
<img width="1465" alt="Screenshot 2025-02-19 at 5 10 30 PM" src="https://github.com/user-attachments/assets/ad66f84a-1bf3-424d-817a-c01771a14ea3" />

#### Error response from API
<img width="1465" alt="Screenshot 2025-02-19 at 5 11 28 PM" src="https://github.com/user-attachments/assets/03a45780-f541-40bd-98d8-92f8f99b7fee" />

### How can this be tested?

- Create some test coupons on http://localhost:8053/ecommerce/admin/coupons/. Make sure you select only **one product** at the time of coupon creation to automatically create [CouponEligibility](https://github.com/mitodl/mitxpro/blob/b358a1b21b9c53804f2b5cd589705667509684a2/ecommerce/models.py#L710) object which is required for processing sheets.
- Follow https://pygsheets.readthedocs.io/en/stable/authorization.html to get the Service Account Key. Set this key in `DRIVE_SERVICE_ACCOUNT_CREDS` environment variable
- Grant your service account `owner` permissions
- Now, create a Shared Drive folder in your google drive.
- Create a folder inside the shared drive. I named it `Sheets xPRO` when creating one for local testing.
- In the `Sheets xPRO` folder, create a spread sheet with name prefixed by `Enrollment Codes - `. See this [shared drive](https://drive.google.com/drive/folders/0AIbxGdFEImI3Uk9PVA) I created when testing for reference. I would still need to give you access so feel free to request one.
- In the .env file add the following variables:
   ```
  SHEETS_ADMIN_EMAILS = "muhammad.anas@arbisoft.com, ocw-422@sodium-platform-401610.iam.gserviceaccount.com" # Your main and service account emails
  DRIVE_OUTPUT_FOLDER_ID=1vz6ZepeCX4lGMrFQmy8PB3Kk6IDGbfQ2 # Id of the folder Sheets xPRO (Can be found in URL)
  DRIVE_SHARED_ID=0AIbxGdFEImI3Uk9PVA # Id of the shared drive (Can be found in URL)
   ```
- Give editor access to service account in both spreadsheet and parent folder(`Sheets xPRO` in our case)
- Your sheets setup is complete and ready to use.
- On a private window login with a test account with no permissions assigned
- From the test account go to `http://localhost:8053/ecommerce/admin/`. You should get a 403
- Grant the test account permissions to add and update `ProductCouponAssignment`.
- Now reload the ecommerce/admin page. Click the `Process Coupon AssignmentSheet` link.
- In the spreadsheet you created in the above steps, add the following row:
```
| Coupon Code | Email (Assignee) | Status   | Status Date         | URL                | Redeemed |
|-------------|-----------------|----------|----------------------|---------------------|----------|
| {Code you created above} | test-learner@gmail.com | enrolled | 2/18/2025 6:50:18 | [xpro.mit.e](https://xpro.mit.e) | 0 |

```
- Copy the spreadsheet ID from the spreadsheet URL and paste it in the text box at `/ecommerce/admin/process-coupon-assignment-sheets/`
- Click the `Process Coupon Sheet` button
- You should be able to see a success page (see the screenshot above)
- You should also receive an email:
<img width="1392" alt="Screenshot 2025-02-19 at 7 46 08 PM" src="https://github.com/user-attachments/assets/dc628d58-854d-4c3f-b18a-6f9ab5af028a" />

- Clicking the email link should open the checkout page with the coupon applied.
- For processing the sheet with title, add another row with the code (created for a different product) in the sheet
- Select the `Use Title Sheet` radio button and enter the title of the sheet in the text box
- You should be able to see a success page (see the screenshot above). You should receive an enrollment email.
- Clicking the email link should open the checkout page with the coupon applied.
- In the form, inputting an invalid ID or title should result in the error page as shown in the screenshots above.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
