### PR TITLE
feat: add update promo coupons self service

### DIFF
--- a/ecommerce/permissions.py
+++ b/ecommerce/permissions.py
@@ -41,7 +41,7 @@ class HasCouponPermission(BasePermission):
         if request.method == "POST":
             return request.user.has_perm(COUPON_ADD_PERMISSION)
 
-        if request.method == "PUT":
+        if request.method in ["PUT", "GET"]:
             return request.user.has_perm(COUPON_UPDATE_PERMISSION)
 
         return False

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -993,26 +993,11 @@ class PromoCouponUpdateSerializer(serializers.Serializer):
         expiration_date = self.validated_data["expiration_date"]
         products = self.validated_data["product_ids"]
 
-        previous_data = {
-            field.name: getattr(coupon.payment.latest_version, field.name)
-            for field in models.CouponPaymentVersion._meta.fields
-            if field.name
-            not in (
-                "id",
-                "activation_date",
-                "expiration_date",
-                "created_on",
-                "updated_on",
-            )
-        }
-        previous_data.update(
-            {
-                "activation_date": activation_date,
-                "expiration_date": expiration_date,
-            }
-        )
-
-        models.CouponPaymentVersion.objects.create(**previous_data)
+        coupon_version = coupon.payment.latest_version
+        coupon_version.pk = None
+        coupon_version.activation_date = activation_date
+        coupon_version.expiration_date = expiration_date
+        coupon_version.save()
 
         # Replace eligibilities
         coupon.couponeligibility_set.all().delete()

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -986,6 +986,7 @@ class PromoCouponUpdateSerializer(serializers.Serializer):
 
     @transaction.atomic
     def save(self):
+        """Save the updated promo coupon data."""
         coupon = self.validated_data["promo_coupon"]
         is_global = self.validated_data["is_global"]
         activation_date = self.validated_data["activation_date"]

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -8,6 +8,7 @@ from ecommerce.views import (
     CheckoutView,
     CompanyViewSet,
     CouponListView,
+    PromoCouponView,
     OrderFulfillmentView,
     OrderReceiptView,
     ProductViewSet,
@@ -41,6 +42,7 @@ urlpatterns = [
     ),
     path("api/basket/", BasketView.as_view(), name="basket_api"),
     path("api/coupons/", CouponListView.as_view(), name="coupon_api"),
+    path("api/promo_coupons/", PromoCouponView.as_view(), name="promo_coupons_api"),
     re_path(
         r"^couponcodes/(?P<version_id>[0-9]+)", coupon_code_csv_view, name="coupons_csv"
     ),

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -394,9 +394,12 @@ class PromoCouponView(APIView):
                         )
 
         except Exception as e:
+            log.error(
+                "Failed to update promo coupon: %s", str(e)
+            )
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"error": f"Failed to update promo coupon: {str(e)}"},
+                data={"error": f"Sorry, something went wrong. Failed to update promo coupon"},
             )
 
         return Response(

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1795,7 +1795,7 @@ def test_promocoupon_get_view_returns_only_latest_promo_versions(admin_drf_clien
     "should_raise_exception,expected_status_code,expected_response_part",
     [
         (False, 200, "message"),  # Success case
-        (True, 400, "error"),  # update_coupon raises an error
+        (True, 400, "error"),  # Save raises an error
     ],
 )
 def test_put_calls_update_coupon_and_handles_errors(
@@ -1820,9 +1820,7 @@ def test_put_calls_update_coupon_and_handles_errors(
         "product_ids": [product.id],
     }
 
-    patch_path = (
-        "ecommerce.views.PromoCouponUpdateSerializer.update_coupon"  # Replace correctly
-    )
+    patch_path = "ecommerce.views.PromoCouponUpdateSerializer.save"
     with patch(patch_path) as mocked_update:
         if should_raise_exception:
             mocked_update.side_effect = Exception("Simulated failure")

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -34,7 +34,9 @@ from ecommerce.factories import (
     CouponEligibilityFactory,
     CouponFactory,
     CouponPaymentFactory,
+    CouponPaymentVersionFactory,
     LineFactory,
+    ProductFactory,
     ProductCouponAssignmentFactory,
     ProductVersionFactory,
 )
@@ -1242,16 +1244,17 @@ def test_create_coupon_permission(user_drf_client, promo_coupon_json):
         "expected_coupons_status",
         "expected_deactivate_status",
         "expected_product_assignment_status",
+        "expected_update_promo_status",
     ),
     [
-        (True, False, False, 200, 200, 403, 403),
-        (False, True, False, 200, 403, 200, 403),
-        (False, False, False, 403, 403, 403, 403),
-        (True, True, False, 200, 200, 200, 403),
-        (False, False, True, 200, 403, 403, 200),  # Product assignment only
-        (True, False, True, 200, 200, 403, 200),  # Coupon + Product assignment
-        (False, True, True, 200, 403, 200, 200),  # Change Coupon + Product assignment
-        (True, True, True, 200, 200, 200, 200),  # All permissions
+        (True, False, False, 200, 200, 403, 403, 403),
+        (False, True, False, 200, 403, 200, 403, 200),
+        (False, False, False, 403, 403, 403, 403, 403),
+        (True, True, False, 200, 200, 200, 403, 200),
+        (False, False, True, 200, 403, 403, 200, 403),
+        (True, False, True, 200, 200, 403, 200, 403),
+        (False, True, True, 200, 403, 200, 200, 200),
+        (True, True, True, 200, 200, 200, 200, 200),
     ],
 )
 def test_ecommerce_restricted_view(
@@ -1263,6 +1266,7 @@ def test_ecommerce_restricted_view(
     expected_coupons_status,
     expected_deactivate_status,
     expected_product_assignment_status,
+    expected_update_promo_status,
 ):
     """Test that the ecommerce restricted view is only accessible with the right permissions."""
 
@@ -1286,6 +1290,7 @@ def test_ecommerce_restricted_view(
     add_coupons_url = ecommerce_admin_url + "coupons"
     deactivate_coupons_url = ecommerce_admin_url + "deactivate-coupons"
     product_assignment_url = ecommerce_admin_url + "process-coupon-assignment-sheets"
+    update_promo_url = ecommerce_admin_url + "update-promo-code"
 
     assert client.get(ecommerce_admin_url).status_code == expected_admin_status
     assert client.get(add_coupons_url).status_code == expected_coupons_status
@@ -1294,6 +1299,7 @@ def test_ecommerce_restricted_view(
         client.get(product_assignment_url).status_code
         == expected_product_assignment_status
     )
+    assert client.get(update_promo_url).status_code == expected_update_promo_status
 
 
 def test_deactivate_coupons(mocker, admin_drf_client):
@@ -1756,3 +1762,67 @@ def test_program_runs_api():
     assert sorted(resp.data, key=lambda item: item["id"]) == sorted(
         serialized_data, key=lambda item: item["id"]
     )
+
+
+def test_promocoupon_get_view_returns_only_latest_promo_versions(admin_drf_client):
+    payment = CouponPaymentFactory()
+    CouponPaymentVersionFactory(
+        payment=payment,
+        coupon_type=CouponPaymentVersion.PROMO,
+        activation_date=now_in_utc() - timedelta(days=2),
+    )
+    payment_version = CouponPaymentVersionFactory(
+        payment=payment,
+        coupon_type=CouponPaymentVersion.PROMO,
+        activation_date=now_in_utc() - timedelta(days=5),
+    )
+
+    coupon = CouponFactory(payment=payment)
+    product = ProductFactory()
+    CouponEligibilityFactory(coupon=coupon, product=product)
+
+    response = admin_drf_client.get(reverse("promo_coupons_api"))
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]["coupon_code"] == coupon.coupon_code
+    assert response.data[0]["activation_date"] == payment_version.activation_date
+
+
+@pytest.mark.django_db
+def test_promocoupon_put_view_updates_dates_and_eligibility(admin_drf_client):
+    payment = CouponPaymentFactory()
+    CouponPaymentVersionFactory(payment=payment)  # Old version
+    coupon = CouponFactory(payment=payment)
+    old_product = ProductFactory()
+    CouponEligibilityFactory(coupon=coupon, product=old_product)
+
+    new_product = ProductFactory()
+    new_activation = now_in_utc()
+    new_expiration = now_in_utc() + timedelta(days=10)
+
+    assert coupon.couponeligibility_set.first().product == old_product
+
+    response = admin_drf_client.put(
+        reverse("promo_coupons_api"),
+        data={
+            "promo_coupon": coupon.id,
+            "activation_date": new_activation.isoformat(),
+            "expiration_date": new_expiration.isoformat(),
+            "product_ids": [new_product.id],
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert "updated successfully" in response.data["message"]
+
+    # Check new version was created
+    assert payment.versions.count() == 2
+    latest_version = payment.versions.order_by("-created_on").first()
+    assert latest_version.activation_date == new_activation
+    assert latest_version.expiration_date == new_expiration
+
+    # Check eligibilities were updated
+    assert coupon.couponeligibility_set.count() == 1
+    assert coupon.couponeligibility_set.first().product == new_product

--- a/static/js/components/ConfirmUpdateModal.js
+++ b/static/js/components/ConfirmUpdateModal.js
@@ -1,0 +1,40 @@
+// @flow
+import React from "react";
+import { Modal, ModalHeader, ModalBody } from "reactstrap";
+
+type Props = {|
+  isOpen: boolean,
+  toggle: () => void,
+  onConfirm: () => void,
+  submitting: boolean,
+|};
+
+export default function ConfirmUpdateModal({
+  isOpen,
+  toggle,
+  onConfirm,
+  submitting,
+  headerMessage,
+  bodyText,
+}: Props) {
+  return (
+    <Modal isOpen={isOpen} toggle={toggle}>
+      <ModalHeader toggle={toggle}>{headerMessage}</ModalHeader>
+      <ModalBody>
+        <div>{bodyText}</div>
+        <div className="float-container">
+          <button className="btn btn-gradient-white-to-blue" onClick={toggle}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-gradient-red-to-blue"
+            onClick={onConfirm}
+            disabled={submitting}
+          >
+            Continue
+          </button>
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/static/js/components/ConfirmUpdateModal_test.js
+++ b/static/js/components/ConfirmUpdateModal_test.js
@@ -1,0 +1,177 @@
+// @flow
+import React from "react";
+import sinon from "sinon";
+import { assert } from "chai";
+import { mount } from "enzyme";
+import { Modal, ModalHeader, ModalBody } from "reactstrap";
+
+import ConfirmUpdateModal from "./ConfirmUpdateModal";
+
+describe("ConfirmUpdateModal", () => {
+  let sandbox, onConfirmStub, toggleStub;
+
+  const defaultProps = {
+    isOpen: true,
+    toggle: () => {},
+    onConfirm: () => {},
+    submitting: false,
+    headerMessage: "Confirm Update",
+    bodyText: "Are you sure you want to continue?",
+  };
+
+  const renderModal = (props = {}) =>
+    mount(<ConfirmUpdateModal {...defaultProps} {...props} />);
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    onConfirmStub = sandbox.stub();
+    toggleStub = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("renders the Modal component with correct props", () => {
+    const wrapper = renderModal({
+      isOpen: true,
+      toggle: toggleStub,
+    });
+
+    const modal = wrapper.find(Modal);
+    assert.ok(modal.exists(), "Modal component should be rendered");
+    assert.isTrue(modal.prop("isOpen"), "Modal should be open");
+    assert.equal(
+      modal.prop("toggle"),
+      toggleStub,
+      "Toggle prop should be passed to Modal",
+    );
+  });
+
+  it("renders the header with the provided headerMessage", () => {
+    const headerMessage = "Custom Header Message";
+    const wrapper = renderModal({
+      headerMessage: headerMessage,
+    });
+
+    const modalHeader = wrapper.find(ModalHeader);
+    assert.ok(modalHeader.exists(), "ModalHeader component should be rendered");
+    assert.include(
+      modalHeader.text(),
+      headerMessage,
+      "Header should contain the provided message",
+    );
+    assert.equal(
+      modalHeader.prop("toggle"),
+      defaultProps.toggle,
+      "Toggle prop should be passed to ModalHeader",
+    );
+  });
+
+  it("renders the body with the provided bodyText", () => {
+    const bodyText = "Custom body text for testing";
+    const wrapper = renderModal({
+      bodyText: bodyText,
+    });
+
+    const modalBody = wrapper.find(ModalBody);
+    assert.ok(modalBody.exists(), "ModalBody component should be rendered");
+    assert.include(
+      modalBody.text(),
+      bodyText,
+      "Body should contain the provided text",
+    );
+  });
+
+  it("renders Cancel and Continue buttons", () => {
+    const wrapper = renderModal();
+
+    const buttons = wrapper.find("button");
+    assert.equal(
+      buttons.length,
+      3,
+      "Should render three buttons including the default close button",
+    );
+
+    const cancelButton = buttons.at(1);
+    assert.include(
+      cancelButton.text(),
+      "Cancel",
+      "First button should be Cancel",
+    );
+
+    const continueButton = buttons.at(2);
+    assert.include(
+      continueButton.text(),
+      "Continue",
+      "Second button should be Continue",
+    );
+  });
+
+  it("disables the Continue button when submitting is true", () => {
+    const wrapper = renderModal({
+      submitting: true,
+    });
+
+    const continueButton = wrapper.find("button").at(2);
+    assert.isTrue(
+      continueButton.prop("disabled"),
+      "Continue button should be disabled when submitting",
+    );
+  });
+
+  it("enables the Continue button when submitting is false", () => {
+    const wrapper = renderModal({
+      submitting: false,
+    });
+
+    const continueButton = wrapper.find("button").at(2);
+    assert.isFalse(
+      continueButton.prop("disabled"),
+      "Continue button should be enabled when not submitting",
+    );
+  });
+
+  it("calls toggle when Cancel button is clicked", () => {
+    const wrapper = renderModal({
+      toggle: toggleStub,
+    });
+
+    const cancelButton = wrapper.find("button").at(0);
+    cancelButton.simulate("click");
+
+    assert.isTrue(
+      toggleStub.calledOnce,
+      "Toggle should be called once when Cancel button is clicked",
+    );
+  });
+
+  it("calls onConfirm when Continue button is clicked", () => {
+    const wrapper = renderModal({
+      onConfirm: onConfirmStub,
+    });
+
+    const continueButton = wrapper.find("button").at(2);
+    continueButton.simulate("click");
+
+    assert.isTrue(
+      onConfirmStub.calledOnce,
+      "onConfirm should be called once when Continue button is clicked",
+    );
+  });
+
+  it("doesn't call onConfirm when Continue button is clicked but disabled", () => {
+    const wrapper = renderModal({
+      onConfirm: onConfirmStub,
+      submitting: true,
+    });
+
+    const continueButton = wrapper.find("button").at(1);
+    continueButton.simulate("click");
+
+    assert.isFalse(
+      onConfirmStub.called,
+      "onConfirm should not be called when Continue button is disabled",
+    );
+  });
+});

--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -16,7 +16,7 @@ import {
   PRODUCT_TYPE_PROGRAM,
 } from "../../constants";
 import { isPromo } from "../../lib/ecommerce";
-import { getProductSelectLabel } from "../../lib/util";
+import { zeroHour, finalHour, getProductSelectLabel } from "../../lib/util";
 import FormError from "../../components/forms/elements/FormError";
 
 import type { Company, Product } from "../../flow/ecommerceTypes";
@@ -93,18 +93,6 @@ const couponValidations = yup.object().shape({
     then: (schema) => schema.required("Payment type is required"),
   }),
 });
-
-const zeroHour = (value) => {
-  if (value instanceof Date) {
-    value.setHours(0, 0, 0, 0);
-  }
-};
-
-const finalHour = (value) => {
-  if (value instanceof Date) {
-    value.setHours(23, 59, 59, 999);
-  }
-};
 
 export const CouponForm = ({
   onSubmit,

--- a/static/js/components/forms/PromoCouponUpdateForm.js
+++ b/static/js/components/forms/PromoCouponUpdateForm.js
@@ -1,0 +1,322 @@
+// @flow
+import React from "react";
+import moment from "moment";
+import { Picky } from "react-picky";
+import { filter, pathSatisfies, equals, always, sortBy, prop } from "ramda";
+import { formatDate, parseDate } from "react-day-picker/moment";
+import DayPickerInput from "react-day-picker/DayPickerInput";
+import { Formik, Field, Form, ErrorMessage } from "formik";
+import * as yup from "yup";
+
+import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants";
+import { getProductSelectLabel } from "../../lib/util";
+import FormError from "./elements/FormError";
+
+import type { Company, Product } from "../../flow/ecommerceTypes";
+
+type PromoCouponUpdateFormProps = {
+  onSubmit: Function,
+  companies: Array<Company>,
+  products: Array<Product>,
+};
+
+const couponValidations = yup.object().shape({
+  promo_coupon: yup.string().required("Promo coupon is required"),
+  activation_date: yup.date().required("Valid activation date required"),
+  expiration_date: yup
+    .date()
+    .min(
+      moment.max(yup.ref("activation_date"), moment()),
+      "Expiration date must be after today/activation date",
+    )
+    .required("Valid expiration date required"),
+  products: yup.array().min(1, "${min} or more products must be selected"),
+});
+
+const selectProducts = (coupon, products) => {
+  const productIds = coupon.eligibility.map((product) => product.product_id);
+  const selectedProducts = products
+    .filter((product) => productIds.includes(product.id))
+    .map((product) => ({
+      ...product,
+      label: getProductSelectLabel(product),
+    }));
+  return selectedProducts;
+};
+
+const zeroHour = (value) => {
+  if (value instanceof Date) {
+    value.setHours(0, 0, 0, 0);
+  }
+};
+
+const finalHour = (value) => {
+  if (value instanceof Date) {
+    value.setHours(23, 59, 59, 999);
+  }
+};
+
+export const PromoCouponUpdateForm = ({
+  onSubmit,
+  promoCoupons,
+  products,
+}: PromoCouponUpdateFormProps) => {
+  return (
+    <Formik
+      onSubmit={onSubmit}
+      validationSchema={couponValidations}
+      initialValues={{
+        promo_coupon: "",
+        product_type: "",
+        products: [],
+        activation_date: "",
+        expiration_date: "",
+        productSelectionsByType: {
+          [PRODUCT_TYPE_COURSERUN]: [],
+          [PRODUCT_TYPE_PROGRAM]: [],
+          "": [],
+        },
+      }}
+      render={({
+        isSubmitting,
+        setFieldValue,
+        setFieldTouched,
+        errors,
+        touched,
+        values,
+      }) => (
+        <Form className="coupon-form">
+          <div className="block">
+            <label htmlFor="promo_coupon">
+              Promo Coupon
+              <Field
+                component="select"
+                name="promo_coupon"
+                onChange={(e) => {
+                  const selectedId = e.target.value;
+                  setFieldValue("promo_coupon", selectedId);
+                  const selectedCoupon = promoCoupons?.find(
+                    (coupon) => String(coupon.id) === selectedId,
+                  );
+                  if (selectedCoupon) {
+                    const activationDate = moment(
+                      selectedCoupon.activation_date,
+                    ).toDate();
+                    const expirationDate = moment(
+                      selectedCoupon.expiration_date,
+                    ).toDate();
+                    const selectedProducts = selectProducts(
+                      selectedCoupon,
+                      products,
+                    );
+
+                    zeroHour(activationDate);
+                    finalHour(expirationDate);
+
+                    setFieldValue("activation_date", activationDate);
+                    setFieldValue("expiration_date", expirationDate);
+                    // setFieldValue("products", selectedProducts);
+                    // Save selected products by product_type
+                    const grouped = {
+                      [PRODUCT_TYPE_COURSERUN]: [],
+                      [PRODUCT_TYPE_PROGRAM]: [],
+                      "": [],
+                    };
+                    selectedProducts.forEach((product) => {
+                      grouped[product.product_type]?.push(product);
+                      grouped[""].push(product);
+                    });
+
+                    Object.entries(grouped).forEach(([type, prods]) => {
+                      setFieldValue(`productSelectionsByType.${type}`, prods);
+                    });
+                    setFieldValue("products", grouped[values.product_type]);
+                  }
+                }}
+              >
+                <option value="">-----</option>
+                {promoCoupons?.map((promoCoupon) => (
+                  <option key={promoCoupon.id} value={promoCoupon.id}>
+                    {promoCoupon.coupon_code}
+                  </option>
+                ))}
+              </Field>
+            </label>
+            <ErrorMessage name="promo_coupon" component={FormError} />
+          </div>
+          <div className="flex">
+            <div className="block">
+              <label htmlFor="activation_date">
+                Valid from*
+                <DayPickerInput
+                  name="activation_date"
+                  placeholder="MM/DD/YYYY"
+                  value={values.activation_date}
+                  format="L"
+                  formatDate={formatDate}
+                  parseDate={parseDate}
+                  onDayChange={(value) => {
+                    zeroHour(value);
+                    setFieldValue("activation_date", value);
+                  }}
+                  onDayPickerHide={() => setFieldTouched("activation_date")}
+                  error={errors.activation_date}
+                  touched={touched.activation_date}
+                />
+              </label>
+              <ErrorMessage name="activation_date" component={FormError} />
+            </div>
+            <div className="block">
+              <label htmlFor="expiration_date">
+                Valid until*
+                <DayPickerInput
+                  name="expiration_date"
+                  placeholder="MM/DD/YYYY"
+                  value={values.expiration_date}
+                  format="L"
+                  formatDate={formatDate}
+                  parseDate={parseDate}
+                  onDayChange={(value) => {
+                    finalHour(value);
+                    setFieldValue("expiration_date", value);
+                  }}
+                  onDayPickerHide={() => setFieldTouched("expiration_date")}
+                  error={errors.expiration_date}
+                  touched={touched.expiration_date}
+                />
+              </label>
+              <ErrorMessage name="expiration_date" component={FormError} />
+            </div>
+          </div>
+          <div className="flex">
+            <Field
+              type="radio"
+              name="product_type"
+              value={PRODUCT_TYPE_PROGRAM}
+              onClick={(evt) => {
+                const newProductType = evt.target.value;
+                setFieldValue("product_type", newProductType);
+
+                const cached =
+                  values.productSelectionsByType?.[newProductType] || [];
+                setFieldValue("products", cached);
+              }}
+              checked={values.product_type === PRODUCT_TYPE_PROGRAM}
+            />
+            Programs
+            <Field
+              type="radio"
+              name="product_type"
+              value={PRODUCT_TYPE_COURSERUN}
+              onClick={(evt) => {
+                const newProductType = evt.target.value;
+                setFieldValue("product_type", newProductType);
+
+                const cached =
+                  values.productSelectionsByType?.[newProductType] || [];
+                setFieldValue("products", cached);
+              }}
+              checked={values.product_type === PRODUCT_TYPE_COURSERUN}
+            />
+            Course runs
+            <Field
+              type="radio"
+              name="product_type"
+              value=""
+              onClick={(evt) => {
+                const newProductType = evt.target.value;
+                setFieldValue("product_type", newProductType);
+
+                // Merge both program + course run selections
+                const courseRun =
+                  values.productSelectionsByType?.[PRODUCT_TYPE_COURSERUN] ||
+                  [];
+                const program =
+                  values.productSelectionsByType?.[PRODUCT_TYPE_PROGRAM] || [];
+
+                // Combine and dedupe by product id
+                const merged = [...courseRun, ...program].filter(
+                  (prod, index, self) =>
+                    index === self.findIndex((p) => p.id === prod.id),
+                );
+
+                setFieldValue("products", merged);
+              }}
+              checked={values.product_type === ""}
+            />
+            All products
+          </div>
+          {values.product_type != "" && (
+            <p className="small-text warning">
+              {" "}
+              Switch to All Products to select both course runs and
+              programs.{" "}
+            </p>
+          )}
+          <ErrorMessage name="products" component={FormError} />
+          <div className="product-selection">
+            <Picky
+              name="products"
+              valueKey="id"
+              labelKey="label"
+              options={filter(
+                values.product_type
+                  ? pathSatisfies(equals(values.product_type), ["product_type"])
+                  : always(true),
+                sortBy(
+                  prop("label"),
+                  (products || []).map((product) => ({
+                    ...product,
+                    label: getProductSelectLabel(product),
+                  })),
+                ),
+              )}
+              value={values.products}
+              open={true}
+              multiple={true}
+              includeSelectAll={false}
+              includeFilter={true}
+              placeholder="Select products"
+              onChange={(value) => {
+                setFieldValue("products", value);
+                setFieldTouched("products");
+
+                if (values.product_type === "") {
+                  // All products mode — split and cache both types
+                  const programProducts = value.filter(
+                    (p) => p.product_type === PRODUCT_TYPE_PROGRAM,
+                  );
+                  const courseRunProducts = value.filter(
+                    (p) => p.product_type === PRODUCT_TYPE_COURSERUN,
+                  );
+
+                  setFieldValue(
+                    `productSelectionsByType.${PRODUCT_TYPE_PROGRAM}`,
+                    programProducts,
+                  );
+                  setFieldValue(
+                    `productSelectionsByType.${PRODUCT_TYPE_COURSERUN}`,
+                    courseRunProducts,
+                  );
+                } else {
+                  // Normal mode — cache only current type
+                  setFieldValue(
+                    `productSelectionsByType.${values.product_type}`,
+                    value,
+                  );
+                }
+              }}
+              dropdownHeight={200}
+              className="product-picker"
+            />
+          </div>
+          <div>
+            <button type="submit" disabled={isSubmitting}>
+              Update promo coupon
+            </button>
+          </div>
+        </Form>
+      )}
+    />
+  );
+};

--- a/static/js/components/forms/PromoCouponUpdateForm.js
+++ b/static/js/components/forms/PromoCouponUpdateForm.js
@@ -246,7 +246,7 @@ export const PromoCouponUpdateForm = ({
             />
             All products
           </div>
-          {values.product_type != "" && (
+          {values.product_type !== "" && (
             <p className="small-text warning">
               {" "}
               Switch to All Products to select both course runs and

--- a/static/js/components/forms/PromoCouponUpdateForm_test.js
+++ b/static/js/components/forms/PromoCouponUpdateForm_test.js
@@ -36,6 +36,7 @@ describe("PromoCouponUpdateForm", () => {
         { product_id: mockProducts[0].id },
         { product_id: mockProducts[1].id },
       ],
+      is_global: false,
     },
     {
       id: "2",
@@ -43,6 +44,7 @@ describe("PromoCouponUpdateForm", () => {
       activation_date: "2025-02-01T00:00:00.000Z",
       expiration_date: "2025-11-30T23:59:59.999Z",
       eligibility: [{ product_id: mockProducts[2].id }],
+      is_global: false,
     },
   ];
 
@@ -74,6 +76,7 @@ describe("PromoCouponUpdateForm", () => {
     const form = wrapper.find("Formik");
     // Check for required form elements
     assert.ok(findFormikFieldByName(form, "promo_coupon").exists());
+    assert.ok(findFormikFieldByName(form, "is_global").exists());
     assert.ok(form.find('DayPickerInput[name="activation_date"]').exists());
     assert.ok(form.find('DayPickerInput[name="expiration_date"]').exists());
     assert.ok(form.find('input[name="product_type"]').exists());

--- a/static/js/components/forms/PromoCouponUpdateForm_test.js
+++ b/static/js/components/forms/PromoCouponUpdateForm_test.js
@@ -1,0 +1,292 @@
+// @flow
+import React from "react";
+import sinon from "sinon";
+import { assert } from "chai";
+import { mount } from "enzyme";
+import wait from "waait";
+import moment from "moment";
+
+import { PromoCouponUpdateForm } from "./PromoCouponUpdateForm";
+import { PRODUCT_TYPE_COURSERUN, PRODUCT_TYPE_PROGRAM } from "../../constants";
+
+import {
+  findFormikFieldByName,
+  findFormikErrorByName,
+} from "../../lib/test_utils";
+import {
+  makeCourseRunProduct,
+  makeProgramProduct,
+} from "../../factories/ecommerce";
+
+describe("PromoCouponUpdateForm", () => {
+  let sandbox, onSubmitStub;
+  // Mock data setup
+  let mockProducts = [
+    makeCourseRunProduct(),
+    makeProgramProduct(),
+    makeCourseRunProduct(),
+  ];
+  let mockPromoCoupons = [
+    {
+      id: "1",
+      coupon_code: "TEST-COUPON-1",
+      activation_date: "2025-01-01T00:00:00.000Z",
+      expiration_date: "2025-12-31T23:59:59.999Z",
+      eligibility: [
+        { product_id: mockProducts[0].id },
+        { product_id: mockProducts[1].id },
+      ],
+    },
+    {
+      id: "2",
+      coupon_code: "TEST-COUPON-2",
+      activation_date: "2025-02-01T00:00:00.000Z",
+      expiration_date: "2025-11-30T23:59:59.999Z",
+      eligibility: [{ product_id: mockProducts[2].id }],
+    },
+  ];
+
+  const renderForm = () =>
+    mount(
+      <PromoCouponUpdateForm
+        onSubmit={onSubmitStub}
+        promoCoupons={mockPromoCoupons}
+        products={mockProducts}
+      />,
+    );
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    onSubmitStub = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("passes onSubmit to Formik", () => {
+    const wrapper = renderForm();
+    assert.equal(wrapper.find("Formik").props().onSubmit, onSubmitStub);
+  });
+
+  it("renders the form with all expected fields", () => {
+    const wrapper = renderForm();
+    const form = wrapper.find("Formik");
+    // Check for required form elements
+    assert.ok(findFormikFieldByName(form, "promo_coupon").exists());
+    assert.ok(form.find('DayPickerInput[name="activation_date"]').exists());
+    assert.ok(form.find('DayPickerInput[name="expiration_date"]').exists());
+    assert.ok(form.find('input[name="product_type"]').exists());
+    assert.ok(form.find("Picky2").exists());
+    assert.ok(form.find('button[type="submit"]').exists());
+  });
+
+  it("renders promo coupon dropdown options correctly", () => {
+    const wrapper = renderForm();
+    const selectOptions = wrapper.find('select[name="promo_coupon"] option');
+
+    // Check number of options (mockPromoCoupons + default empty option)
+    assert.equal(selectOptions.length, mockPromoCoupons.length + 1);
+
+    // Check default empty option
+    assert.equal(selectOptions.at(0).text(), "-----");
+
+    // Check coupon options
+    mockPromoCoupons.forEach((coupon, index) => {
+      assert.equal(selectOptions.at(index + 1).text(), coupon.coupon_code);
+      assert.equal(selectOptions.at(index + 1).prop("value"), coupon.id);
+    });
+  });
+
+  it("populates form fields when promo coupon is selected", async () => {
+    const wrapper = renderForm();
+
+    // Select a promo coupon
+    const select = wrapper.find('select[name="promo_coupon"]');
+    select.simulate("change", { target: { value: "1" } });
+
+    await wait();
+    wrapper.update();
+
+    // Check if dates are populated correctly
+    const activationDate = moment(mockPromoCoupons[0].activation_date).format(
+      "L",
+    );
+    const expirationDate = moment(mockPromoCoupons[0].expiration_date).format(
+      "L",
+    );
+
+    const activationInput = wrapper.find(
+      'DayPickerInput[name="activation_date"]',
+    );
+    const expirationInput = wrapper.find(
+      'DayPickerInput[name="expiration_date"]',
+    );
+
+    // Note: In a real test, you might need to check the internal state rather than the DOM value
+    // This is a simplified check that would need to be adjusted based on how DayPickerInput works
+    assert.ok(activationInput.exists());
+    assert.ok(expirationInput.exists());
+  });
+
+  it("switches product selections based on product type radio buttons", async () => {
+    const wrapper = renderForm();
+
+    // First select a coupon to populate product selections
+    const select = wrapper.find('select[name="promo_coupon"]');
+    select.simulate("change", { target: { value: "1" } });
+
+    await wait();
+    wrapper.update();
+
+    // Select course runs radio button
+    const courseRunRadio = wrapper.find(
+      `input[name="product_type"][value="${PRODUCT_TYPE_COURSERUN}"]`,
+    );
+    courseRunRadio.simulate("click", {
+      target: { value: PRODUCT_TYPE_COURSERUN },
+    });
+
+    await wait();
+    wrapper.update();
+
+    // Now select programs radio button
+    const programsRadio = wrapper.find(
+      `input[name="product_type"][value="${PRODUCT_TYPE_PROGRAM}"]`,
+    );
+    programsRadio.simulate("click", {
+      target: { value: PRODUCT_TYPE_PROGRAM },
+    });
+
+    await wait();
+    wrapper.update();
+
+    // Select all products radio button
+    const allProductsRadio = wrapper.find(
+      'input[name="product_type"][value=""]',
+    );
+    allProductsRadio.simulate("click", { target: { value: "" } });
+
+    await wait();
+    wrapper.update();
+  });
+
+  describe("form validation", () => {
+    [
+      ["", "Promo coupon is required"],
+      ["1", ""],
+    ].forEach(([value, errorMessage]) => {
+      it(`validates the field name=promo_coupon, value="${JSON.stringify(
+        value,
+      )}" and expects error=${JSON.stringify(errorMessage)}`, async () => {
+        const wrapper = renderForm();
+        const formik = wrapper.find("Formik").instance();
+        formik.setFieldValue("promo_coupon", value);
+        formik.setFieldTouched("promo_coupon");
+        await wait();
+        wrapper.update();
+        assert.deepEqual(
+          findFormikErrorByName(wrapper, "promo_coupon").text(),
+          errorMessage,
+        );
+      });
+    });
+
+    [
+      [[], "1 or more products must be selected"],
+      [[makeCourseRunProduct()], ""],
+    ].forEach(([value, errorMessage]) => {
+      it(`validates the field name=products, value="${JSON.stringify(
+        value,
+      )}" and expects error=${JSON.stringify(
+        errorMessage,
+      )} for coupons`, async () => {
+        const wrapper = renderForm();
+        const formik = wrapper.find("Formik").instance();
+        formik.setFieldValue("products", value);
+        formik.setFieldTouched("products");
+        await wait();
+        wrapper.update();
+        assert.deepEqual(
+          findFormikErrorByName(wrapper, "products").text(),
+          errorMessage,
+        );
+      });
+    });
+    [
+      [PRODUCT_TYPE_COURSERUN, [mockProducts[0]]],
+      [PRODUCT_TYPE_PROGRAM, [mockProducts[1]]],
+      ["", mockProducts],
+    ].forEach(([productType, availableProduct]) => {
+      it(`displays correct product checkboxes when productType radio button value="${productType}"`, async () => {
+        const wrapper = renderForm();
+        wrapper
+          .find(`input[name='product_type'][value='${productType}']`)
+          .simulate("click");
+        await wait();
+        wrapper.update();
+        const picky = wrapper.find(".picky");
+        const options = picky.find("input[type='checkbox']");
+        assert.equal(options.at(2).exists(), productType === "");
+        assert.ok(
+          picky.text().includes(availableProduct[0].content_object.title),
+        );
+        if (productType === "") {
+          assert.equal(options.at(1).exists(), productType === "");
+          assert.ok(
+            picky.text().includes(availableProduct[1].content_object.title),
+          );
+        }
+      });
+    });
+
+    [
+      ["expiration_date", 1, "", "Valid expiration date required"],
+      ["activation_date", 0, "", "Valid activation date required"],
+      ["expiration_date", 1, "bad_date", "Valid expiration date required"],
+      ["activation_date", 0, "bad_date", "Valid activation date required"],
+      ["activation_date", 0, "06/27/2019", ""],
+      ["expiration_date", 1, moment().add(1, "days").format("MM/DD/YYYY"), ""],
+      [
+        "expiration_date",
+        1,
+        moment().subtract(1, "days").format("MM/DD/YYYY"),
+        "Expiration date must be after today/activation date",
+      ],
+    ].forEach(([name, idx, value, errorMessage]) => {
+      it(`validates the field name=${name}, value=${JSON.stringify(
+        value,
+      )} and expects error=${JSON.stringify(errorMessage)}`, async () => {
+        const wrapper = renderForm();
+
+        const input = wrapper.find("DayPickerInput").at(idx).find("input");
+        input.simulate("click");
+        input.simulate("change", {
+          persist: () => {},
+          target: { name, value },
+        });
+        input.simulate("blur");
+        await wait();
+        wrapper.update();
+        assert.deepEqual(
+          findFormikErrorByName(wrapper, name).text(),
+          errorMessage,
+        );
+      });
+    });
+  });
+
+  it("submits form data when valid", async () => {
+    const wrapper = renderForm();
+
+    // Select a promo coupon
+    const select = wrapper.find('select[name="promo_coupon"]');
+    select.simulate("change", { target: { value: "1" } });
+
+    await wait();
+    wrapper.update();
+
+    // Submit the form
+    wrapper.find("form").simulate("submit");
+  });
+});

--- a/static/js/components/forms/PromoCouponUpdateForm_test.js
+++ b/static/js/components/forms/PromoCouponUpdateForm_test.js
@@ -21,12 +21,12 @@ import {
 describe("PromoCouponUpdateForm", () => {
   let sandbox, onSubmitStub;
   // Mock data setup
-  let mockProducts = [
+  const mockProducts = [
     makeCourseRunProduct(),
     makeProgramProduct(),
     makeCourseRunProduct(),
   ];
-  let mockPromoCoupons = [
+  const mockPromoCoupons = [
     {
       id: "1",
       coupon_code: "TEST-COUPON-1",

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -143,3 +143,9 @@ export const ACCOUNT_SETTINGS_PAGE_TITLE = "Account Settings";
 export const EMAIL_CONFIRM_PAGE_TITLE = "Confirm Email Change";
 
 export const RECEIPT_PAGE_TITLE = "Receipt";
+export const DEACTIVATE_COUPONS_MODAL_HEADER = "Deactivate Coupon(s)";
+export const DEACTIVATE_COUPONS_MODAL_BODY =
+  "Are you sure you want to deactivate coupon(s)?";
+export const UPDATE_PROMO_COUPON_MODAL_HEADER = "Update Promo Coupon";
+export const UPDATE_PROMO_COUPON_MODAL_BODY =
+  "Update this promo coupon? This will overwrite existing product eligibility settings.";

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -121,7 +121,7 @@ export const CREATE_COUPON_PAGE_TITLE = "Create Coupon";
 export const DEACTIVATE_COUPONS_PAGE_TITLE = "Deactivate Coupons";
 export const PROCESS_COUPON_ASSIGNMENT_SHEET_PAGE_TITLE =
   "Process Coupon Assignment Sheet";
-
+export const UPDATE_PROMO_COUPON_PAGE_TITLE = "Update Promo Coupon";
 export const LOGIN_EMAIL_PAGE_TITLE = "Sign In";
 export const LOGIN_PASSWORD_PAGE_TITLE = LOGIN_EMAIL_PAGE_TITLE;
 

--- a/static/js/containers/pages/admin/DeactivateCouponPage.js
+++ b/static/js/containers/pages/admin/DeactivateCouponPage.js
@@ -14,8 +14,7 @@ import { routes } from "../../../lib/urls";
 
 import type { Response } from "redux-query";
 import { createStructuredSelector } from "reselect";
-import { Modal, ModalHeader, ModalBody } from "reactstrap";
-
+import ConfirmUpdateModal from "../../../components/ConfirmUpdateModal";
 type State = {
   submitting: ?boolean,
   isDeactivated: ?boolean,
@@ -98,29 +97,14 @@ export class DeactivateCouponPage extends React.Component<Props, State> {
         title={`${SETTINGS.site_name} | ${DEACTIVATE_COUPONS_PAGE_TITLE}`}
       >
         <div className="ecommerce-admin-body">
-          <Modal isOpen={openConfirmModal} toggle={this.toggleOpenConfirmModal}>
-            <ModalHeader toggle={this.toggleOpenConfirmModal}>
-              Confirm Coupon Deactivation
-            </ModalHeader>
-            <ModalBody>
-              <div> Are you sure you want to deactivate coupon(s)?</div>
-              <div className="float-container">
-                <button
-                  className="btn btn-gradient-white-to-blue"
-                  onClick={() => this.toggleOpenConfirmModal()}
-                >
-                  Cancel
-                </button>
-                <button
-                  className="btn btn-gradient-red-to-blue"
-                  onClick={() => this.onModalSubmit()}
-                  disabled={this.state.submitting}
-                >
-                  Deactivate
-                </button>
-              </div>
-            </ModalBody>
-          </Modal>
+          <ConfirmUpdateModal
+            isOpen={openConfirmModal}
+            toggle={this.toggleOpenConfirmModal}
+            onConfirm={this.onModalSubmit}
+            submitting={this.state.submitting}
+            headerMessage="Confirm Coupon Deactivation"
+            bodyText="Are you sure you want to deactivate coupon(s)?"
+          />
           <p>
             <Link to={routes.ecommerceAdmin.index}>
               Back to Ecommerce Admin

--- a/static/js/containers/pages/admin/DeactivateCouponPage.js
+++ b/static/js/containers/pages/admin/DeactivateCouponPage.js
@@ -2,7 +2,11 @@
 /* global SETTINGS: false */
 import React from "react";
 import DocumentTitle from "react-document-title";
-import { DEACTIVATE_COUPONS_PAGE_TITLE } from "../../../constants";
+import {
+  DEACTIVATE_COUPONS_MODAL_BODY,
+  DEACTIVATE_COUPONS_MODAL_HEADER,
+  DEACTIVATE_COUPONS_PAGE_TITLE,
+} from "../../../constants";
 import { mutateAsync } from "redux-query";
 import { compose } from "redux";
 import { connect } from "react-redux";
@@ -102,8 +106,8 @@ export class DeactivateCouponPage extends React.Component<Props, State> {
             toggle={this.toggleOpenConfirmModal}
             onConfirm={this.onModalSubmit}
             submitting={this.state.submitting}
-            headerMessage="Confirm Coupon Deactivation"
-            bodyText="Are you sure you want to deactivate coupon(s)?"
+            headerMessage={DEACTIVATE_COUPONS_MODAL_HEADER}
+            bodyText={DEACTIVATE_COUPONS_MODAL_BODY}
           />
           <p>
             <Link to={routes.ecommerceAdmin.index}>

--- a/static/js/containers/pages/admin/DeactivateCouponPage_test.js
+++ b/static/js/containers/pages/admin/DeactivateCouponPage_test.js
@@ -63,26 +63,26 @@ describe("DeactivateCouponPage", () => {
     const testCouponsData = {
       coupons: "abc\nbcd",
     };
-  
+
     helper.handleRequestStub.returns({
       body: {
         skipped_codes: ["xyz", "pqr"],
         num_of_coupons_deactivated: 1,
       },
     });
-  
+
     const { inner } = await renderDeactivateCouponPage();
-  
+
     await inner.instance().onSubmit(testCouponsData, {
       setSubmitting: setSubmittingStub,
     });
-  
+
     // Instead of simulating a button click, invoke the onConfirm directly
     const modal = inner.find(ConfirmUpdateModal);
     await modal.prop("onConfirm")();
-  
+
     await wait;
-  
+
     sinon.assert.calledWith(setSubmittingStub, false);
     sinon.assert.calledWith(helper.handleRequestStub, "/api/coupons/", "PUT", {
       body: testCouponsData,
@@ -91,9 +91,9 @@ describe("DeactivateCouponPage", () => {
       },
       credentials: undefined,
     });
-  
+
     assert.equal(inner.state().isDeactivated, true);
-  });  
+  });
 
   it("clearSuccess() changes state.isDeactivated", async () => {
     const { inner } = await renderDeactivateCouponPage();

--- a/static/js/containers/pages/admin/DeactivateCouponPage_test.js
+++ b/static/js/containers/pages/admin/DeactivateCouponPage_test.js
@@ -7,7 +7,7 @@ import DeactivateCouponPage, {
 } from "./DeactivateCouponPage";
 
 import IntegrationTestHelper from "../../../util/integration_test_helper";
-import { Modal } from "reactstrap";
+import ConfirmUpdateModal from "../../../components/ConfirmUpdateModal";
 import wait from "waait";
 
 describe("DeactivateCouponPage", () => {
@@ -63,21 +63,27 @@ describe("DeactivateCouponPage", () => {
     const testCouponsData = {
       coupons: "abc\nbcd",
     };
+  
     helper.handleRequestStub.returns({
       body: {
         skipped_codes: ["xyz", "pqr"],
+        num_of_coupons_deactivated: 1,
       },
     });
+  
     const { inner } = await renderDeactivateCouponPage();
-
+  
     await inner.instance().onSubmit(testCouponsData, {
       setSubmitting: setSubmittingStub,
     });
-    sinon.assert.calledWith(setSubmittingStub, false);
-    assert.isTrue(inner.find(Modal).exists());
-
-    inner.find(".btn-gradient-red-to-blue").simulate("click");
+  
+    // Instead of simulating a button click, invoke the onConfirm directly
+    const modal = inner.find(ConfirmUpdateModal);
+    await modal.prop("onConfirm")();
+  
     await wait;
+  
+    sinon.assert.calledWith(setSubmittingStub, false);
     sinon.assert.calledWith(helper.handleRequestStub, "/api/coupons/", "PUT", {
       body: testCouponsData,
       headers: {
@@ -85,10 +91,9 @@ describe("DeactivateCouponPage", () => {
       },
       credentials: undefined,
     });
-
-    await wait;
+  
     assert.equal(inner.state().isDeactivated, true);
-  });
+  });  
 
   it("clearSuccess() changes state.isDeactivated", async () => {
     const { inner } = await renderDeactivateCouponPage();

--- a/static/js/containers/pages/admin/EcommerceAdminPages.js
+++ b/static/js/containers/pages/admin/EcommerceAdminPages.js
@@ -12,6 +12,7 @@ import { routes } from "../../../lib/urls";
 import CouponCreationPage from "./CreateCouponPage";
 import DeactivateCouponPage from "./DeactivateCouponPage";
 import ProcessCouponAssignmentSheetPage from "./ProcessCouponAssignmentSheetPage";
+import UpdatePromoCodePage from "./UpdatePromoCouponPage";
 
 const EcommerceAdminIndexPage = () => (
   <div className="ecommerce-admin-body">
@@ -33,6 +34,13 @@ const EcommerceAdminIndexPage = () => (
         <li>
           <Link to={routes.ecommerceAdmin.processSheets}>
             Process Coupon Assignment Sheet
+          </Link>
+        </li>
+      )}
+      {USER_PERMISSIONS.has_coupon_update_permission && (
+        <li>
+          <Link to={routes.ecommerceAdmin.updatePromoCode}>
+            Update Promo Coupon
           </Link>
         </li>
       )}
@@ -62,6 +70,11 @@ const EcommerceAdminPages = () => (
         exact
         path={routes.ecommerceAdmin.processSheets}
         component={ProcessCouponAssignmentSheetPage}
+      />
+      <Route
+        exact
+        path={routes.ecommerceAdmin.updatePromoCode}
+        component={UpdatePromoCodePage}
       />
       <Redirect to={routes.ecommerceAdmin.index} />
     </Switch>

--- a/static/js/containers/pages/admin/UpdatePromoCouponPage.js
+++ b/static/js/containers/pages/admin/UpdatePromoCouponPage.js
@@ -2,7 +2,11 @@
 /* global SETTINGS: false */
 import React from "react";
 import DocumentTitle from "react-document-title";
-import { UPDATE_PROMO_COUPON_PAGE_TITLE } from "../../../constants";
+import {
+  UPDATE_PROMO_COUPON_MODAL_BODY,
+  UPDATE_PROMO_COUPON_MODAL_HEADER,
+  UPDATE_PROMO_COUPON_PAGE_TITLE,
+} from "../../../constants";
 import { connectRequest, mutateAsync } from "redux-query";
 import { compose } from "redux";
 import { connect } from "react-redux";
@@ -70,7 +74,7 @@ export class UpdatePromoCouponPage extends React.Component<Props, State> {
   };
 
   onModalSubmit = async () => {
-    const { updatePromoCoupon, forceRequest } = this.props;
+    const { updatePromoCoupon } = this.props;
     const { couponData } = this.state;
 
     couponData.product_ids = couponData.products.map((product) => product.id);
@@ -118,8 +122,8 @@ export class UpdatePromoCouponPage extends React.Component<Props, State> {
             toggle={this.toggleOpenConfirmModal}
             onConfirm={this.onModalSubmit}
             submitting={this.state.submitting}
-            headerMessage="Update Promo Coupon"
-            bodyText="Update this promo coupon? This will overwrite existing product eligibility settings."
+            headerMessage={UPDATE_PROMO_COUPON_MODAL_HEADER}
+            bodyText={UPDATE_PROMO_COUPON_MODAL_BODY}
           />
           <p>
             <Link to={routes.ecommerceAdmin.index}>

--- a/static/js/containers/pages/admin/UpdatePromoCouponPage.js
+++ b/static/js/containers/pages/admin/UpdatePromoCouponPage.js
@@ -1,0 +1,188 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react";
+import DocumentTitle from "react-document-title";
+import { UPDATE_PROMO_COUPON_PAGE_TITLE } from "../../../constants";
+import { connectRequest, mutateAsync } from "redux-query";
+import { compose } from "redux";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
+
+import queries from "../../../lib/queries";
+import { routes } from "../../../lib/urls";
+
+import type { Response } from "redux-query";
+import type { QueryConfig } from "redux-query";
+
+import { createStructuredSelector } from "reselect";
+import { PromoCouponUpdateForm } from "../../../components/forms/PromoCouponUpdateForm";
+import ConfirmUpdateModal from "../../../components/ConfirmUpdateModal";
+import type { Product, PromoCoupon } from "../../../flow/ecommerceTypes";
+
+type State = {
+  couponData: Object,
+  isUpdated: ?boolean,
+  openConfirmModal: ?boolean,
+  submitting: ?boolean,
+  errorMsg: string,
+  responseMsg: string,
+};
+
+type StateProps = {|
+  products: Array<Product>,
+  promoCoupons: Array<PromoCoupon>,
+|};
+
+type DispatchProps = {|
+  updatePromoCoupon: (
+    coupon: Object,
+  ) => Promise<Response<CouponPaymentVersion>>,
+|};
+
+type ReduxQueryProps = {
+  forceRequest: (config: QueryConfig) => void,
+};
+
+type Props = {|
+  ...StateProps,
+  ...DispatchProps,
+  ...ReduxQueryProps,
+|};
+
+export class UpdatePromoCouponPage extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      couponData: {},
+      openConfirmModal: false,
+      submitting: false,
+      isUpdated: false,
+      errorMsg: "",
+      responseMsg: "",
+    };
+  }
+  toggleOpenConfirmModal = async () => {
+    await this.setState({
+      ...this.state,
+      openConfirmModal: !this.state.openConfirmModal,
+    });
+  };
+
+  onModalSubmit = async () => {
+    const { updatePromoCoupon, forceRequest } = this.props;
+    const { couponData } = this.state;
+
+    couponData.product_ids = couponData.products.map((product) => product.id);
+    await this.setState({ ...this.state, submitting: true });
+
+    const result = await updatePromoCoupon(couponData);
+    // Refetch promo coupons from server
+    forceRequest(queries.ecommerce.promoCouponsQuery());
+
+    this.setState({
+      couponData: couponData,
+      isUpdated: true,
+      openConfirmModal: false,
+      submitting: false,
+      errorMsg: result.body.error,
+      responseMsg: result.body.message,
+    });
+  };
+
+  onSubmit = async (couponData: Object, { setSubmitting }: Object) => {
+    await this.setState({ ...this.state, couponData: couponData });
+    await this.toggleOpenConfirmModal();
+    setSubmitting(false);
+  };
+
+  clearSuccess = async () => {
+    await this.setState({
+      isUpdated: false,
+      openConfirmModal: false,
+      couponData: {},
+      errorMsg: "",
+      responseMsg: "",
+    });
+  };
+
+  render() {
+    const { openConfirmModal, responseMsg, isUpdated, errorMsg } = this.state;
+    const { products, promoCoupons } = this.props;
+
+    return (
+      <DocumentTitle
+        title={`${SETTINGS.site_name} | ${UPDATE_PROMO_COUPON_PAGE_TITLE}`}
+      >
+        <div className="ecommerce-admin-body">
+          <ConfirmUpdateModal
+            isOpen={openConfirmModal}
+            toggle={this.toggleOpenConfirmModal}
+            onConfirm={this.onModalSubmit}
+            submitting={this.state.submitting}
+            headerMessage="Update Promo Coupon"
+            bodyText="Update this promo coupon? This will overwrite existing product eligibility settings."
+          />
+          <p>
+            <Link to={routes.ecommerceAdmin.index}>
+              Back to Ecommerce Admin
+            </Link>
+          </p>
+          <h3>Update Promo Coupon</h3>
+          {isUpdated ? (
+            <div className="coupon-result-div">
+              {responseMsg ? (
+                <div className="form-message form-success">
+                  <p className="message-text">{responseMsg}</p>
+                </div>
+              ) : (
+                <div className="form-message form-warning">
+                  <p className="message-text">{errorMsg}</p>
+                </div>
+              )}
+              <div>
+                <input
+                  type="button"
+                  value="Update more Promo Coupons"
+                  onClick={this.clearSuccess}
+                />
+              </div>
+            </div>
+          ) : (
+            <PromoCouponUpdateForm
+              onSubmit={this.onSubmit}
+              promoCoupons={promoCoupons}
+              products={products?.filter(
+                (product) => product.is_private === false,
+              )}
+            />
+          )}
+        </div>
+      </DocumentTitle>
+    );
+  }
+}
+
+const updatePromoCoupon = (coupon: Object) =>
+  mutateAsync(queries.ecommerce.promoCouponUpdation(coupon));
+
+const mapPropsToConfig = () => [
+  queries.ecommerce.productsQuery(),
+  queries.ecommerce.promoCouponsQuery(),
+];
+
+const mapStateToProps = createStructuredSelector({
+  products: queries.ecommerce.productsSelector,
+  promoCoupons: queries.ecommerce.promoCouponsSelector,
+});
+
+const mapDispatchToProps = {
+  updatePromoCoupon: updatePromoCoupon,
+};
+
+export default compose(
+  connect<Props, _, _, DispatchProps, _, _>(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  connectRequest(mapPropsToConfig),
+)(UpdatePromoCouponPage);

--- a/static/js/containers/pages/admin/UpdatePromoCouponPage.js
+++ b/static/js/containers/pages/admin/UpdatePromoCouponPage.js
@@ -52,6 +52,7 @@ type Props = {|
 export class UpdatePromoCouponPage extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    props.forceRequest(queries.ecommerce.promoCouponsQuery());
     this.state = {
       couponData: {},
       openConfirmModal: false,
@@ -76,8 +77,6 @@ export class UpdatePromoCouponPage extends React.Component<Props, State> {
     await this.setState({ ...this.state, submitting: true });
 
     const result = await updatePromoCoupon(couponData);
-    // Refetch promo coupons from server
-    forceRequest(queries.ecommerce.promoCouponsQuery());
 
     this.setState({
       couponData: couponData,

--- a/static/js/containers/pages/admin/UpdatePromoCouponPage.js
+++ b/static/js/containers/pages/admin/UpdatePromoCouponPage.js
@@ -106,6 +106,7 @@ export class UpdatePromoCouponPage extends React.Component<Props, State> {
       errorMsg: "",
       responseMsg: "",
     });
+    this.props.forceRequest(queries.ecommerce.promoCouponsQuery());
   };
 
   render() {

--- a/static/js/containers/pages/admin/UpdatePromoCouponPage_test.js
+++ b/static/js/containers/pages/admin/UpdatePromoCouponPage_test.js
@@ -14,6 +14,10 @@ import {
   makeCourseRunProduct,
   makeProgramProduct,
 } from "../../../factories/ecommerce";
+import {
+  UPDATE_PROMO_COUPON_MODAL_BODY,
+  UPDATE_PROMO_COUPON_MODAL_HEADER,
+} from "../../../constants";
 
 describe("UpdatePromoCouponPage", () => {
   let helper, renderUpdatePromoCouponPage, setSubmittingStub;
@@ -62,11 +66,8 @@ describe("UpdatePromoCouponPage", () => {
     const { inner } = await renderUpdatePromoCouponPage();
     const modal = inner.find(ConfirmUpdateModal);
     assert.isTrue(modal.exists());
-    assert.equal(modal.props().headerMessage, "Update Promo Coupon");
-    assert.equal(
-      modal.props().bodyText,
-      "Update this promo coupon? This will overwrite existing product eligibility settings.",
-    );
+    assert.equal(modal.props().headerMessage, UPDATE_PROMO_COUPON_MODAL_HEADER);
+    assert.equal(modal.props().bodyText, UPDATE_PROMO_COUPON_MODAL_BODY);
   });
 
   it("filters private products from being passed to the form", async () => {
@@ -156,9 +157,7 @@ describe("UpdatePromoCouponPage", () => {
       },
     });
 
-    const { inner } = await renderUpdatePromoCouponPage({
-      updatePromoCoupon: updatePromoCouponStub,
-    });
+    const { inner } = await renderUpdatePromoCouponPage();
 
     // Set modal to open and coupon data
     await inner.instance().setState({

--- a/static/js/containers/pages/admin/UpdatePromoCouponPage_test.js
+++ b/static/js/containers/pages/admin/UpdatePromoCouponPage_test.js
@@ -1,0 +1,255 @@
+// @flow
+import { assert } from "chai";
+import * as sinon from "sinon";
+
+import UpdatePromoCouponPage, {
+  UpdatePromoCouponPage as InnerUpdatePromoCouponPage,
+} from "./UpdatePromoCouponPage";
+
+import IntegrationTestHelper from "../../../util/integration_test_helper";
+import { PromoCouponUpdateForm } from "../../../components/forms/PromoCouponUpdateForm";
+import ConfirmUpdateModal from "../../../components/ConfirmUpdateModal";
+import wait from "waait";
+import {
+  makeCourseRunProduct,
+  makeProgramProduct,
+} from "../../../factories/ecommerce";
+
+describe("UpdatePromoCouponPage", () => {
+  let helper, renderUpdatePromoCouponPage, setSubmittingStub;
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper();
+    setSubmittingStub = helper.sandbox.stub();
+    renderUpdatePromoCouponPage = helper.configureHOCRenderer(
+      UpdatePromoCouponPage,
+      InnerUpdatePromoCouponPage,
+      {
+        entities: {
+          products: [
+            {
+              ...makeCourseRunProduct(),
+              is_private: false,
+            },
+            {
+              ...makeProgramProduct(),
+              is_private: false,
+            },
+            {
+              ...makeCourseRunProduct(),
+              is_private: true,
+            },
+          ],
+          promoCoupons: [
+            { id: "coupon1", name: "Promo 1" },
+            { id: "coupon2", name: "Promo 2" },
+          ],
+        },
+      },
+    );
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it("displays a promo coupon update form on the page", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+    assert.isTrue(inner.find(PromoCouponUpdateForm).exists());
+  });
+
+  it("renders the ConfirmUpdateModal component", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+    const modal = inner.find(ConfirmUpdateModal);
+    assert.isTrue(modal.exists());
+    assert.equal(modal.props().headerMessage, "Update Promo Coupon");
+    assert.equal(
+      modal.props().bodyText,
+      "Update this promo coupon? This will overwrite existing product eligibility settings.",
+    );
+  });
+
+  it("filters private products from being passed to the form", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+    const form = inner.find(PromoCouponUpdateForm);
+    assert.equal(form.props().products.length, 2);
+    assert.isFalse(
+      form.props().products.some((product) => product.is_private === true),
+    );
+  });
+
+  it("displays a success message on the page after update", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+
+    // Set state to simulate successful update with response message
+    await inner.instance().setState({
+      isUpdated: true,
+      responseMsg: "Promo coupon successfully updated.",
+    });
+
+    const successMessage = inner.find(".form-success");
+    assert.isTrue(successMessage.exists());
+    assert.equal(
+      successMessage.find(".message-text").text(),
+      "Promo coupon successfully updated.",
+    );
+  });
+
+  it("displays an error message when update fails", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+
+    // Set state to simulate failed update with error message
+    await inner.instance().setState({
+      isUpdated: true,
+      responseMsg: "",
+      errorMsg: "Failed to update promo coupon.",
+    });
+
+    const errorMessage = inner.find(".form-warning");
+    assert.isTrue(errorMessage.exists());
+    assert.equal(
+      errorMessage.find(".message-text").text(),
+      "Failed to update promo coupon.",
+    );
+  });
+
+  it("toggles the confirmation modal when onSubmit is called", async () => {
+    const testCouponData = {
+      id: "coupon1",
+      products: [{ id: "1" }, { id: "2" }],
+    };
+
+    const { inner } = await renderUpdatePromoCouponPage();
+
+    // Initially modal should be closed
+    assert.isFalse(inner.state().openConfirmModal);
+
+    // Call onSubmit which should open the modal
+    await inner.instance().onSubmit(testCouponData, {
+      setSubmitting: setSubmittingStub,
+    });
+
+    sinon.assert.calledWith(setSubmittingStub, false);
+    assert.isTrue(inner.state().openConfirmModal);
+    assert.deepEqual(inner.state().couponData, testCouponData);
+  });
+
+  it("toggles the confirmation modal with toggleOpenConfirmModal", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+
+    // Initial state
+    assert.isFalse(inner.state().openConfirmModal);
+
+    // Toggle modal open
+    await inner.instance().toggleOpenConfirmModal();
+    assert.isTrue(inner.state().openConfirmModal);
+
+    // Toggle modal closed
+    await inner.instance().toggleOpenConfirmModal();
+    assert.isFalse(inner.state().openConfirmModal);
+  });
+
+  it("closes the modal when modal confirmation button is clicked", async () => {
+    const updatePromoCouponStub = helper.handleRequestStub.returns({
+      body: {
+        message: "Promo coupon successfully updated.",
+      },
+    });
+
+    const { inner } = await renderUpdatePromoCouponPage({
+      updatePromoCoupon: updatePromoCouponStub,
+    });
+
+    // Set modal to open and coupon data
+    await inner.instance().setState({
+      openConfirmModal: true,
+      couponData: {
+        id: "coupon1",
+        products: [{ id: "1" }],
+      },
+    });
+
+    // Verify modal is open
+    const modal = inner.find(ConfirmUpdateModal);
+    assert.isTrue(modal.exists());
+    assert.isTrue(modal.props().isOpen);
+
+    // Simulate confirmation click
+    await modal.props().onConfirm();
+    await wait;
+
+    // Modal should be closed after confirmation
+    assert.isFalse(inner.state().openConfirmModal);
+    assert.isTrue(inner.state().isUpdated);
+  });
+
+  it("updates promo coupon when onModalSubmit is called", async () => {
+    const testCouponData = {
+      id: "coupon1",
+      products: [{ id: "1" }, { id: "2" }],
+    };
+
+    helper.handleRequestStub.returns({
+      body: {
+        message: "Promo coupon successfully updated.",
+      },
+    });
+
+    const { inner } = await renderUpdatePromoCouponPage();
+
+    // Set up the state with coupon data
+    await inner.instance().setState({
+      couponData: testCouponData,
+      openConfirmModal: true,
+    });
+
+    // Call onModalSubmit
+    await inner.instance().onModalSubmit();
+
+    // After update, the state should be updated appropriately
+    assert.equal(inner.state().isUpdated, true);
+    assert.equal(inner.state().openConfirmModal, false);
+    assert.equal(inner.state().submitting, false);
+    assert.equal(
+      inner.state().responseMsg,
+      "Promo coupon successfully updated.",
+    );
+  });
+
+  it("clearSuccess() resets the state", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+
+    // Set a state to clear
+    inner.instance().setState({
+      isUpdated: true,
+      openConfirmModal: true,
+      couponData: { id: "test" },
+      errorMsg: "Error",
+      responseMsg: "Success",
+    });
+
+    // Verify initial state
+    assert.equal(inner.state().isUpdated, true);
+    assert.equal(inner.state().openConfirmModal, true);
+    assert.deepEqual(inner.state().couponData, { id: "test" });
+    assert.equal(inner.state().errorMsg, "Error");
+    assert.equal(inner.state().responseMsg, "Success");
+
+    // Call clearSuccess
+    await inner.instance().clearSuccess();
+
+    // Verify state has been reset
+    assert.equal(inner.state().isUpdated, false);
+    assert.equal(inner.state().openConfirmModal, false);
+    assert.deepEqual(inner.state().couponData, {});
+    assert.equal(inner.state().errorMsg, "");
+    assert.equal(inner.state().responseMsg, "");
+  });
+
+  it("renders a link back to ecommerce admin", async () => {
+    const { inner } = await renderUpdatePromoCouponPage();
+    const backLink = inner.find("Link");
+    assert.isTrue(backLink.exists());
+    assert.equal(backLink.props().to, "/ecommerce/admin/");
+  });
+});

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -271,3 +271,18 @@ export type EnrollmentCode = {
   thumbnail_url: string,
   start_date: Date,
 };
+
+export type Eligibility = {
+  coupon_code: string,
+  product_id: number,
+  program_run_id: ?number,
+}
+
+export type PromoCoupon = {
+  id: number,
+  name: string,
+  coupon_code: string,
+  expiration_date: Date,
+  activation_date: Date,
+  eligibility: Array<Eligibility>,
+};

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -85,6 +85,20 @@ export default {
       companies: (prev: Array<Company>, next: Array<Company>) => next,
     },
   }),
+  promoCouponsSelector: pathOr(null, ["entities", "promoCoupons"]),
+  promoCouponsQuery: () => ({
+    queryKey: "promoCoupons",
+    url: "/api/promo_coupons/",
+    transform: (json: Array<CouponPaymentVersion>) => ({
+      promoCoupons: json,
+    }),
+    update: {
+      promoCoupons: (
+        prev: Array<CouponPaymentVersion>,
+        next: Array<CouponPaymentVersion>,
+      ) => next,
+    },
+  }),
   couponsSelector: pathOr(null, ["entities", "coupons"]),
   couponsMutation: (coupon: Object) => ({
     queryKey: "couponsMutation",
@@ -123,6 +137,15 @@ export default {
     body: payload,
     options: {
       method: "POST",
+      ...DEFAULT_POST_OPTIONS,
+    },
+  }),
+  promoCouponUpdation: (coupon: Object) => ({
+    queryKey: "promoCouponUpdation",
+    url: `/api/promo_coupons/`,
+    body: coupon,
+    options: {
+      method: "PUT",
       ...DEFAULT_POST_OPTIONS,
     },
   }),

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -49,6 +49,7 @@ export const routes = {
     coupons: "coupons/",
     deactivate: "deactivate-coupons/",
     processSheets: "process-coupon-assignment-sheets/",
+    updatePromoCode: "update-promo-code/",
   }),
 
   ecommerceBulk: include("/ecommerce/bulk/", {

--- a/static/js/lib/util.js
+++ b/static/js/lib/util.js
@@ -285,3 +285,15 @@ export const getAppropriateInformationFragment = (state: string) => {
     </React.Fragment>
   );
 };
+
+export const zeroHour = (value) => {
+  if (value instanceof Date) {
+    value.setHours(0, 0, 0, 0);
+  }
+};
+
+export const finalHour = (value) => {
+  if (value instanceof Date) {
+    value.setHours(23, 59, 59, 999);
+  }
+};

--- a/static/js/lib/util_test.js
+++ b/static/js/lib/util_test.js
@@ -27,6 +27,8 @@ import {
   isSuccessResponse,
   isErrorResponse,
   isUnauthorizedResponse,
+  zeroHour,
+  finalHour,
 } from "./util";
 import { makeUserEnrollments } from "../factories/course";
 import {
@@ -380,5 +382,39 @@ describe("utility functions", () => {
       };
       assert.equal(isUnauthorizedResponse(response), expResult);
     });
+  });
+});
+
+describe("zeroHour", () => {
+  it("sets the time to 00:00:00.000 if input is a Date", () => {
+    const date = new Date("2025-06-02T15:45:30.123Z");
+    zeroHour(date);
+
+    assert.strictEqual(date.getUTCHours(), 0);
+    assert.strictEqual(date.getUTCMinutes(), 0);
+    assert.strictEqual(date.getUTCSeconds(), 0);
+    assert.strictEqual(date.getUTCMilliseconds(), 0);
+  });
+
+  it("does nothing if value is not a Date", () => {
+    const notDate = "2025-06-02T15:45:30.123Z";
+    assert.doesNotThrow(() => zeroHour(notDate));
+  });
+});
+
+describe("finalHour", () => {
+  it("sets the time to 23:59:59.999 if input is a Date", () => {
+    const date = new Date("2025-06-02T10:20:30.123Z");
+    finalHour(date);
+
+    assert.strictEqual(date.getUTCHours(), 23);
+    assert.strictEqual(date.getUTCMinutes(), 59);
+    assert.strictEqual(date.getUTCSeconds(), 59);
+    assert.strictEqual(date.getUTCMilliseconds(), 999);
+  });
+
+  it("does nothing if value is not a Date", () => {
+    const notDate = 12345;
+    assert.doesNotThrow(() => finalHour(notDate));
   });
 });


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7310

### Description (What does it do?)
This PR adds the `Update Promo Code` option in the e-commerce admin. Users are required to have `ecommerce | coupon | Can change coupon` permission to access this feature

### Screenshots (if appropriate):

<img width="865" alt="Screenshot 2025-05-19 at 4 02 38 PM" src="https://github.com/user-attachments/assets/67f4de58-24f1-4d76-a4c4-7440057db7db" />

https://github.com/user-attachments/assets/75c91ca5-712e-4a13-98f4-94fef9943644


### How can this be tested?

- Create some promo coupons from [`http://localhost:8053/ecommerce/admin/coupons/`](http://localhost:8053/ecommerce/admin/coupons/)
- From django admin, grant user `ecommerce | coupon | Can change coupon` permission.
- Visit [http://localhost:8053/ecommerce/admin](http://localhost:8053/ecommerce/admin). `Update Promo Coupon` button should start appearing. Click the button.
- On the `Update Promo Coupon` page, select a Promo Coupon to update.
- Change the activation, expiration dates, and products, and validate that the changes are updated successfully.
- Validate that no private product ([reference](https://github.com/mitodl/hq/issues/7310#issuecomment-2873621293)) has been shown in the Picky options.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
