### PR TITLE
fix: codecov action files error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
 
   javascript-tests:
     runs-on: ubuntu-22.04
@@ -188,4 +188,4 @@ jobs:
       - name: Upload test coverage to CodeCov
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
         with:
-          file: coverage/lcov.info
+          files: coverage/lcov.info


### PR DESCRIPTION
### What are the relevant tickets?
None, It fixes a Codecov warning in CI
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Noticed that Codecov action was throwing a warning in CI. In v5 `file:` has been replaced with `files:`, which can now accept multiple files separated by a comma.
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/654648ec-00f5-4c62-a319-6c44107957dd" />


This PR replaces the `file` key with `files`
<!--- Describe your changes in detail -->


<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Check the codecov action is not throwing the warning.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
