### PR TITLE
External Course Sync Email

### DIFF
--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -336,14 +336,18 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
             log.info(
                 f"Skipping due to bad data... Course data: {json.dumps(external_course_json)}"  # noqa: G004
             )
-            stats["course_runs_skipped"].add(external_course.course_run_code)
+            stats["course_runs_skipped"].add(
+                (external_course.course_run_code, external_course.course_title)
+            )
             continue
 
         if not external_course.validate_end_date():
             log.info(
                 f"Course run is expired, Skipping... Course data: {json.dumps(external_course_json)}"  # noqa: G004
             )
-            stats["course_runs_expired"].add(external_course.course_run_code)
+            stats["course_runs_expired"].add(
+                (external_course.course_run_code, external_course.course_title)
+            )
             continue
 
         with transaction.atomic():
@@ -360,12 +364,16 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
             )
 
             if course_created:
-                stats["courses_created"].add(external_course.course_code)
+                stats["courses_created"].add(
+                    (external_course.course_code, external_course.course_title)
+                )
                 log.info(
                     f"Created course, title: {external_course.course_title}, readable_id: {external_course.course_readable_id}"  # noqa: G004
                 )
             else:
-                stats["existing_courses"].add(external_course.course_code)
+                stats["existing_courses"].add(
+                    (external_course.course_code, external_course.course_title)
+                )
                 log.info(
                     f"Course already exists, title: {external_course.course_title}, readable_id: {external_course.course_readable_id}"  # noqa: G004
                 )
@@ -378,12 +386,16 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
             )
 
             if course_run_created:
-                stats["course_runs_created"].add(course_run.external_course_run_id)
+                stats["course_runs_created"].add(
+                    (course_run.external_course_run_id, course_run.title)
+                )
                 log.info(
                     f"Created Course Run, title: {external_course.course_title}, external_course_run_id: {course_run.external_course_run_id}"  # noqa: G004
                 )
             elif course_run_updated:
-                stats["course_runs_updated"].add(course_run.external_course_run_id)
+                stats["course_runs_updated"].add(
+                    (course_run.external_course_run_id, course_run.title)
+                )
                 log.info(
                     f"Updated Course Run, title: {external_course.course_title}, external_course_run_id: {course_run.external_course_run_id}"  # noqa: G004
                 )
@@ -399,14 +411,16 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
                     )
                 )
                 if product_created:
-                    stats["products_created"].add(course_run.external_course_run_id)
+                    stats["products_created"].add(
+                        (course_run.external_course_run_id, course_run.title)
+                    )
                     log.info(
                         f"Created Product for course run: {course_run.courseware_id}"  # noqa: G004
                     )
 
                 if product_version_created:
                     stats["product_versions_created"].add(
-                        course_run.external_course_run_id
+                        (course_run.external_course_run_id, course_run.title)
                     )
                     log.info(
                         f"Created Product Version for course run: {course_run.courseware_id}, Price: {external_course.price}"  # noqa: G004
@@ -415,7 +429,9 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
                 log.info(
                     f"Price is Null for course run code: {external_course.course_run_code}"  # noqa: G004
                 )
-                stats["course_runs_without_prices"].add(external_course.course_run_code)
+                stats["course_runs_without_prices"].add(
+                    (external_course.course_run_code, external_course.course_title)
+                )
 
             log.info(
                 f"Creating or Updating course page, title: {external_course.course_title}, course_code: {external_course.course_run_code}"  # noqa: G004
@@ -427,12 +443,16 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
             )
 
             if course_page_created:
-                stats["course_pages_created"].add(external_course.course_code)
+                stats["course_pages_created"].add(
+                    (external_course.course_code, external_course.course_title)
+                )
                 log.info(
                     f"Created external course page for course title: {external_course.course_title}"  # noqa: G004
                 )
             elif course_page_updated:
-                stats["course_pages_updated"].add(external_course.course_code)
+                stats["course_pages_updated"].add(
+                    (external_course.course_code, external_course.course_title)
+                )
                 log.info(
                     f"Updated external course page for course title: {external_course.course_title}"  # noqa: G004
                 )
@@ -476,9 +496,9 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
 
                 if is_certificatepage_created:
                     log.info("Certificate Page Created")
-                    stats["certificates_created"].add(course.readable_id)
+                    stats["certificates_created"].add((course.readable_id,))
                 elif is_certificatepage_updated:
-                    stats["certificates_updated"].add(course.readable_id)
+                    stats["certificates_updated"].add((course.readable_id,))
                     log.info("Certificate Page Updated")
 
             overview_page = course_page.get_child_page_of_type_including_draft(

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -602,10 +602,11 @@ def test_update_external_course_runs(  # noqa: PLR0915, PLR0913
     assert len(stats["course_runs_without_prices"]) == 1
 
     for external_course_run in external_course_runs:
-        if (
-            external_course_run["course_run_code"] in stats["course_runs_skipped"]
-            or external_course_run["course_run_code"] in stats["course_runs_expired"]
-        ):
+        if external_course_run["course_run_code"] in {
+            code for code, _, _ in stats["course_runs_skipped"]
+        } or external_course_run["course_run_code"] in {
+            code for code, _ in stats["course_runs_expired"]
+        }:
             continue
 
         course = Course.objects.filter(
@@ -861,58 +862,124 @@ def test_save_page_revision(is_draft_page, has_unpublished_changes):
     indirect=True,
 )
 @pytest.mark.parametrize(
-    ("title", "course_code", "course_run_code", "is_valid"),
+    ("title", "course_code", "course_run_code", "is_valid", "reason"),
     [
         (
             "Internet of Things (IoT): Design and Applications     ",
             "MO-DBIP",
             "MO-DBIP.ELE-99-07#1",
             True,
+            None,
         ),
         (
             "Internet of Things (IoT): Design and Applications     ",
             "MXP-DBIP",
             "MXP-DBIP.ELE-99-07#1",
             True,
+            None,
         ),
-        ("", "MO-DBIP", "MO-DBIP.ELE-99-07#1", False),
-        ("", "MXP-DBIP", "MXP-DBIP.ELE-99-07#1", False),
-        (None, "MO-DBIP", "MO-DBIP.ELE-99-07#1", False),
-        (None, "MXP-DBIP", "MXP-DBIP.ELE-99-07#1", False),
+        (
+            "",
+            "MO-DBIP",
+            "MO-DBIP.ELE-99-07#1",
+            False,
+            "Missing required field course_title",
+        ),
+        (
+            "",
+            "MXP-DBIP",
+            "MXP-DBIP.ELE-99-07#1",
+            False,
+            "Missing required field course_title",
+        ),
+        (
+            None,
+            "MO-DBIP",
+            "MO-DBIP.ELE-99-07#1",
+            False,
+            "Missing required field course_title",
+        ),
+        (
+            None,
+            "MXP-DBIP",
+            "MXP-DBIP.ELE-99-07#1",
+            False,
+            "Missing required field course_title",
+        ),
         (
             "    Internet of Things (IoT): Design and Applications   ",
             "",
             "MO-DBIP.ELE-99-07#1",
             False,
+            "Missing required field course_code",
         ),
         (
             "    Internet of Things (IoT): Design and Applications   ",
             "",
             "MXP-DBIP.ELE-99-07#1",
             False,
+            "Missing required field course_code",
         ),
         (
             "    Internet of Things (IoT): Design and Applications",
             None,
             "MO-DBIP.ELE-99-07#1",
             False,
+            "Missing required field course_code",
         ),
         (
             "    Internet of Things (IoT): Design and Applications",
             None,
             "MXP-DBIP.ELE-99-07#1",
             False,
+            "Missing required field course_code",
         ),
-        ("Internet of Things (IoT): Design and Applications", "MO-DBIP", "", False),
-        ("Internet of Things (IoT): Design and Applications", "MXP-DBIP", "", False),
-        ("Internet of Things (IoT): Design and Applications", "MO-DBIP", None, False),
-        ("Internet of Things (IoT): Design and Applications", "MXP-DBIP", None, False),
-        ("", "", "", False),
-        (None, None, None, False),
+        (
+            "Internet of Things (IoT): Design and Applications",
+            "MO-DBIP",
+            "",
+            False,
+            "Missing required field course_run_code",
+        ),
+        (
+            "Internet of Things (IoT): Design and Applications",
+            "MXP-DBIP",
+            "",
+            False,
+            "Missing required field course_run_code",
+        ),
+        (
+            "Internet of Things (IoT): Design and Applications",
+            "MO-DBIP",
+            None,
+            False,
+            "Missing required field course_run_code",
+        ),
+        (
+            "Internet of Things (IoT): Design and Applications",
+            "MXP-DBIP",
+            None,
+            False,
+            "Missing required field course_run_code",
+        ),
+        (
+            "",
+            "",
+            "",
+            False,
+            "Missing required field course_title",
+        ),
+        (
+            None,
+            None,
+            None,
+            False,
+            "Missing required field course_title",
+        ),
     ],
 )
 def test_external_course_validate_required_fields(
-    external_course_data, title, course_code, course_run_code, is_valid
+    external_course_data, title, course_code, course_run_code, is_valid, reason
 ):
     """
     Tests that ExternalCourse.validate_required_fields validates required fields.
@@ -922,7 +989,11 @@ def test_external_course_validate_required_fields(
     external_course.course_title = title.strip() if title else title
     external_course.course_code = course_code
     external_course.course_run_code = course_run_code
-    assert external_course.validate_required_fields(keymap=keymap) == is_valid
+    fields_valid, fields_reason = external_course.validate_required_fields(
+        keymap=keymap
+    )
+    assert fields_valid == is_valid
+    assert fields_reason == reason
 
 
 @pytest.mark.parametrize(
@@ -931,17 +1002,17 @@ def test_external_course_validate_required_fields(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    ("list_currency", "is_valid"),
+    ("list_currency", "is_valid", "reason"),
     [
-        ("USD", True),
-        ("INR", False),
-        ("EUR", False),
-        ("GBP", False),
-        ("PKR", False),
+        ("USD", True, None),
+        ("INR", False, "Invalid currency: INR."),
+        ("EUR", False, "Invalid currency: EUR."),
+        ("GBP", False, "Invalid currency: GBP."),
+        ("PKR", False, "Invalid currency: PKR."),
     ],
 )
 def test_external_course_validate_list_currency(
-    external_course_data, list_currency, is_valid
+    external_course_data, list_currency, is_valid, reason
 ):
     """
     Tests that the `USD` is the only valid currency for the External courses.
@@ -949,7 +1020,9 @@ def test_external_course_validate_list_currency(
     keymap = get_keymap(external_course_data["course_run_code"])
     external_course = ExternalCourse(external_course_data, keymap=keymap)
     external_course.list_currency = list_currency
-    assert external_course.validate_list_currency() == is_valid
+    currency_valid, currency_reason = external_course.validate_list_currency()
+    assert currency_valid == is_valid
+    assert currency_reason == reason
 
 
 @pytest.mark.parametrize(

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -21,6 +21,7 @@ from courses.utils import (
     sync_course_runs,
 )
 from courseware.api import get_edx_grades_with_users
+from ecommerce.mail_api import send_external_data_sync_email
 from mitxpro.celery import app
 from mitxpro.utils import now_in_utc
 
@@ -129,6 +130,10 @@ def task_sync_external_course_runs():
         try:
             keymap = keymap()
             external_course_runs = fetch_external_courses(keymap)
-            update_external_course_runs(external_course_runs, keymap)
+            stats = update_external_course_runs(external_course_runs, keymap)
+            send_external_data_sync_email(
+                vendor_name=platform.name.lower(),
+                stats=stats,
+            )
         except Exception:
             log.exception("Some error occurred")

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -19,6 +19,7 @@ from mail.constants import (
     EMAIL_COURSE_RUN_UNENROLLMENT,
     EMAIL_PRODUCT_ORDER_RECEIPT,
     EMAIL_WELCOME_COURSE_RUN_ENROLLMENT,
+    EMAIL_EXTERNAL_DATA_SYNC,
 )
 from mitxpro import features
 from mitxpro.utils import format_price
@@ -393,3 +394,21 @@ def send_enrollment_failure_message(order, obj, details):
         details=details,
     )
     send_support_email(ENROLL_ERROR_EMAIL_SUBJECT, message)
+
+
+def send_external_data_sync_email(stats, vendor_name):
+    recipients = settings.EXTERNAL_DATA_SYNC_RECIPIENTS
+    if not recipients:
+        log.warning("No recipients configured for external data sync email.")
+        return
+
+    try:
+        api.send_messages(
+            api.build_messages(
+                EMAIL_EXTERNAL_DATA_SYNC,
+                recipients,
+                extra_context={"stats": stats, "vendor_name": vendor_name},
+            )
+        )
+    except Exception as exp:
+        log.exception("Error sending external data sync email: %s", exp)  # noqa: TRY401

--- a/mail/constants.py
+++ b/mail/constants.py
@@ -8,6 +8,7 @@ EMAIL_B2B_RECEIPT = "b2b_receipt"
 EMAIL_PRODUCT_ORDER_RECEIPT = "product_order_receipt"
 EMAIL_CHANGE_EMAIL = "change_email"
 EMAIL_WELCOME_COURSE_RUN_ENROLLMENT = "welcome_course_run_enrollment"
+EMAIL_EXTERNAL_DATA_SYNC = "external_data_sync"
 
 EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_VERIFICATION: "Verify Email",
@@ -16,6 +17,7 @@ EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_B2B_RECEIPT: "Enrollment Code Purchase Receipt",
     EMAIL_CHANGE_EMAIL: "Change Email",
     EMAIL_WELCOME_COURSE_RUN_ENROLLMENT: "Welcome Course Run Enrollment",
+    EMAIL_EXTERNAL_DATA_SYNC: "External Data Sync",
 }
 
 MAILGUN_API_DOMAIN = "api.mailgun.net"

--- a/mail/templates/external_data_sync/body.html
+++ b/mail/templates/external_data_sync/body.html
@@ -1,0 +1,239 @@
+{% extends "email_base.html" %}
+
+{% block content %}
+<tr>
+  <td style="background-color: #ffffff">
+    <table
+      role="presentation"
+      cellspacing="0"
+      cellpadding="0"
+      border="0"
+      width="100%"
+    >
+      <tr>
+        <td
+          style="
+            padding: 20px;
+            font-family: sans-serif;
+            font-size: 15px;
+            line-height: 20px;
+            color: #555555;
+          "
+        >
+          <p style="margin: 0 0 10px">Dear Team,</p>
+          <p style="margin: 0 0 10px">
+            The latest course synchronization process for
+            {{ vendor_name }}
+            has completed. Below are the generated statistics:
+          </p>
+
+          <p style="margin: 0 0 10px"><strong>Courses:</strong></p>
+          <ul style="margin: 0 0 10px; padding-left: 20px">
+            <li>
+              <span style="color: #008000">Courses Created:</span>
+              {% if stats.courses_created %}
+              <ul>
+                {% for course in stats.courses_created %}
+                <li>
+                  {{ course.0 }}
+                  ({{ course.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No courses created during this sync.{% endif %}
+            </li>
+            <li>
+              <span style="color: #008000">Existing Courses:</span>
+              {% if stats.existing_courses %}
+              <ul>
+                {% for course in stats.existing_courses %}
+                <li>
+                  {{ course.0 }}
+                  ({{ course.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No existing courses found.{% endif %}
+            </li>
+          </ul>
+
+          <p style="margin: 0 0 10px"><strong>Course Runs:</strong></p>
+          <ul style="margin: 0 0 10px; padding-left: 20px">
+            <li>
+              <span style="color: #008000">Course Runs Created:</span>
+              {% if stats.course_runs_created %}
+              <ul>
+                {% for run in stats.course_runs_created %}
+                <li>
+                  {{ run.0 }}
+                  ({{ run.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course runs created during this sync.{% endif %}
+            </li>
+            <li>
+              <span style="color: #008000">Course Runs Updated:</span>
+              {% if stats.course_runs_updated %}
+              <ul>
+                {% for run in stats.course_runs_updated %}
+                <li>
+                  {{ run.0 }}
+                  ({{ run.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course runs updated during this sync.{% endif %}
+            </li>
+            <li>
+              <span style="color: #ff0000">Course Runs Without Prices:</span>
+              {% if stats.course_runs_without_prices %}
+              <ul>
+                {% for run in stats.course_runs_without_prices %}
+                <li>
+                  {{ run.0 }}
+                  ({{ run.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course runs without prices.{% endif %}
+            </li>
+            <li>
+              <span style="color: #ff0000"
+                >Course Runs Skipped (Bad Data):</span
+              >
+              {% if stats.course_runs_skipped %}
+              <ul>
+                {% for run in stats.course_runs_skipped %}
+                <li>
+                  {{ run.0 }}
+                  ({{ run.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course runs skipped.{% endif %}
+            </li>
+            <li>
+              <span style="color: #ff0000">Course Runs Expired:</span>
+              {% if stats.course_runs_expired %}
+              <ul>
+                {% for run in stats.course_runs_expired %}
+                <li>
+                  {{ run.0 }}
+                  ({{ run.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course runs expired.{% endif %}
+            </li>
+            <li>
+              <span style="color: #ff0000">Course Runs Deactivated:</span>
+              {% if stats.course_runs_deactivated %}
+              <ul>
+                {% for run in stats.course_runs_deactivated %}
+                <li>
+                  {{ run.0 }}
+                  ({{ run.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course runs deactivated.{% endif %}
+            </li>
+          </ul>
+
+          <p style="margin: 0 0 10px"><strong>Course Pages:</strong></p>
+          <ul style="margin: 0 0 10px; padding-left: 20px">
+            <li>
+              <span style="color: #008000">Course Pages Created:</span>
+              {% if stats.course_pages_created %}
+              <ul>
+                {% for page in stats.course_pages_created %}
+                <li>
+                  {{ page.0 }}
+                  ({{ page.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course pages created during this sync.{% endif %}
+            </li>
+            <li>
+              <span style="color: #008000">Course Pages Updated:</span>
+              {% if stats.course_pages_updated %}
+              <ul>
+                {% for page in stats.course_pages_updated %}
+                <li>
+                  {{ page.0 }}
+                  ({{ page.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No course pages updated during this sync.{% endif %}
+            </li>
+          </ul>
+
+          <p style="margin: 0 0 10px"><strong>Products:</strong></p>
+          <ul style="margin: 0 0 10px; padding-left: 20px">
+            <li>
+              <span style="color: #008000">Products Created:</span>
+              {% if stats.products_created %}
+              <ul>
+                {% for product in stats.products_created %}
+                <li>
+                  {{ product.0 }}
+                  ({{ product.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No products created during this sync.{% endif %}
+            </li>
+            <li>
+              <span style="color: #008000">Products Versions Created:</span>
+              {% if stats.products_versions_created %}
+              <ul>
+                {% for product in stats.products_versions_created %}
+                <li>
+                  {{ product.0 }}
+                  ({{ product.1 }})
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No products versions created during this sync.{% endif %}
+            </li>
+          </ul>
+
+          <p style="margin: 0 0 10px"><strong>Certificate Pages:</strong></p>
+          <ul style="margin: 0 0 10px; padding-left: 20px">
+            <li>
+              <span style="color: #008000">Certificates Pages Created:</span>
+              {% if stats.certificates_created %}
+              <ul>
+                {% for cert in stats.certificates_created %}
+                <li>{{ cert.0 }}</li>
+                {% endfor %}
+              </ul>
+              {% else %}No certificates pages created during this sync.{% endif %}
+            </li>
+            <li>
+              <span style="color: #008000">Certificates Pages Updated:</span>
+              {% if stats.certificates_updated %}
+              <ul>
+                {% for cert in stats.certificates_updated %}
+                <li>{{ cert.0 }}</li>
+                {% endfor %}
+              </ul>
+              {% else %}No certificates pages updated during this sync.{% endif %}
+            </li>
+          </ul>
+
+          <p style="margin: 0 0 10px">
+            Please review the details and reach out if any discrepancies are
+            found.
+          </p>
+          <p style="margin: 0 0 10px">Best regards,</p>
+          <p style="margin: 0 0 10px">MIT xPRO Team</p>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}

--- a/mail/templates/external_data_sync/body.html
+++ b/mail/templates/external_data_sync/body.html
@@ -107,7 +107,8 @@
                 {% for run in stats.course_runs_skipped %}
                 <li>
                   {{ run.0 }}
-                  ({{ run.1 }})
+                  ({{ run.1 }}) -
+                  {{ run.2 }}
                 </li>
                 {% endfor %}
               </ul>

--- a/mail/templates/external_data_sync/subject.txt
+++ b/mail/templates/external_data_sync/subject.txt
@@ -1,0 +1,1 @@
+MIT xPRO {{ vendor_name }} Course Sync Report – Latest Statistics

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1560,3 +1560,9 @@ ECOMMERCE_FORCE_PROFILE_COUNTRY = get_bool(
     default=False,
     description="Force the country determination to be done with the user profile only",
 )
+
+EXTERNAL_DATA_SYNC_RECIPIENTS = get_delimited_list(
+    name="EXTERNAL_DATA_SYNC_RECIPIENTS",
+    default=[],
+    description="Comma-separated list of email addresses to receive notifications about external data syncs",
+)


### PR DESCRIPTION
### What are the relevant tickets?
[#6769](https://github.com/mitodl/hq/issues/6769)

### Description (What does it do?)
This PR extends the codebase to send emails containing external API sync stats.
- The email is sent upon completion of daily sync external course run celery task and upon running sync_external_course_runs management command 
- The recipients are configurable via .env
- Email contains all the stats that were previously being shown in logs. A draft of Emeritus course sync can be seen here [Arbisoft Mail - MIT xPRO Emeritus Course Sync Report – Latest Statistics.pdf](https://github.com/user-attachments/files/19051594/Arbisoft.Mail.-.MIT.xPRO.Emeritus.Course.Sync.Report.Latest.Statistics.pdf)

### How can this be tested?

1. Checkout this branch
2. In your .env configure the emails recipients as comma seprated values with `EXTERNAL_DATA_SYNC_RECIPIENTS=johndoe@gmail.com,janedoe@gmail.com`
3. Restart xPRO container so the new env values are registered
4. Make sure you have `Emeritus` or `Global Alumni` configured as platfroms in xPRO admin
5. Try to start an external course sync by running the following management command
`docker-compose exec web ./manage.py sync_external_course_runs --vendor-name (Emeritus or Global Alumni)`
6. Upon successful course sync each recipient should receive an email with course sync stats
 - Verify the content of the email with welcome letter provided in the the ticket
     - Make sure you see both course code and course title for each course (except for certificate which only show course's readable_id)
     - Make sure reasons are attached for each course skipped
