### PR TITLE
fix: spreadsheet matching

### DIFF
--- a/sheets/management/utils.py
+++ b/sheets/management/utils.py
@@ -22,9 +22,10 @@ def get_assignment_spreadsheet_by_title(pygsheets_client, title):
             base_query=CouponAssignmentHandler.ASSIGNMENT_SHEETS_QUERY, title=title
         )
     )
-    if len(matching_spreadsheets) != 1:
+    exact_match_sheets = [sheet for sheet in matching_spreadsheets if sheet.title == title]
+    if len(exact_match_sheets) != 1:
         raise CouponAssignmentError(
             f"There should be 1 coupon assignment sheet that matches the given title ('{title}'). "  # noqa: EM102
             f"{len(matching_spreadsheets)} were found."
         )
-    return matching_spreadsheets[0]
+    return exact_match_sheets[0]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6582

### Description (What does it do?)
This PR ensures that we match Google Sheets by exact title when assigning coupons via the CouponAssignmentHandler. Previously, we were using the `name contains` query in the Drive API, which could lead to partial matches.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Same as https://github.com/mitodl/mitxpro/pull/3406. Make sure the code doesn't select a sheet based on partial titles

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
