### PR TITLE
Areeb/7122 certificate django admin enhancements

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -385,7 +385,7 @@ class CourseRunCertificateAdmin(TimestampedModelAdmin):
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "course_run":
-            kwargs["queryset"] = CourseRun.objects.filter(external_course_run_id="")
+            kwargs["queryset"] = CourseRun.objects.filter(course__is_external=False)
 
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -362,6 +362,7 @@ class CourseRunCertificateAdmin(TimestampedModelAdmin):
         "certificate_page_revision",
     ]
     search_fields = [
+        "uuid",
         "course_run__courseware_id",
         "course_run__title",
         "user__username",

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -383,6 +383,12 @@ class CourseRunCertificateAdmin(TimestampedModelAdmin):
             "user", "course_run"
         )
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "course_run":
+            kwargs["queryset"] = CourseRun.objects.filter(external_course_run_id="")
+
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
 
 @admin.register(ProgramCertificate)
 class ProgramCertificateAdmin(TimestampedModelAdmin):


### PR DESCRIPTION
### What are the relevant tickets?
[#7122](https://github.com/mitodl/hq/issues/7122)

### Description (What does it do?)
This PR enhances functionality on the CourseRunCertificate django admin: 
1. Makes the certificate list searchable by UUID
2. Prevents User from selecting External Course Run when adding a new certificate - as xPRO doesn't support creating certificates for External Courses

Previously, we were allowing selection of External courses which later failed with a generic error message.

### How can this be tested?
1. Checkout this branch
2. Create a bunch of dummy courses/course runs using the management command `seed_data`
3. In the CMS, create a certificate page associated with a few of the dummy course pages
4. In Django admin, create a Course Run Certificate for courses you created the certificate pages for
5. Use the auto generated UUID to search the list of certificates and verify it gets filtered

To test Certificates for External Course Runs: 

6. Use the management command `sync_external_course_runs` to import a bunch of External Courses from either `Emeritus` or `Global Alumni`, this would automatically create corresponding certificate pages in the CMS
7. In Django admin, try to create a new certificate but verify that no External Course shows up in the course run options

