### PR TITLE
perf: improved update promo coupon performance by fixing N+1 issues

### DIFF
--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -935,11 +935,11 @@ class PromoCouponDetailSerializer(serializers.ModelSerializer):
 
     def get_activation_date(self, instance):
         """Get the activation date of the associated CouponPayment"""
-        return instance.payment.latest_version.activation_date
+        return instance.payment.versions.first().activation_date
 
     def get_expiration_date(self, instance):
         """Get the expiration date of the associated CouponPayment"""
-        return instance.payment.latest_version.expiration_date
+        return instance.payment.versions.first().expiration_date
 
 
 class PromoCouponUpdateSerializer(serializers.Serializer):

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -918,13 +918,9 @@ class PromoCouponDetailSerializer(serializers.ModelSerializer):
         """
         eligibility_qs = instance.couponeligibility_set.all()
 
-        # Only apply the filter if is_private is explicitly False
-        if self.context.get("is_private") is False:
-            eligibility_qs = eligibility_qs.filter(product__is_private=False)
-
         return [
             {
-                "coupon_code": eligibility.coupon.coupon_code,
+                "coupon_code": instance.coupon_code,
                 "product_id": eligibility.product.id,
                 "program_run_id": eligibility.program_run.id
                 if eligibility.program_run

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -593,7 +593,7 @@ def test_serialize_program_run():
 
 
 def test_promo_coupon_get_serializer():
-    """Test PromoCouponDetailSerializer with different product visibility"""
+    """Test PromoCouponDetailSerializer shows correct data"""
     payment = CouponPaymentFactory(name="Test Payment")
     version = CouponPaymentVersionFactory.create(
         payment=payment,
@@ -601,11 +601,9 @@ def test_promo_coupon_get_serializer():
         expiration_date=now_in_utc() + timedelta(days=30),
     )
     coupon = CouponFactory.create(coupon_code="TESTCODE123", payment=payment)
-    public_product = ProductFactory.create(is_private=False)
-    private_product = ProductFactory.create(is_private=True)
-    CouponEligibilityFactory.create(coupon=coupon, product=public_product)
-    CouponEligibilityFactory.create(coupon=coupon, product=private_product)
-    serializer = PromoCouponDetailSerializer(coupon, context={"is_private": False})
+    product = ProductFactory.create(is_private=False)
+    CouponEligibilityFactory.create(coupon=coupon, product=product)
+    serializer = PromoCouponDetailSerializer(coupon)
     data = serializer.data
 
     assert data["coupon_code"] == "TESTCODE123"
@@ -613,12 +611,7 @@ def test_promo_coupon_get_serializer():
     assert data["activation_date"] == version.activation_date
     assert data["expiration_date"] == version.expiration_date
     assert len(data["eligibility"]) == 1
-    assert data["eligibility"][0]["product_id"] == public_product.id
-
-    # If is_private is not provided, it returns all eligibilities
-    serializer = PromoCouponDetailSerializer(coupon)
-    data = serializer.data
-    assert len(data["eligibility"]) == 2
+    assert data["eligibility"][0]["product_id"] == product.id
 
 
 def test_promo_coupon_update_serializer():

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -353,7 +353,7 @@ class PromoCouponView(APIView):
                 Prefetch(
                     "payment__versions",
                     queryset=CouponPaymentVersion.objects.order_by("-created_on"),
-                )
+                ),
             )
             .order_by("coupon_code")
         )

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -349,6 +349,10 @@ class PromoCouponView(APIView):
                     queryset=CouponEligibility.objects.filter(
                         product__is_private=False
                     ).select_related("product", "program_run"),
+                ),
+                Prefetch(
+                    "payment__versions",
+                    queryset=CouponPaymentVersion.objects.order_by("-created_on"),
                 )
             )
             .order_by("coupon_code")

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1780,8 +1780,8 @@ def test_promocoupon_get_view_returns_only_latest_promo_versions(admin_drf_clien
     )
 
     coupon = CouponFactory(payment=payment)
-    product = ProductFactory()
-    CouponEligibilityFactory(coupon=coupon, product=product)
+    CouponEligibilityFactory(coupon=coupon, product=ProductFactory(is_private=False))
+    CouponEligibilityFactory(coupon=coupon, product=ProductFactory(is_private=True))
 
     response = admin_drf_client.get(reverse("promo_coupons_api"))
 
@@ -1789,6 +1789,7 @@ def test_promocoupon_get_view_returns_only_latest_promo_versions(admin_drf_clien
     assert len(response.data) == 1
     assert response.data[0]["coupon_code"] == coupon.coupon_code
     assert response.data[0]["activation_date"] == payment_version.activation_date
+    assert len(response.data[0]["eligibility"]) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7310

### Description (What does it do?)
This PR fixes the N+1 query issues in the update promo coupon feature to improve the performance.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- On the master branch, open http://localhost:8053/ecommerce/admin/update-promo-code/.
- Check the web container logs; you should see N+1 query warnings.
- Visit http://localhost:8053/silk/requests/ and inspect the query count for the /api/promo_coupons/ request.
- Switch to this branch and reload the [update promo code](http://localhost:8053/ecommerce/admin/update-promo-code/) page.
- You should no longer see any N+1 query warnings in the logs.
- The number of queries for the /api/promo_coupons/ endpoint should also be reduced.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
