### PR TITLE
Areeb/6813 sync courseruns date validation

### DIFF
--- a/courses/exceptions.py
+++ b/courses/exceptions.py
@@ -1,0 +1,9 @@
+"""
+Exceptions for courses
+"""
+
+from django.core.exceptions import ValidationError
+
+
+class CourseRunDateValidationError(ValidationError):
+    """ValidationError for when course run dates don't meet validation requirements."""

--- a/courses/models.py
+++ b/courses/models.py
@@ -22,6 +22,7 @@ from courses.constants import (
     ENROLL_CHANGE_STATUS_CHOICES,
     ENROLLABLE_ITEM_ID_SEPARATOR,
 )
+from courses.exceptions import CourseRunDateValidationError
 from courseware.utils import edx_redirect_url
 from ecommerce.models import Product
 from mitxpro.models import AuditableModel, AuditModel, TimestampedModel
@@ -793,7 +794,7 @@ class CourseRun(TimestampedModel, ValidateOnSaveMixin):
             self.expiration_date,
         )
         if not is_valid:
-            raise ValidationError(error_msg)  # noqa: EM101
+            raise CourseRunDateValidationError(error_msg)
 
     def save(
         self,

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -20,6 +20,7 @@ from courses.models import (
     ProgramEnrollment,
     CourseLanguage,
 )
+from courses.exceptions import CourseRunDateValidationError
 from courseware.api import get_edx_api_course_detail_client
 from mitxpro.utils import has_equal_properties, now_in_utc
 
@@ -302,9 +303,12 @@ def sync_course_runs(runs):
                 run.save()
                 success_count += 1
                 log.info("Updated course run: %s", run.courseware_id)
+            except CourseRunDateValidationError as e:
+                log.warning("Skipping update for %s: %s", str(e), run.courseware_id)
+                failure_count += 1
             except Exception as e:  # noqa: BLE001
-                # Report any validation or otherwise model errors
-                log.error("%s: %s", str(e), run.courseware_id)  # noqa: TRY400
+                # Report any other model errors as errors
+                log.error("%s: %s", str(e), run.courseware_id)
                 failure_count += 1
 
     return success_count, failure_count

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -180,7 +180,7 @@ def send_course_run_enrollment_welcome_email(enrollment):
     Args:
         enrollment (CourseRunEnrollment): the enrollment for which to send the welcome email
     """
-    if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=False):
+    if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=True):
         log.info("Feature `enrollment_welcome_email` is disabled.")
         return
     run_start_date, run_start_time = format_run_date(enrollment.run.start_date)

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -185,7 +185,7 @@ def send_course_run_enrollment_welcome_email(enrollment):
         return
     run_start_date, _ = format_run_date(enrollment.run.start_date)
     run_end_date, _ = format_run_date(enrollment.run.end_date)
-    run_duration = enrollment.run.course.coursepage.duration
+    run_duration = enrollment.run.course.coursepage.max_weeks
     try:
         user = enrollment.user
         api.send_message(

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -183,11 +183,9 @@ def send_course_run_enrollment_welcome_email(enrollment):
     if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=False):
         log.info("Feature `enrollment_welcome_email` is disabled.")
         return
-    run_start_date, run_start_time = format_run_date(enrollment.run.start_date)
+    run_start_date, _ = format_run_date(enrollment.run.start_date)
     run_end_date, _ = format_run_date(enrollment.run.end_date)
-    run_duration = (
-        f"{run_start_date} - {run_end_date}" if run_start_date and run_end_date else ""
-    )
+    run_duration = enrollment.run.course.coursepage.duration
     try:
         user = enrollment.user
         api.send_message(
@@ -198,8 +196,8 @@ def send_course_run_enrollment_welcome_email(enrollment):
                     extra_context={
                         "enrollment": enrollment,
                         "run_start_date": run_start_date,
-                        "run_start_time": run_start_time,
-                        "run_date_range": run_duration,
+                        "run_end_date": run_end_date,
+                        "run_duration": run_duration,
                         "support_email": settings.EMAIL_SUPPORT,
                     },
                 ),

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -180,7 +180,7 @@ def send_course_run_enrollment_welcome_email(enrollment):
     Args:
         enrollment (CourseRunEnrollment): the enrollment for which to send the welcome email
     """
-    if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=True):
+    if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=False):
         log.info("Feature `enrollment_welcome_email` is disabled.")
         return
     run_start_date, run_start_time = format_run_date(enrollment.run.start_date)

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -183,8 +183,8 @@ def send_course_run_enrollment_welcome_email(enrollment):
     if not is_enabled(features.ENROLLMENT_WELCOME_EMAIL, default=False):
         log.info("Feature `enrollment_welcome_email` is disabled.")
         return
-    run_start_date, _ = format_run_date(enrollment.run.start_date)
-    run_end_date, _ = format_run_date(enrollment.run.end_date)
+    run_start_date, run_start_time = format_run_date(enrollment.run.start_date)
+    run_end_date, run_end_time = format_run_date(enrollment.run.end_date)
     run_duration = enrollment.run.course.coursepage.max_weeks
     try:
         user = enrollment.user
@@ -196,7 +196,9 @@ def send_course_run_enrollment_welcome_email(enrollment):
                     extra_context={
                         "enrollment": enrollment,
                         "run_start_date": run_start_date,
+                        "run_start_time": run_start_time,
                         "run_end_date": run_end_date,
+                        "run_end_time": run_end_time,
                         "run_duration": run_duration,
                         "support_email": settings.EMAIL_SUPPORT,
                     },

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -27,7 +27,6 @@ from ecommerce.factories import (
 )
 from ecommerce.mail_api import (
     EMAIL_DATE_FORMAT,
-    EMAIL_TIME_FORMAT,
     ENROLL_ERROR_EMAIL_SUBJECT,
     send_b2b_receipt_email,
     send_bulk_enroll_emails,
@@ -121,13 +120,8 @@ def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
     enrollment = CourseRunEnrollmentFactory.create()
 
     run_start_date = enrollment.run.start_date
-    run_start_time = run_start_date.astimezone(datetime.UTC).strftime(EMAIL_TIME_FORMAT)
     run_end_date = enrollment.run.end_date
-    date_range = (
-        f"{run_start_date.strftime(EMAIL_DATE_FORMAT)} - "
-        f"{run_end_date.strftime(EMAIL_DATE_FORMAT)}"
-    )
-
+    run_duration = enrollment.run.course.coursepage.duration
     send_course_run_enrollment_welcome_email(enrollment)
 
     if not enabled:
@@ -140,8 +134,8 @@ def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
             extra_context={
                 "enrollment": enrollment,
                 "run_start_date": run_start_date.strftime(EMAIL_DATE_FORMAT),
-                "run_start_time": run_start_time,
-                "run_date_range": date_range,
+                "run_end_date": run_end_date.strftime(EMAIL_DATE_FORMAT),
+                "run_duration": run_duration,
                 "support_email": settings.EMAIL_SUPPORT,
             },
         )

--- a/ecommerce/mail_api_test.py
+++ b/ecommerce/mail_api_test.py
@@ -27,6 +27,7 @@ from ecommerce.factories import (
 )
 from ecommerce.mail_api import (
     EMAIL_DATE_FORMAT,
+    EMAIL_TIME_FORMAT,
     ENROLL_ERROR_EMAIL_SUBJECT,
     send_b2b_receipt_email,
     send_bulk_enroll_emails,
@@ -120,7 +121,9 @@ def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
     enrollment = CourseRunEnrollmentFactory.create()
 
     run_start_date = enrollment.run.start_date
+    run_start_time = run_start_date.astimezone(datetime.UTC).strftime(EMAIL_TIME_FORMAT)
     run_end_date = enrollment.run.end_date
+    run_end_time = run_end_date.astimezone(datetime.UTC).strftime(EMAIL_TIME_FORMAT)
     run_duration = enrollment.run.course.coursepage.duration
     send_course_run_enrollment_welcome_email(enrollment)
 
@@ -134,7 +137,9 @@ def test_send_course_run_enrollment_welcome_email(settings, mocker, enabled):
             extra_context={
                 "enrollment": enrollment,
                 "run_start_date": run_start_date.strftime(EMAIL_DATE_FORMAT),
+                "run_start_time": run_start_time,
                 "run_end_date": run_end_date.strftime(EMAIL_DATE_FORMAT),
+                "run_end_time": run_end_time,
                 "run_duration": run_duration,
                 "support_email": settings.EMAIL_SUPPORT,
             },

--- a/mail/templates/welcome_course_run_enrollment/body.html
+++ b/mail/templates/welcome_course_run_enrollment/body.html
@@ -23,7 +23,7 @@
         >
           <p style="margin: 0 0 10px">
             Dear
-            {{ user.name }},
+            {{ user.legal_address.first_name }},
           </p>
           <p style="margin: 0 0 10px">Welcome to MIT xPRO!</p>
           <p style="margin: 0 0 10px">

--- a/mail/templates/welcome_course_run_enrollment/body.html
+++ b/mail/templates/welcome_course_run_enrollment/body.html
@@ -25,105 +25,149 @@
             Dear
             {{ user.name }},
           </p>
-          <p style="margin: 0 0 10px 50px">Welcome to MIT xPRO!</p>
+          <p style="margin: 0 0 10px">Welcome to MIT xPRO!</p>
           <p style="margin: 0 0 10px">
-            We're thrilled to have you on board for our upcoming course,
-            <strong>{{ enrollment.run }}</strong>. This is a significant step
-            toward advancing your expertise.
+            You are now enrolled in <strong>{{ enrollment.run.title }}</strong>.
+            We're thrilled to have you in the upcoming course session. This is a
+            significant step toward advancing your expertise!
           </p>
           <p style="margin: 0 0 10px">
-            <strong>Here are some vital details about your course:</strong>
+            <strong
+              >Here is some important information about your course:</strong
+            >
           </p>
           <ul style="margin: 0 0 10px; padding-left: 20px">
             <li>
-              Course Name: <strong>{{ enrollment.run }}</strong>
+              Course Name: <strong>{{ enrollment.run.title }}</strong>
             </li>
             {% if run_start_date %}
             <li>
               Start Date: <strong>{{ run_start_date }}</strong>
             </li>
             {% endif %}
-            {% if run_date_range %}
+            {% if run_end_date %}
             <li>
-              Duration: <strong>{{ run_date_range }}</strong>
+              End Date: <strong>{{ run_end_date }}</strong>
             </li>
             {% endif %}
-            {% if run_start_time %}
+            {% if run_duration %}
             <li>
-              Start Time: <strong>{{ run_start_time }}</strong>
+              Duration: <strong>{{ run_duration }}</strong>
             </li>
             {% endif %}
           </ul>
           <p style="margin: 0 0 10px">
-            <strong><u>Course Format:</u></strong
-            ><br />
+            <strong><u>Course Format, Schedule, and Deadlines:</u></strong>
+            <br />
             All MIT xPRO courses are delivered online for maximum flexibility.
-            The course content, including pre-recorded video lectures, is
-            accessible at your convenience, with no specific log-on times.
+            Once course content is released, it will be accessible at your
+            convenience. You will not be required to log in at any specific time
+            to view it.
+            <a
+              href="https://xpro.zendesk.com/hc/en-us/articles/360056024592-How-are-courses-delivered-Are-lectures-live-at-specific-times-or-pre-recorded"
+            >
+              See this FAQ article for more details
+            </a>
           </p>
           <p style="margin: 0 0 10px">
-            <strong><u>Accessing Your Course:</u></strong
-            ><br />
-            Once you have enrolled in a course or program with MIT xPRO, you can
-            expect to gain access to the course materials and platform on the
-            scheduled start date. You will not be able to access any of the
-            course content before the start date and time. To log in and start
-            your course, visit your
-            <a href="{{ base_url }}{% url 'user-dashboard' %}"
-              >{{ site_name }}
-              account dashboard</a
+            Your course will become accessible only after its start date and
+            time, and course content will start to be released.
+          </p>
+          <p style="margin: 0 0 10px">
+            The course will have a specific schedule set by its instructors,
+            which will determine when Course Content is released (weekly, for
+            most courses). All Coursework will have a specific due date and
+            time, which is strictly enforced. Late submissions will not be
+            accepted for course credit.
+          </p>
+          <p style="margin: 0 0 10px">
+            The course session will conclude on the scheduled End Date, at which
+            point live aspects of the course, such as the discussion forums,
+            will close. Your Courseware will contain more specific details about
+            the course schedule, which you will be expected to read and
+            understand.
+          </p>
+          <p style="margin: 0 0 10px">
+            <strong><u>Accessing Your Course:</u></strong>
+            <br />
+            Once your course session starts, you will be able to open its
+            Courseware and start learning! Access
+            <a href="{{ base_url }}{% url 'user-dashboard' %}">
+              your
+              {{ site_name }}
+              Dashboard </a
+            >, locate your course, and click its name to get started!
+            <a
+              href="https://xpro.zendesk.com/hc/en-us/articles/15757684685467-How-can-I-access-and-view-my-enrolled-courses"
+            >
+              See this MIT xPRO FAQ article for details
+            </a>
+          </p>
+          <p style="margin: 0 0 10px">
+            <strong><u>Certificate of Completion:</u></strong>
+            <br />
+            When you complete the course with a passing score, you will earn a
+            digital Professional Certificate from MIT xPRO, validating your
+            accomplishment and expertise in
+            <strong>{{ enrollment.run.title }}</strong>. Certificates are
+            typically issued about 3-5 business days after the End Date of the
+            course session.
+            <a
+              href="https://xpro.zendesk.com/hc/en-us/articles/35110117468443-What-is-an-xPRO-Certificate"
+            >
+              See this FAQ article for details
+            </a>
+          </p>
+          <p style="margin: 0 0 10px">
+            <strong><u>Where to Seek Support:</u></strong>
+            <br />
+            Once your course session starts, you should familiarize yourself
+            with its Courseware—especially the first module, which typically
+            contains important information introducing you to the course, its
+            structure, schedule, and deadlines, and any special instructions or
+            considerations unique to this course.
+          </p>
+          <p style="margin: 0 0 10px">
+            Additionally, each MIT xPRO course offers in-course discussion
+            forums, hich will allow you to both engage with your fellow learners
+            and seek support from your dedicated Course Assistant (CA) Team. The
+            CA Team actively monitors these forums to offer assistance and
+            guidance to all learners.
+          </p>
+          <p style="margin: 0 0 10px">
+            Any questions you may have about in-course matters, such as course
+            content, coursework, and course logistics, should be posted to the
+            Discussion Forums for the CA Team. They are best able to provide
+            support for these inquiries.
+          </p>
+          <p style="margin: 0 0 10px">
+            Some xPRO courses may also offer other channels to interact with the
+            Course Team. Check within your Courseware for more information, once
+            your session starts.
+          </p>
+          <p style="margin: 0 0 10px">
+            For more general support questions, or questions containing
+            sensitive or personal information, reach out to the MIT xPRO Support
+            Team for assistance!
+            <a href="https://xpro.zendesk.com/hc/en-us/requests/new"
+              >Click here to submit a support ticket</a
+            >
+            and we'll be happy to help! You can also find a lot of useful
+            information in
+            <a href="https://xpro.zendesk.com/hc/en-us">MIT xPRO Help Center</a
             >.
           </p>
           <p style="margin: 0 0 10px">
-            <strong><u>In-Course Support:</u></strong
-            ><br />
-            Each course offers in-course discussion forums, allowing you to
-            engage with fellow learners and receive support. Our dedicated
-            course assistant (CA) team actively monitors these forums to offer
-            assistance and guidance.
-          </p>
-          <p style="margin: 0 0 10px">
-            <strong><u>Course Schedule and Deadlines:</u></strong
-            ><br />
-            Please be aware that each MIT xPRO course has its own schedule, with
-            content becoming available after the course start date. Content
-            releases typically adhere to a schedule determined by the course
-            instructors, often on a weekly basis. Assignment deadlines are
-            strictly enforced, and late submissions are not accepted. The course
-            will conclude on a designated end date, at which point live aspects
-            such as discussion forums will be closed.
-          </p>
-          <p style="margin: 0 0 10px">
-            <strong><u>Certificate of Completion:</u></strong
-            ><br />
-            Upon successfully completing the course, you'll receive a digital
-            Professional Certificate from MIT xPRO, validating your
-            accomplishment and expertise in
-            <strong>{{ enrollment.run }}</strong>.
-          </p>
-          <p style="margin: 0 0 10px">
-            <strong><u>Where to Seek Support:</u></strong
-            ><br />
-            For inquiries related to in-course content, we recommend reaching
-            out directly to the course team. They possess the expertise and have
-            access to the course materials, making them best equipped to provide
-            accurate and detailed responses. You can find the contact
-            information for the course team within the courseware itself,
-            typically in sections such as the Syllabus, Course Guide, or FAQ.
-          </p>
-          <p style="margin: 0 0 10px">
-            For non-sensitive course assignment questions, posting them in the
-            in-course discussion forums is another valuable option. Our course
-            assistants (CAs) actively monitor these forums, and fellow learners
-            often contribute their insights and solutions.
-          </p>
-          <p style="margin: 0 0 10px">
-            For general inquiries not specific to course content, our xPRO
-            Support Team is here to assist you. Feel free to check out the
-            <a href="https://xpro.zendesk.com/hc/en-us">MIT xPRO Help Center</a>
-            or reach out to us at
-            <a href="mailto:{{ support_email }}">{{ support_email }}</a>, and
-            we'll be happy to help.
+            <strong><u>Purchase Receipt:</u></strong>
+            <br />
+            In addition to this Welcome Letter, a payment receipt email was sent
+            to the email address used to complete your purchase. The receipt can
+            also be accessed via your xPRO Dashboard—
+            <a
+              href="https://xpro.zendesk.com/hc/en-us/articles/35109598265243-How-do-I-view-my-receipt"
+            >
+              see this FAQ article for a guide.
+            </a>
           </p>
           <p style="margin: 0 0 10px">
             We look forward to supporting you during your time with MIT xPRO. If
@@ -133,13 +177,8 @@
           <p style="margin: 0 0 10px">
             Get ready to unlock your potential and excel!
           </p>
-          <p style="margin: 0 0 10px">Best of luck with your studies,</p>
+          <p style="margin: 0 0 10px">Best wishes,</p>
           <p style="margin: 0 0 10px">MIT xPRO Team</p>
-          <p style="margin: 0 0 10px">
-            <strong>P.S.</strong> Don't forget to check out the "Getting
-            Started" section in your course dashboard for helpful tips and
-            resources to kick-start your learning experience!
-          </p>
         </td>
       </tr>
     </table>

--- a/mail/templates/welcome_course_run_enrollment/body.html
+++ b/mail/templates/welcome_course_run_enrollment/body.html
@@ -1,4 +1,5 @@
 {% extends "email_base.html" %}
+{% load dateful_url %}
 
 {% block content %}
 <!-- 1 Column Text + Button : BEGIN -->
@@ -38,21 +39,40 @@
           </p>
           <ul style="margin: 0 0 10px; padding-left: 20px">
             <li>
-              Course Name: <strong>{{ enrollment.run.title }}</strong>
+              Course Name:
+              {{ enrollment.run.title }}
             </li>
             {% if run_start_date %}
             <li>
-              Start Date: <strong>{{ run_start_date }}</strong>
+              Start Date:
+              {{ run_start_date }}
+              {% if run_start_time %}
+              at
+              {{ run_start_time }}
+              {% endif %}
+              <a href="{{ enrollment.run.start_date|dateful_url }}">
+                (convert to local time)
+              </a>
             </li>
             {% endif %}
             {% if run_end_date %}
             <li>
-              End Date: <strong>{{ run_end_date }}</strong>
+              End Date:
+              {{ run_end_date }}
+              {% if run_end_time %}
+              at
+              {{ run_end_time }}
+              {% endif %}
+              <a href="{{ enrollment.run.end_date|dateful_url }}">
+                (convert to local time)
+              </a>
             </li>
             {% endif %}
             {% if run_duration %}
             <li>
-              Duration: <strong>{{ run_duration }}</strong>
+              Duration:
+              {{ run_duration }}
+              week(s)
             </li>
             {% endif %}
           </ul>

--- a/mail/templates/welcome_course_run_enrollment/body.html
+++ b/mail/templates/welcome_course_run_enrollment/body.html
@@ -26,6 +26,18 @@
             Dear
             {{ user.legal_address.first_name }},
           </p>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style="
+            padding: 20px;
+            font-family: sans-serif;
+            font-size: 15px;
+            line-height: 20px;
+            color: #555555;
+          "
+        >
           <p style="margin: 0 0 10px">Welcome to MIT xPRO!</p>
           <p style="margin: 0 0 10px">
             You are now enrolled in <strong>{{ enrollment.run.title }}</strong>.
@@ -115,7 +127,7 @@
             <a href="{{ base_url }}{% url 'user-dashboard' %}">
               your
               {{ site_name }}
-              Dashboard </a
+              Dashboard</a
             >, locate your course, and click its name to get started!
             <a
               href="https://xpro.zendesk.com/hc/en-us/articles/15757684685467-How-can-I-access-and-view-my-enrolled-courses"
@@ -142,17 +154,17 @@
             <strong><u>Where to Seek Support:</u></strong>
             <br />
             Once your course session starts, you should familiarize yourself
-            with its Courseware—especially the first module, which typically
-            contains important information introducing you to the course, its
-            structure, schedule, and deadlines, and any special instructions or
-            considerations unique to this course.
+            with its Courseware&mdash;especially the first module, which
+            typically contains important information introducing you to the
+            course, its structure, schedule, and deadlines, and any special
+            instructions or considerations unique to this course.
           </p>
           <p style="margin: 0 0 10px">
             Additionally, each MIT xPRO course offers in-course discussion
-            forums, hich will allow you to both engage with your fellow learners
-            and seek support from your dedicated Course Assistant (CA) Team. The
-            CA Team actively monitors these forums to offer assistance and
-            guidance to all learners.
+            forums, which will allow you to both engage with your fellow
+            learners and seek support from your dedicated Course Assistant (CA)
+            Team. The CA Team actively monitors these forums to offer assistance
+            and guidance to all learners.
           </p>
           <p style="margin: 0 0 10px">
             Any questions you may have about in-course matters, such as course
@@ -174,7 +186,8 @@
             >
             and we'll be happy to help! You can also find a lot of useful
             information in
-            <a href="https://xpro.zendesk.com/hc/en-us">MIT xPRO Help Center</a
+            <a href="https://xpro.zendesk.com/hc/en-us"
+              >the MIT xPRO Help Center</a
             >.
           </p>
           <p style="margin: 0 0 10px">
@@ -182,21 +195,31 @@
             <br />
             In addition to this Welcome Letter, a payment receipt email was sent
             to the email address used to complete your purchase. The receipt can
-            also be accessed via your xPRO Dashboard—
-            <a
+            also be accessed via your xPRO Dashboard&mdash;<a
               href="https://xpro.zendesk.com/hc/en-us/articles/35109598265243-How-do-I-view-my-receipt"
+              >see this FAQ article for a guide.</a
             >
-              see this FAQ article for a guide.
-            </a>
           </p>
           <p style="margin: 0 0 10px">
             We look forward to supporting you during your time with MIT xPRO. If
-            you have any further questions or need assistance, please do not
+            you have any further questions or need assistance, please don't
             hesitate to reach out.
           </p>
           <p style="margin: 0 0 10px">
             Get ready to unlock your potential and excel!
           </p>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style="
+            padding: 20px;
+            font-family: sans-serif;
+            font-size: 15px;
+            line-height: 20px;
+            color: #555555;
+          "
+        >
           <p style="margin: 0 0 10px">Best wishes,</p>
           <p style="margin: 0 0 10px">MIT xPRO Team</p>
         </td>

--- a/mail/templates/welcome_course_run_enrollment/body.html
+++ b/mail/templates/welcome_course_run_enrollment/body.html
@@ -1,5 +1,5 @@
 {% extends "email_base.html" %}
-{% load dateful_url %}
+{% load timezone_converter_url %}
 
 {% block content %}
 <!-- 1 Column Text + Button : BEGIN -->
@@ -50,7 +50,7 @@
               at
               {{ run_start_time }}
               {% endif %}
-              <a href="{{ enrollment.run.start_date|dateful_url }}">
+              <a href="{{ enrollment.run.start_date|timezone_converter_url }}">
                 (convert to local time)
               </a>
             </li>
@@ -63,7 +63,7 @@
               at
               {{ run_end_time }}
               {% endif %}
-              <a href="{{ enrollment.run.end_date|dateful_url }}">
+              <a href="{{ enrollment.run.end_date|timezone_converter_url }}">
                 (convert to local time)
               </a>
             </li>

--- a/mail/templates/welcome_course_run_enrollment/subject.txt
+++ b/mail/templates/welcome_course_run_enrollment/subject.txt
@@ -1,1 +1,1 @@
-Welcome! {{ enrollment.run }} starts on {{ run_start_date }}
+Welcome! {{ enrollment.run.title }} starts on {{ run_start_date }}

--- a/mail/templatetags/dateful_url.py
+++ b/mail/templatetags/dateful_url.py
@@ -1,0 +1,27 @@
+from django import template
+from django.utils import timezone
+
+register = template.Library()
+
+
+@register.filter
+def dateful_url(datetime_obj):
+    """
+    Convert a DateTimeField object to a dateful.com URL for timezone conversion
+
+    Args:
+        datetime_obj (datetime): The DateTimeField object to convert.
+
+    Returns:
+        str: The dateful.com URL for the given datetime object.
+    """
+    if not datetime_obj:
+        return ""
+
+    if timezone.is_naive(datetime_obj):
+        datetime_obj = timezone.make_aware(datetime_obj, timezone.utc)
+
+    time_param = datetime_obj.strftime("%H%M")
+    date_param = datetime_obj.strftime("%Y-%m-%d")
+
+    return f"https://dateful.com/convert/utc?t={time_param}&d={date_param}"

--- a/mail/templatetags/timezone_converter_url.py
+++ b/mail/templatetags/timezone_converter_url.py
@@ -1,3 +1,5 @@
+"""custom template tag to convert a DateTimeField object to a URL for timezone conversion"""
+
 from django import template
 from django.utils import timezone
 

--- a/mail/templatetags/timezone_converter_url.py
+++ b/mail/templatetags/timezone_converter_url.py
@@ -5,15 +5,15 @@ register = template.Library()
 
 
 @register.filter
-def dateful_url(datetime_obj):
+def timezone_converter_url(datetime_obj):
     """
-    Convert a DateTimeField object to a dateful.com URL for timezone conversion
+    Convert a DateTimeField object to a URL for timezone conversion
 
     Args:
         datetime_obj (datetime): The DateTimeField object to convert.
 
     Returns:
-        str: The dateful.com URL for the given datetime object.
+        str: The timezone converter URL for the given datetime object.
     """
     if not datetime_obj:
         return ""


### PR DESCRIPTION
### What are the relevant tickets?
[#6813](https://github.com/mitodl/hq/issues/6813)

### Description (What does it do?)
This PR fixes handling of `courses.tasks.sync_courseruns_data` when edX courses have `start` and `enrollment end` dates set in past. Previously these date validation failures triggered Sentry errors. This PR creates a custom CourseRunDateValidationError exception that's caught separately in the sync process, logs as a warning instead of error, and tracks them - preventing Sentry noise while still maintaining proper validation.

### How can this be tested?
1. Checkout this branch
2. In your edX studio, make sure you have a course that has `start date` and `enrollment end date` set in the past.
3. Create a corresponding course in xPRO
5. Use this management command that uses the same underlying function to sync courses as `courses.tasks.sync_courseruns_data`
    ```python
    docker-compose exec celery ./manage.py shell
    ./manage.py sync_courseruns
    ```
7. Verify the course did not sync because it failed the course date validation and a warning was logged with such a format -  `Skipping update for [start_date or enrollment_end must be in the future]:courseware_id`