### PR TITLE
fix: course run updated_on updation when deactivating external course run

### DIFF
--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -862,10 +862,11 @@ def deactivate_missing_course_runs(external_course_run_codes, platform):
             related_product = course_run.product.first()
             if related_product:
                 related_product.is_active = False
+                related_product.updated_on = now_in_utc()
                 updated_products.append(related_product)
 
     CourseRun.objects.bulk_update(course_runs, ["live", "updated_on"])
-    Product.objects.bulk_update(updated_products, ["is_active"])
+    Product.objects.bulk_update(updated_products, ["is_active", "updated_on"])
     log.info(
         f"Deactivated {len(deactivated_runs_list)} course runs for platform {platform.name}."
     )

--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -854,17 +854,17 @@ def deactivate_missing_course_runs(external_course_run_codes, platform):
             Prefetch("product", queryset=Product.all_objects.filter(is_active=True))
         )
     )
-
     for course_run in course_runs:
         if course_run.is_unexpired:
             course_run.live = False
+            course_run.updated_on = now_in_utc()
             deactivated_runs_list.append(course_run.external_course_run_id)
             related_product = course_run.product.first()
             if related_product:
                 related_product.is_active = False
                 updated_products.append(related_product)
 
-    CourseRun.objects.bulk_update(course_runs, ["live"])
+    CourseRun.objects.bulk_update(course_runs, ["live", "updated_on"])
     Product.objects.bulk_update(updated_products, ["is_active"])
     log.info(
         f"Deactivated {len(deactivated_runs_list)} course runs for platform {platform.name}."

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -1027,7 +1027,7 @@ def test_deactivate_missing_course_runs(
         new_callable=mocker.PropertyMock,
         return_value=is_unexpired,
     )
-    mock_now = now_in_utc() + timedelta(1) # By default the course run is created with updated_on set to now therefore adding timedelta
+    mock_now = now_in_utc() + timedelta(1) # By default, the course run is created with updated_on set to the current time, so we add a timedelta to adjust it accordingly.
     mocker.patch("courses.sync_external_courses.external_course_sync_api.now_in_utc", return_value=mock_now)
     deactivated_runs_list = deactivate_missing_course_runs(
         api_course_run_codes, platform
@@ -1038,3 +1038,4 @@ def test_deactivate_missing_course_runs(
     assert course_run.live == expected_is_live
     assert product.is_active == expected_is_live
     assert (course_run.updated_on.replace(microsecond=0) == mock_now.replace(microsecond=0)) == (not expected_is_live)
+    assert (product.updated_on.replace(microsecond=0) == mock_now.replace(microsecond=0)) == (not expected_is_live)

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -1028,7 +1028,10 @@ def test_deactivate_missing_course_runs(
         return_value=is_unexpired,
     )
     mock_now = now_in_utc()
-    mocker.patch("courses.sync_external_courses.external_course_sync_api.now_in_utc", return_value=mock_now)
+    mocker.patch(
+        "courses.sync_external_courses.external_course_sync_api.now_in_utc",
+        return_value=mock_now,
+    )
     deactivated_runs_list = deactivate_missing_course_runs(
         api_course_run_codes, platform
     )

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -1027,7 +1027,7 @@ def test_deactivate_missing_course_runs(
         new_callable=mocker.PropertyMock,
         return_value=is_unexpired,
     )
-    mock_now = now_in_utc() + timedelta(1) # By default, the course run is created with updated_on set to the current time, so we add a timedelta to adjust it accordingly.
+    mock_now = now_in_utc()
     mocker.patch("courses.sync_external_courses.external_course_sync_api.now_in_utc", return_value=mock_now)
     deactivated_runs_list = deactivate_missing_course_runs(
         api_course_run_codes, platform
@@ -1037,5 +1037,5 @@ def test_deactivate_missing_course_runs(
     assert (external_course_run_id in deactivated_runs_list) == (not expected_is_live)
     assert course_run.live == expected_is_live
     assert product.is_active == expected_is_live
-    assert (course_run.updated_on.replace(microsecond=0) == mock_now.replace(microsecond=0)) == (not expected_is_live)
-    assert (product.updated_on.replace(microsecond=0) == mock_now.replace(microsecond=0)) == (not expected_is_live)
+    assert (course_run.updated_on == mock_now) == (not expected_is_live)
+    assert (product.updated_on == mock_now) == (not expected_is_live)

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -1027,6 +1027,8 @@ def test_deactivate_missing_course_runs(
         new_callable=mocker.PropertyMock,
         return_value=is_unexpired,
     )
+    mock_now = now_in_utc() + timedelta(1) # By default the course run is created with updated_on set to now therefore adding timedelta
+    mocker.patch("courses.sync_external_courses.external_course_sync_api.now_in_utc", return_value=mock_now)
     deactivated_runs_list = deactivate_missing_course_runs(
         api_course_run_codes, platform
     )
@@ -1035,3 +1037,4 @@ def test_deactivate_missing_course_runs(
     assert (external_course_run_id in deactivated_runs_list) == (not expected_is_live)
     assert course_run.live == expected_is_live
     assert product.is_active == expected_is_live
+    assert (course_run.updated_on.replace(microsecond=0) == mock_now.replace(microsecond=0)) == (not expected_is_live)


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up PR of https://github.com/mitodl/mitxpro/pull/3386

### Description (What does it do?)
While testing, it came into notice that the `updated_on` field is not updated for external course runs which are deactivated, due to [bulk_update](https://github.com/mitodl/mitxpro/pull/3386/files#diff-2ced998483e8958644e8ae749e2055bae58b599e2c37a4507e7013f21834c45bR867). This PR fixes this issue

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Follow the testing instructions in https://github.com/mitodl/mitxpro/pull/3386
- Validate that the updated_on field is updated properly

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
