### PR TITLE
fix: reset date field value when user deletes the input string

### DIFF
--- a/static/js/components/input/FormikDatePicker.js
+++ b/static/js/components/input/FormikDatePicker.js
@@ -59,7 +59,10 @@ const FormikDatePicker = ({
     const { value } = e.target;
     setInputValue(value);
     setFieldTouched(name, true);
-
+    if (value.length === 0) {
+      setFieldValue(name, null); // Reset field if input is cleared
+      return;
+    }
     if (value.length === 10) {
       const parsedDate = parse(value, dateFormat, new Date());
       if (!isNaN(parsedDate.getTime())) {


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR adds the code to reset the date field in ecommerce admin form when user removes the input string sompletely

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Visit the ecommerce admin and navigate to the update promo coupon form.
- Select a date using the date-picker.
- Clear the input field.
- The date in the DayPicker should reset.
- Verify the same for coupon creation form

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
