### PR TITLE
fix: check for non-external courses before generating edx certificates

### DIFF
--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -37,7 +37,8 @@ def generate_course_certificates():
         CourseRun.objects.live()
         .filter(
             end_date__lt=now
-            - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS)
+            - timedelta(hours=settings.CERTIFICATE_CREATION_DELAY_IN_HOURS),
+            course__is_external=False,
         )
         .exclude(
             id__in=CourseRunCertificate.objects.values_list("course_run__id", flat=True)

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -1,14 +1,21 @@
 """Tests for Course related tasks"""
 
 from collections import Counter
+from datetime import timedelta
 
 import pytest
+from django.utils.timezone import now
 
+from users.factories import UserFactory
 from courses.factories import CourseRunFactory, PlatformFactory
 from courses.sync_external_courses.external_course_sync_api import (
     EMERITUS_PLATFORM_NAME,
 )
-from courses.tasks import sync_courseruns_data, task_sync_external_course_runs
+from courses.tasks import (
+    sync_courseruns_data,
+    task_sync_external_course_runs,
+    generate_course_certificates,
+)
 
 pytestmark = [pytest.mark.django_db]
 
@@ -51,3 +58,49 @@ def test_task_sync_external_course_runs(mocker, settings):
         "The platform '%s' does not have a sync API configured. Please disable the 'enable_sync' setting for this platform.",
         "UnknownPlatform",
     )
+
+
+def test_task_generate_course_certificates(mocker):
+    """Test generate_course_certificates calls the right API functionality making sure external courses are filtered out."""
+
+    class MockEdxGrade:
+        def __init__(self):
+            self.percent = 0.85
+            self.passed = True
+            self.letter_grade = "B"
+
+    user1 = UserFactory()
+    user2 = UserFactory()
+
+    mock_grades = [(MockEdxGrade(), user1), (MockEdxGrade(), user2)]
+
+    get_edx_grades_mock = mocker.patch(
+        "courses.tasks.get_edx_grades_with_users", return_value=mock_grades
+    )
+
+    mock_course_run_grade = mocker.Mock(name="course_run_grade")
+    ensure_grades_mock = mocker.patch(
+        "courses.tasks.ensure_course_run_grade",
+        return_value=(mock_course_run_grade, True, False),
+    )
+    process_grades_mock = mocker.patch(
+        "courses.tasks.process_course_run_grade_certificate",
+        return_value=(mocker.Mock(), True, False),
+    )
+    mocker.patch("courses.tasks.exception_logging_generator", side_effect=lambda x: x)
+    course_runs = CourseRunFactory.create_batch(
+        size=3, end_date=now() - timedelta(days=2)
+    )
+    CourseRunFactory.create_batch(
+        size=3, course__is_external=True, end_date=now() - timedelta(days=2)
+    )
+
+    generate_course_certificates.delay()
+
+    get_edx_grades_mock.assert_called()
+    ensure_grades_mock.assert_called()
+    process_grades_mock.assert_called()
+
+    called_args, _ = get_edx_grades_mock.call_args
+    actual_course_run = called_args[0]
+    assert actual_course_run in course_runs

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -74,19 +74,19 @@ def test_task_generate_course_certificates(mocker):
 
     mock_grades = [(MockEdxGrade(), user1), (MockEdxGrade(), user2)]
 
-    get_edx_grades_mock = mocker.patch(
+    mock_get_edx_grades = mocker.patch(
         "courses.tasks.get_edx_grades_with_users", return_value=mock_grades
     )
-
     mock_course_run_grade = mocker.Mock(name="course_run_grade")
-    ensure_grades_mock = mocker.patch(
+    mock_ensure_grades = mocker.patch(
         "courses.tasks.ensure_course_run_grade",
         return_value=(mock_course_run_grade, True, False),
     )
-    process_grades_mock = mocker.patch(
+    mock_process_grades = mocker.patch(
         "courses.tasks.process_course_run_grade_certificate",
         return_value=(mocker.Mock(), True, False),
     )
+
     mocker.patch("courses.tasks.exception_logging_generator", side_effect=lambda x: x)
     course_runs = CourseRunFactory.create_batch(
         size=3, end_date=now() - timedelta(days=2)
@@ -97,10 +97,10 @@ def test_task_generate_course_certificates(mocker):
 
     generate_course_certificates.delay()
 
-    get_edx_grades_mock.assert_called()
-    ensure_grades_mock.assert_called()
-    process_grades_mock.assert_called()
+    mock_get_edx_grades.assert_called()
+    mock_ensure_grades.assert_called()
+    mock_process_grades.assert_called()
 
-    called_args, _ = get_edx_grades_mock.call_args
+    called_args, _ = mock_get_edx_grades.call_args
     actual_course_run = called_args[0]
     assert actual_course_run in course_runs

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -101,6 +101,6 @@ def test_task_generate_course_certificates(mocker):
     mock_ensure_grades.assert_called()
     mock_process_grades.assert_called()
 
-    called_args, _ = mock_get_edx_grades.call_args
-    actual_course_run = called_args[0]
-    assert actual_course_run in course_runs
+    assert mock_get_edx_grades.call_count == len(course_runs)
+    for run in course_runs:
+        mock_get_edx_grades.assert_any_call(run)


### PR DESCRIPTION
### What are the relevant tickets?
[#6813](https://github.com/mitodl/hq/issues/6813)

### Description (What does it do?)
This PR enhances filtering on which course runs are to be used when we run generate_course_certificates celery task. Course runs for external courses don't need to get grades from edx to generate certificates.

### How can this be tested?
1. Checkout this branch
2. Create an external course in xPRO with any platform of your choice
    - Set `external=True` for this course
    - Create at least one corresponding **course run** for this course
3. Run the celery task to sync courses:  
    ```python
    docker-compose exec celery ./manage.py shell
    from courses.tasks import generate_course_certificates
    generate_course_certificates.delay()
    ```
4. Verify the course run did not sync because the parent course in xPRO is external (external=True).