### PR TITLE
fix: non-live courses shouldn't sync

### DIFF
--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -107,6 +107,7 @@ def sync_courseruns_data():
         CourseRun.objects.live().filter(
             Q(expiration_date__isnull=True) | Q(expiration_date__gt=now),
             course__is_external=False,
+            course__live=True,
         )
     )
 

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -17,7 +17,10 @@ def test_sync_courseruns_data(mocker):
     """Test sync_courseruns_data calls the right api functionality from courses"""
     sync_course_runs = mocker.patch("courses.tasks.sync_course_runs")
 
-    course_runs = CourseRunFactory.create_batch(size=3)
+    course_runs_with_live_courses = CourseRunFactory.create_batch(
+        size=3, course__live=True
+    )
+    CourseRunFactory.create_batch(size=3, course__live=False)
     CourseRunFactory.create_batch(size=3, course__is_external=True)
 
     sync_courseruns_data.delay()
@@ -25,7 +28,7 @@ def test_sync_courseruns_data(mocker):
 
     called_args, _ = sync_course_runs.call_args
     actual_course_runs = called_args[0]
-    assert Counter(actual_course_runs) == Counter(course_runs)
+    assert Counter(actual_course_runs) == Counter(course_runs_with_live_courses)
 
 
 def test_task_sync_external_course_runs(mocker, settings):


### PR DESCRIPTION
### What are the relevant tickets?
[#6813](https://github.com/mitodl/hq/issues/6813)

### Description (What does it do?)
This PR enhances filtering on which course runs are to be synced sync_courseruns_data celery task. Any course run whose corresponding course isn't live shouldn't sync.

### How can this be tested?
1. Checkout this branch
2. In your edX studio, make sure you have a course that can be synced
3. Create a corresponding course in xPRO
    - Set `live=False` for this course
    - Ensure at least one **course run** under this course is active (`live=True`)
5. Run the celery task to sync courses:  
    ```python
    docker-compose exec celery ./manage.py shell
    from courses.tasks import sync_courseruns_data
    sync_courseruns_data.delay()
    ```
7. Verify the course did not sync because the parent course in xPRO is inactive (is_live=False).