### PR TITLE
chore: remove catalog language filter feature flag

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -97,8 +97,6 @@ from courses.models import (
 )
 from courses.utils import get_catalog_languages
 from ecommerce.models import Product
-from mitol.olposthog.features import is_enabled
-from mitxpro.features import CATALOG_LANGUAGE_FILTER
 from mitxpro.utils import now_in_utc
 from mitxpro.views import get_base_context
 from courses.serializers import CourseSerializer, ProgramSerializer
@@ -527,8 +525,6 @@ class CatalogPage(Page):
         topic_filter = request.GET.get("topic", ALL_TOPICS)
         language_filter = request.GET.get("language", ALL_LANGUAGES)
 
-        is_language_filter_enabled = is_enabled(CATALOG_LANGUAGE_FILTER, default=False)
-
         # Best Match is the default sorting.
         sort_by = request.GET.get("sort-by", CatalogSorting.BEST_MATCH.sorting_value)
         try:
@@ -680,11 +676,8 @@ class CatalogPage(Page):
                 }
                 for sorting_option in CatalogSorting
             ],
-            show_language_filter=is_language_filter_enabled,
             selected_language=language_filter,
-            language_options=[ALL_LANGUAGES, *get_catalog_languages()]
-            if is_language_filter_enabled
-            else [],
+            language_options=[ALL_LANGUAGES, *get_catalog_languages()],
         )
 
 

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -266,7 +266,6 @@ def test_catalog_page_language_context(
     """
     Verify the language context is properly passed to the catalog_page.html
     """
-    mocker.patch("cms.models.is_enabled", return_value=True)
     CourseLanguage.objects.all().delete()
     # Verify that all the languages are deleted. This will help us understand and debug the failures in future.
     assert CourseLanguage.objects.all().count() == 0

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -329,45 +329,6 @@ def test_catalog_page_language_context(
         assert context.get("selected_language") == selected_language
 
 
-@pytest.mark.parametrize(
-    "is_enabled",
-    [True, False],
-)
-def test_catalog_page_language_feature_flag(mocker, staff_user, is_enabled):
-    """
-    Verify the language context is properly passed to the catalog_page.html if CATALOG_LANGUAGE_FILTER is enabled
-    """
-    mocker.patch("cms.models.is_enabled", return_value=is_enabled)
-    CourseLanguage.objects.all().delete()
-    # Verify that all the languages are deleted. This will help us understand and debug the failures in future.
-    assert CourseLanguage.objects.all().count() == 0
-
-    catalog_page = CatalogPageFactory.create()
-    # The priority of the languages matters and we want them in order. Here 1 means top priority
-    languages = CourseLanguageFactory.create_batch(2, priority=factory.Iterator([1, 2]))
-    now = now_in_utc()
-    CourseRunFactory.create_batch(
-        2,
-        start_date=now + timedelta(days=1),
-        course__page__language=factory.Iterator(languages),
-        course__program__page__language=factory.Iterator(languages),
-    )
-
-    rf = RequestFactory()
-    request = rf.get("/")
-    request.user = staff_user
-    context = catalog_page.get_context(request=request)
-
-    assert context.get("selected_language") == ALL_LANGUAGES
-    assert context.get("show_language_filter") == is_enabled
-    expected_languages = (
-        [ALL_LANGUAGES] + [language.name for language in languages]
-        if is_enabled
-        else []
-    )
-    assert context.get("language_options") == expected_languages
-
-
 def test_course_page_program_page():
     """
     Verify `program_page` property from the course page returns expected value

--- a/cms/templates/catalog_page.html
+++ b/cms/templates/catalog_page.html
@@ -22,7 +22,6 @@
   <div class="catalog-content">
     <div class="courseware-filter-container">
       <div class="courseware-filters">
-        {% if show_language_filter %}
         <div class="catalog-filter-dropdown dropdown" id="topicSortDropdown">
           <span class="filter-label">Topic</span>
           <div
@@ -102,20 +101,6 @@
               </div>
             </div>
           </div>
-          {% else %}
-          {% for topic in topics %}
-          {% if selected_topic == topic %}
-          <div class="topic selected">
-            {% else %}
-            <div class="topic">
-              {% endif %}
-              <a href="{% pageurl page %}?topic={{ topic | urlencode }}"
-                >{{ topic }}</a
-              >
-            </div>
-            {% endfor %}
-          </div>
-          {% endif %}
         </div>
 
         <div class="courseware">

--- a/cms/views_test.py
+++ b/cms/views_test.py
@@ -467,7 +467,6 @@ def test_catalog_page_languages(  # noqa: PLR0913
     """
     Test that language filters are working fine.
     """
-    mocker.patch("cms.models.is_enabled", return_value=True)
     CourseLanguage.objects.all().delete()
     homepage = wagtail_basics.root
     catalog_page = CatalogPageFactory.create(parent=homepage)

--- a/courses/api.py
+++ b/courses/api.py
@@ -153,8 +153,8 @@ def create_run_enrollments(
             )
         else:
             successful_enrollments.append(enrollment)
-            if enrollment.edx_enrolled:
-                mail_api.send_course_run_enrollment_welcome_email(enrollment)
+            # if enrollment.edx_enrolled:
+            mail_api.send_course_run_enrollment_welcome_email(enrollment)
     return successful_enrollments, edx_request_success
 
 

--- a/courses/api.py
+++ b/courses/api.py
@@ -153,8 +153,8 @@ def create_run_enrollments(
             )
         else:
             successful_enrollments.append(enrollment)
-            # if enrollment.edx_enrolled:
-            mail_api.send_course_run_enrollment_welcome_email(enrollment)
+            if enrollment.edx_enrolled:
+                mail_api.send_course_run_enrollment_welcome_email(enrollment)
     return successful_enrollments, edx_request_success
 
 

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -3,4 +3,3 @@
 DIGITAL_CREDENTIALS = "digital_credentials"
 ENABLE_ENTERPRISE = "enable_enterprise"
 ENROLLMENT_WELCOME_EMAIL = "enrollment_welcome_email"
-CATALOG_LANGUAGE_FILTER = "catalog_language_filter"


### PR DESCRIPTION
### What are the relevant tickets?
[#7122](https://github.com/mitodl/hq/issues/7112)

### Description (What does it do?)
This PR removes the `CATALOG_LANGUAGE_FILTER` feature flag, making the language filter a permanent feature in the catalog. The feature flag was initially added in [#3384](https://github.com/mitodl/mitxpro/pull/3384) when the language filter was first implemented, allowing us to potentially revert to the previous UI if needed. After several months of successful use, we have gained confidence in the language filter functionality and are now removing the conditional behavior.

Changes include:

- Removing the CATALOG_LANGUAGE_FILTER feature flag check from the views and templates
- Updating the corresponding HTML to always show the language filter dropdown
- Updating tests to reflect the permanent language filter feature
- Removing the feature flag from settings files and documentation
### How can this be tested?

This PR would be tested the same way as the [original PR](https://github.com/mitodl/mitxpro/pull/3384) without the need to enable feature flag `CATALOG_LANGUAGE_FILTER`:
- Setup a couple of courses and programs
- Assign these courses and programs pages to different languages that you are going to test these with
- Also make sure to add and associates multiple topics to course pages
- Verify you get both topic and language filter without adding `CATALOG_LANGUAGE_FILTER` flag
- Clicking any topic should filter the course list based on that topic
- Clicking any language in the dropdown should filter the course, program list on the catalog based on that language  
