### PR TITLE
feat: add management command to update certificate revisions

### DIFF
--- a/courses/management/commands/test_update_certificate_revision_to_latest.py
+++ b/courses/management/commands/test_update_certificate_revision_to_latest.py
@@ -1,0 +1,94 @@
+import pytest
+from io import StringIO
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from cms.models import CertificatePage
+from courses.factories import CourseRunFactory, CourseRunCertificateFactory, ProgramFactory, ProgramCertificateFactory
+from cms.factories import CertificatePageFactory, CoursePageFactory, ProgramPageFactory
+
+
+@pytest.mark.django_db
+def test_update_certificate_for_course_run():
+    """Test updating certificate revision for a course run."""
+    course_page = CoursePageFactory.create(certificate_page=None)
+    course_run = CourseRunFactory(course=course_page.course)
+    certificate_page = CertificatePageFactory(parent=course_page, live=True)
+    certificate_page.save_revision().publish()
+    cert_page_revision = certificate_page.latest_revision
+
+    # Create a CourseRunCertificate with the initial certificate page revision
+    certificate = CourseRunCertificateFactory(course_run=course_run)
+    assert certificate.certificate_page_revision == cert_page_revision
+
+    # Update the certificate page
+    certificate_page.product_name = "Updated Course Certificate"
+    certificate_page.save_revision().publish()
+    certificate_page.refresh_from_db()
+    new_page_revision = certificate_page.latest_revision
+    assert certificate.certificate_page_revision != new_page_revision
+    
+    out = StringIO()
+    call_command("update_certificate_revision_to_latest", "--course_run_id", str(course_run.id), stdout=out)
+
+    certificate.refresh_from_db()
+    assert certificate.certificate_page_revision == new_page_revision
+    assert f"Successfully updated 1 course run certificate" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_update_certificate_for_program():
+    """Test updating certificate revision for a program."""
+    program = ProgramFactory()
+    program_page = program.page
+    cert_page = program_page.get_children().type(CertificatePage).first().specific
+    cert_page.save_revision().publish()
+    cert_page_revision = cert_page.latest_revision
+
+    # Create a ProgramCertificate with the initial certificate page revision
+    certificate = ProgramCertificateFactory(program=program)
+    assert certificate.certificate_page_revision == cert_page_revision
+
+    # Publish a new revision to simulate update
+    cert_page.product_name = "Updated Program Certificate"
+    cert_page.save_revision().publish()
+    cert_page.refresh_from_db()
+    new_cert_page_revision = cert_page.latest_revision
+    assert certificate.certificate_page_revision != new_cert_page_revision
+
+    # Run the management command
+    out = StringIO()
+    call_command("update_certificate_revision_to_latest", "--program_id", str(program.id), stdout=out)
+
+    # Assert it updated to the latest revision
+    certificate.refresh_from_db()
+    assert certificate.certificate_page_revision == new_cert_page_revision
+    assert "Successfully updated 1 program certificate" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_course_run_not_found_raises():
+    with pytest.raises(CommandError, match="CourseRun with id 9999 does not exist"):
+        call_command("update_certificate_revision_to_latest", "--course_run_id", "9999")
+
+
+@pytest.mark.django_db
+def test_program_not_found_raises():
+    with pytest.raises(CommandError, match="Program with id 9999 does not exist"):
+        call_command("update_certificate_revision_to_latest", "--program_id", "9999")
+
+
+@pytest.mark.django_db
+def test_no_certificates_found_logs_warning_for_course_run():
+    course_run = CourseRunFactory()
+    out = StringIO()
+    call_command("update_certificate_revision_to_latest", "--course_run_id", str(course_run.id), stdout=out)
+    assert "No certificates found for course run" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_no_certificates_found_logs_warning_for_program():
+    program = ProgramFactory()
+    out = StringIO()
+    call_command("update_certificate_revision_to_latest", "--program_id", str(program.id), stdout=out)
+    assert "No certificates found for program" in out.getvalue()

--- a/courses/management/commands/update_certificate_revision_to_latest.py
+++ b/courses/management/commands/update_certificate_revision_to_latest.py
@@ -1,0 +1,84 @@
+from django.core.management.base import BaseCommand, CommandError
+from courses.models import CourseRun, CourseRunCertificate, Program, ProgramCertificate
+from cms.models import CertificatePage
+
+class Command(BaseCommand):
+    """
+    Change the certificate revision to the latest for the specified course run or program.
+    """
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--course_run_id', type=int, help="ID of the course run")
+        group.add_argument('--program_id', type=int, help="ID of the program")
+
+    def handle(self, *args, **options):
+        """Handle command execution"""
+        course_run_id = options.get('course_run_id')
+        program_id = options.get('program_id')
+
+        # Handling CourseRun update
+        if course_run_id:
+            try:
+                course_run = CourseRun.objects.get(id=course_run_id)
+            except CourseRun.DoesNotExist:
+                raise CommandError(f"CourseRun with id {course_run_id} does not exist.")
+
+            certificates = list(CourseRunCertificate.objects.filter(course_run=course_run))
+            if not certificates:
+                self.stdout.write(self.style.WARNING(f"No certificates found for course run {course_run_id}."))
+                return
+
+            latest_revision = (
+                course_run.course.page.get_children()
+                .type(CertificatePage)
+                .live()
+                .order_by('-last_published_at')
+                .first()
+                .latest_revision
+            )
+
+            if not latest_revision:
+                raise CommandError("No live CertificatePage with a published revision found for the course run.")
+
+            for certificate in certificates:
+                certificate.certificate_page_revision = latest_revision
+
+            CourseRunCertificate.objects.bulk_update(certificates, ['certificate_page_revision'])
+
+            self.stdout.write(self.style.SUCCESS(
+                f"Successfully updated {len(certificates)} course run certificate(s) to latest revision."
+            ))
+
+        # Handling Program update
+        elif program_id:
+            try:
+                program = Program.objects.get(id=program_id)
+            except Program.DoesNotExist:
+                raise CommandError(f"Program with id {program_id} does not exist.")
+
+            certificates = list(ProgramCertificate.objects.filter(program=program))
+            if not certificates:
+                self.stdout.write(self.style.WARNING(f"No certificates found for program {program_id}."))
+                return
+
+            latest_revision = (
+                program.page.get_children()
+                .type(CertificatePage)
+                .live()
+                .order_by('-last_published_at')
+                .first()
+                .latest_revision
+            )
+
+            if not latest_revision:
+                raise CommandError("No live CertificatePage with a published revision found for the program.")
+
+            for certificate in certificates:
+                certificate.certificate_page_revision = latest_revision
+
+            ProgramCertificate.objects.bulk_update(certificates, ['certificate_page_revision'])
+
+            self.stdout.write(self.style.SUCCESS(
+                f"Successfully updated {len(certificates)} program certificate(s) to latest revision."
+            ))


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7507

### Description (What does it do?)
This PR adds a management command to change the Course Run or Program certificates revision to latest

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Create a certificate page for a course.
- From Django admin, create some Course Run Certificates entries for different users, choosing the certificate page revision you just created above. Select the test course run for all the certificates. You can also select a different course run and verify the case that the command doesn't update the run that is not specified.
- Make some changes in the certificate page.
- Refresh the certificate page; the changes won't appear as the certificate is on the previous revision.
- Run the management command: `./manage.py update_certificate_revision_to_latest --course_run_id {test_course_run_id}`
- Verify that the certificate is updated to the latest revision.
- Repeat the same for Programs.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
