### PR TITLE
fix: add max-redemptions validation to avoid server error

### DIFF
--- a/static/js/components/forms/CouponForm.js
+++ b/static/js/components/forms/CouponForm.js
@@ -72,7 +72,7 @@ const couponValidations = yup.object().shape({
     then: (schema) =>
       schema
         .min(1, "Must be at least ${min}")
-        .max(1000000000, "Must be at most ${max}")
+        .max(2147483647, "Must be at most ${max}") // max value for a 32-bit signed integer
         .required("Number required"),
   }),
   coupon_code: yup.string().when("coupon_type", {

--- a/static/js/components/forms/CouponForm_test.js
+++ b/static/js/components/forms/CouponForm_test.js
@@ -283,7 +283,7 @@ describe("CouponForm", () => {
     ["max_redemptions", "", "Number required"],
     ["max_redemptions", "-10", "Must be at least 1"],
     ["max_redemptions", "10000", ""],
-    ["max_redemptions", "100000000000", "Must be at most 1000000000"],
+    ["max_redemptions", "100000000000", "Must be at most 2147483647"],
   ].forEach(([name, value, errorMessage]) => {
     it(`validates the field name=${name}, value="${value}" and expects error=${JSON.stringify(
       errorMessage,


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/6745503284/?alert_rule_id=15045794&alert_type=issue&notification_uuid=2ff17801-8e44-4635-8d9a-5f3cb9b8aebf&project=1413655&referrer=slack

### Description (What does it do?)
This PR adds Formik validations for max-redemptions to prevent passing excessively large values for this field

### Screenshots (if appropriate):
<img width="507" height="131" alt="Screenshot 2025-07-14 at 6 56 38 PM" src="https://github.com/user-attachments/assets/b38e1a80-a89d-4bcc-b038-96ec30dba346" />

### How can this be tested?
- Visit the coupon creation form page: http://localhost:8053/ecommerce/admin/coupons/
- Select the `Promo` coupon.
- In the `Maximum redemptions` field, add a value larger than `1000000000` and focus out of the input box.
- You should see the validation error in the screenshot above.
- Click the `Create coupons` button after filling in the other details.
- The form won't submit.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
