### PR TITLE
feat: check for live courses for failed edx enrollments

### DIFF
--- a/courseware/api.py
+++ b/courseware/api.py
@@ -704,6 +704,7 @@ def retry_failed_edx_enrollments():
         user__is_active=True,
         edx_enrolled=False,
         created_on__lt=now - timedelta(minutes=COURSEWARE_REPAIR_GRACE_PERIOD_MINS),
+        run__live=True,
     )
     succeeded = []
     for enrollment in failed_run_enrollments:

--- a/courseware/api_test.py
+++ b/courseware/api_test.py
@@ -620,9 +620,14 @@ def test_retry_failed_edx_enrollments_exists(
     is_valid_mode = mode in [EDX_ENROLLMENT_PRO_MODE, EDX_ENROLLMENT_AUDIT_MODE]
     with freeze_time(now_in_utc() - timedelta(days=1)):
         failed_enrollment = CourseRunEnrollmentFactory.create(
-            edx_enrolled=False, user__is_active=True
+            edx_enrolled=False, user__is_active=True, run__live=True
         )
-        CourseRunEnrollmentFactory.create(edx_enrolled=False, user__is_active=False)
+        CourseRunEnrollmentFactory.create(
+            edx_enrolled=False, user__is_active=False, run__live=True
+        )
+        CourseRunEnrollmentFactory.create(
+            edx_enrolled=False, user__is_active=True, run__live=False
+        )
     patched_enroll_in_edx = mocker.patch(
         "courseware.api.enroll_in_edx_course_runs",
         side_effect=EdxApiEnrollErrorException(


### PR DESCRIPTION
### What are the relevant tickets?
[#6813](https://github.com/mitodl/hq/issues/6813)

### Description (What does it do?)
This PR enhances filtering on which course runs are to be used when we run retry_failed_edx_enrollments celery task. Enrollments based on inactive course runs should not be retried.

### How can this be tested?
1. Checkout this branch
2. In your edX studio, make sure you have a course that can be synced
3. Create a corresponding course run in xPRO with `live=True`
4. Enroll a user in this course run (should be successfully enrolled)
5. In xPRO admin, set `edx_enrolled` for this enrollment to False
6. Set `live=False` on the course run created above
7. Run the celery task to sync courses:  
    ```python
    docker-compose exec celery ./manage.py shell
    from courseware.tasks import retry_failed_edx_enrollments
    retry_failed_edx_enrollments.delay()
    ```
8. Verify this particular enrollment was not retried because the course-run is no longer active in xPRO.