### PR TITLE
chore: remove zendesk chatbot widget and related components

### DIFF
--- a/app.json
+++ b/app.json
@@ -696,14 +696,6 @@
     "WAGTAIL_CACHE_URL": {
       "description": "URL for Wagtail image renditions cache",
       "required": false
-    },
-    "ZENDESK_HELP_WIDGET_ENABLED": {
-      "description": "Enabled/disable state for Zendesk web help widget.",
-      "required": false
-    },
-    "ZENDESK_HELP_WIDGET_KEY": {
-      "description": "Represents the key for Zendesk web help widget.",
-      "required": false
     }
   },
   "keywords": ["Django", "Python", "MIT", "Office of Digital Learning"],

--- a/mitxpro/context_processors.py
+++ b/mitxpro/context_processors.py
@@ -31,8 +31,4 @@ def configuration_context(request):  # noqa: ARG001
             "HUBSPOT_FOOTER_FORM_GUID"
         ),
         "site_name": settings.SITE_NAME,
-        "zendesk_config": {
-            "help_widget_enabled": settings.ZENDESK_CONFIG.get("HELP_WIDGET_ENABLED"),
-            "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),
-        },
     }

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -108,19 +108,6 @@ SECURE_SSL_HOST = get_string(
     "Overrides value from HOST header.",
 )
 
-ZENDESK_CONFIG = {
-    "HELP_WIDGET_ENABLED": get_bool(
-        name="ZENDESK_HELP_WIDGET_ENABLED",
-        default=False,
-        description="Enabled/disable state for Zendesk web help widget.",
-    ),
-    "HELP_WIDGET_KEY": get_string(
-        name="ZENDESK_HELP_WIDGET_KEY",
-        default="8ef9ef96-3317-40a9-8ef6-de0737503caa",
-        description="Represents the key for Zendesk web help widget.",
-    ),
-}
-
 WEBPACK_LOADER = {
     "DEFAULT": {
         "CACHE": not DEBUG,

--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -42,18 +42,7 @@
       content="{{ domain_verification_tag }}"
     />
     {% endif %}
-    <meta name="zd-site-verification" content="o0itxdfh369m1bw4cuz9" />
-    <meta name="zd-site-verification" content="7e22kzikbruclk2jjomono" />
-    {% block extrahead %}
-    {% endblock %}
     {% endspaceless %}
-    {% if zendesk_config.help_widget_enabled and not request.path|startswith:'/certificate/' %}
-    <script
-      defer
-      id="ze-snippet"
-      src="https://static.zdassets.com/ekr/snippet.js?key={{zendesk_config.help_widget_key}}"
-    ></script>
-    {% endif %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
     <div class="main-panel">

--- a/mitxpro/utils.py
+++ b/mitxpro/utils.py
@@ -610,10 +610,6 @@ def get_js_settings(request: HttpRequest):
         "sentry_dsn": remove_password_from_url(settings.SENTRY_DSN),
         "support_email": settings.EMAIL_SUPPORT,
         "site_name": settings.SITE_NAME,
-        "zendesk_config": {
-            "help_widget_enabled": settings.ZENDESK_CONFIG.get("HELP_WIDGET_ENABLED"),
-            "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),
-        },
         "digital_credentials": is_enabled(features.DIGITAL_CREDENTIALS, default=False),
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "is_tax_applicable": is_tax_applicable(request),

--- a/mitxpro/utils_test.py
+++ b/mitxpro/utils_test.py
@@ -486,10 +486,6 @@ def test_get_js_settings(settings, rf, user, mocker):
     settings.EMAIL_SUPPORT = "support@text.com"
     settings.WEBPACK_USE_DEV_SERVER = False
     settings.RECAPTCHA_SITE_KEY = "fake_key"
-    settings.ZENDESK_CONFIG = {
-        "HELP_WIDGET_ENABLED": False,
-        "HELP_WIDGET_KEY": "fake_key",
-    }
     settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS = "test_run1,test_run2"
     mocker.patch(
         "mitol.olposthog.features.is_enabled",
@@ -510,7 +506,6 @@ def test_get_js_settings(settings, rf, user, mocker):
         "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
         "support_email": settings.EMAIL_SUPPORT,
         "site_name": settings.SITE_NAME,
-        "zendesk_config": {"help_widget_enabled": False, "help_widget_key": "fake_key"},
         "digital_credentials": True,
         "digital_credentials_supported_runs": settings.DIGITAL_CREDENTIALS_SUPPORTED_RUNS,
         "is_tax_applicable": is_tax_applicable(request),

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "react-router-dom": "^4.1.1",
     "react-select": "^3.0.4",
     "react-test-renderer": "^16.8.4",
-    "react-zendesk": "^0.1.5",
     "reactstrap": "^8.0.0",
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",

--- a/static/js/components/forms/CheckoutForm_test.js
+++ b/static/js/components/forms/CheckoutForm_test.js
@@ -43,10 +43,6 @@ describe("CheckoutForm", () => {
     submitCouponStub = sandbox.stub();
     updateProductStub = sandbox.stub();
     isVoucherApplied = false;
-    SETTINGS.zendesk_config = {
-      help_widget_enabled: false,
-      help_widget_key: "fake_key",
-    };
   });
 
   afterEach(() => {

--- a/static/js/containers/pages/CheckoutPage_test.js
+++ b/static/js/containers/pages/CheckoutPage_test.js
@@ -24,10 +24,6 @@ describe("CheckoutPage", () => {
     calcSelectedRunIdsStub = helper.sandbox
       .stub(ecommerceApi, "calcSelectedRunIds")
       .returns({});
-    SETTINGS.zendesk_config = {
-      help_widget_enabled: false,
-      help_widget_key: "fake_key",
-    };
     renderPage = helper.configureHOCRenderer(
       CheckoutPage,
       InnerCheckoutPage,

--- a/static/js/entry/root.js
+++ b/static/js/entry/root.js
@@ -10,11 +10,6 @@ import { AppTypeContext, SPA_APP_CONTEXT } from "../contextDefinitions";
 import * as Sentry from "@sentry/browser";
 // Object.entries polyfill
 import entries from "object.entries";
-// Zendesk react module
-import Zendesk from "react-zendesk";
-
-const ZENDESK_KEY = SETTINGS.zendesk_config.help_widget_key;
-const ZENDESK_ENABLED = SETTINGS.zendesk_config.help_widget_enabled;
 
 require("react-hot-loader/patch");
 /* global SETTINGS:false */
@@ -34,15 +29,8 @@ const store = configureStore();
 
 const rootEl = document.getElementById("container");
 
-const loadZendesk = () => {
-  return <Zendesk zendeskKey={ZENDESK_KEY} />;
-};
-
 const renderApp = (Component) => {
   const history = createBrowserHistory();
-  if (ZENDESK_ENABLED && ZENDESK_KEY) {
-    loadZendesk();
-  }
   ReactDOM.render(
     <AppContainer>
       <AppTypeContext.Provider value={SPA_APP_CONTEXT}>

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -12,10 +12,6 @@ declare type Settings = {
   recaptchaKey: ?string,
   support_email: string,
   site_name: string,
-  zendesk_config: {
-    help_widget_enabled: boolean,
-    help_widget_key: ?string,
-  },
   digital_credentials: boolean,
   digital_credentials_supported_runs: Array<string>,
   is_tax_applicable: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8941,7 +8941,6 @@ __metadata:
     react-router-dom: ^4.1.1
     react-select: ^3.0.4
     react-test-renderer: ^16.8.4
-    react-zendesk: ^0.1.5
     reactstrap: ^8.0.0
     redux: ^3.7.2
     redux-actions: ^2.2.1
@@ -10593,15 +10592,6 @@ __metadata:
     react: ">=16.6.0"
     react-dom: ">=16.6.0"
   checksum: 75602840106aa9c6545149d6d7ae1502fb7b7abadcce70a6954c4b64a438ff1cd16fc77a0a1e5197cdd72da398f39eb929ea06f9005c45b132ed34e056ebdeb1
-  languageName: node
-  linkType: hard
-
-"react-zendesk@npm:^0.1.5":
-  version: 0.1.13
-  resolution: "react-zendesk@npm:0.1.13"
-  dependencies:
-    prop-types: ^15.7.2
-  checksum: f9925da864db78fc0977dbd3e5eeaaed6a792dccc35fcf3f594f4f0f3c1d11e2fd5e939a58b02240c39b71dbf8993308e873e51248dac8263019385bada0d58b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
[#7504](https://github.com/mitodl/hq/issues/7504)

### Description (What does it do?)
This PR removes the Zendesk help widget (chatbot) functionality from the MIT xPRO website to comply with upcoming Zendesk contract changes.

- Changes Made:

    - Removed React component integration (react-zendesk)
    - Removed Django settings and context processors for Zendesk widget
    - Removed template script loading and meta tags
    - Removed package dependencies and environment variables
    - Updated test files to remove Zendesk config references
    
The chatbot widget has been completely removed. Note that direct Zendesk support links in emails, footers, and other components remain unchanged as they are separate from the chatbot functionality.

### How can this be tested?
1. Verify widget is gone: Load any page on the site and confirm the Zendesk chat widget no longer appears
2. Check console errors: Open browser dev tools and ensure no JavaScript errors related to Zendesk
3. Test page functionality: Verify all pages load correctly without the widget interfering
