### PR TITLE
feat: enable display_mit_seal for all certificates

### DIFF
--- a/cms/migrations/0083_enable_display_seal_for_all_certificates.py
+++ b/cms/migrations/0083_enable_display_seal_for_all_certificates.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+from django.db import models
+
+
+def enable_display_mit_seal(apps, schema_editor):
+    """Enable the display of the MIT seal on all CertificatePage instances."""
+    CertificatePage = apps.get_model('cms', 'CertificatePage')
+
+    for page in CertificatePage.objects.all():
+        page.display_mit_seal = True
+        revision = page.save_revision()
+        revision.publish()
+
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0082_alter_certificatepage_display_mit_seal'),
+    ]
+
+    operations = [
+        migrations.RunPython(enable_display_mit_seal),
+        migrations.AlterField(
+            model_name='certificatepage',
+            name='display_mit_seal',
+            field=models.BooleanField(
+                default=True,
+                verbose_name='Display MIT seal',
+                help_text='Show the MIT seal when a Partner logo is present. If no Partner logo is set, the seal will be shown by default.',
+            ),
+        ),
+    ]

--- a/cms/models.py
+++ b/cms/models.py
@@ -2410,7 +2410,7 @@ class CertificatePage(CourseProgramChildPage):
     )
 
     display_mit_seal = models.BooleanField(
-        default=False,
+        default=True,
         verbose_name="Display MIT seal",
         help_text="Show the MIT seal when a Partner logo is present. If no Partner logo is set, the seal will be shown by default.",
     )

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -142,7 +142,7 @@
             >Massachusetts Institute of Technology</span
           >
           {% endif %}
-          {% if page.partner_logo == None or page.partner_logo_placement == None or page.display_mit_seal %}
+          {% if page.display_mit_seal %}
           <div class="institute-logo">
             <img
               src="{% static 'images/certificates/certificate-logo.png' %}"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7507

### Description (What does it do?)

This PR updates the default value of the display_mit_seal toggle to True and includes a data migration to enable it for all existing course certificates. As a result, the MIT seal will now be displayed by default unless the flag is explicitly disabled on the certificate.

Additionally, the `update_certificate_revision_to_latest` management command now supports a `--all` argument. When used, it updates the certificate page revision to the latest for all course runs and programs.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Steps to test the migration and management command:

- Before applying the migration, create 2–3 CertificatePage instances for different courses with display_mit_seal set to False.
- From the Django admin, create corresponding certificates and verify that the MIT seal is not visible.
- Run the migration using: ./manage.py migrate. This should create a new revision for each `CertificatePage` with display_mit_seal=True.
- Then run the management command to update all certificates to the latest revision: `./manage.py update_certificate_revision_to_latest --all`
- Finally, verify that the MIT seal is now visible on all certificate pages.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
