### PR TITLE
fix: check for coursepage before getting max_weeks

### DIFF
--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -185,7 +185,9 @@ def send_course_run_enrollment_welcome_email(enrollment):
         return
     run_start_date, run_start_time = format_run_date(enrollment.run.start_date)
     run_end_date, run_end_time = format_run_date(enrollment.run.end_date)
-    run_duration = enrollment.run.course.coursepage.max_weeks
+    coursepage = getattr(enrollment.run.course, "coursepage", None)
+    run_duration = getattr(coursepage, "max_weeks", None) if coursepage else None
+
     try:
         user = enrollment.user
         api.send_message(

--- a/ecommerce/mail_api.py
+++ b/ecommerce/mail_api.py
@@ -186,7 +186,7 @@ def send_course_run_enrollment_welcome_email(enrollment):
     run_start_date, run_start_time = format_run_date(enrollment.run.start_date)
     run_end_date, run_end_time = format_run_date(enrollment.run.end_date)
     coursepage = getattr(enrollment.run.course, "coursepage", None)
-    run_duration = getattr(coursepage, "max_weeks", None) if coursepage else None
+    run_duration = getattr(coursepage, "max_weeks", None)
 
     try:
         user = enrollment.user


### PR DESCRIPTION
### What are the relevant tickets?
[#6938](https://github.com/mitodl/hq/issues/6938)

### Description (What does it do?)
This PR fixes a bug in `send_course_run_enrollment_welcome_email` where the function would throw a [Course.coursepage.RelatedObjectDoesNotExist](https://mit-office-of-digital-learning.sentry.io/issues/6575858732/?project=1413655&query=coursepage&referrer=issue-stream&sort=freq&stream_index=0) exception when trying to access `max_weeks` for courses that don't have an associated coursepage.

Changes made:

- Replaced the direct attribute access `enrollment.run.course.coursepage.max_weeks` with a safe getattr() chain
- When coursepage doesn't exist or doesn't have `max_weeks`, `run_duration` is now set to None instead of throwing an exception and a welcome email without duration is sent

### How can this be tested?

1. Checkout this branch and make sure you have EdX, xPRO, and PostHog configured correctly
2. Enable the `ENROLLMENT_WELCOME_EMAIL` feature flag in PostHog
3. Select a course you want to enroll in, make sure that the course doesn't have a corresponding coursepage in the CMS.
4. Use the product_id to automatically go to the checkout page - setting it like `http://xpro.odl.local:8053/checkout/?product=<product_id>` and enroll.
5. Verify that:
    - Enrollment is successful and the welcome email is received without any `Duration` mentioned
    - No `Course.coursepage.RelatedObjectDoesNotExist` error is thrown
