### PR TITLE
fix: condition of is_external attribute change in course

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -628,7 +628,7 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
         if original.is_external == self.is_external:
             return
 
-        if getattr(self, "coursepage", None):
+        if getattr(self, "coursepage", None) and self.is_external:
             raise ValidationError(
                 {
                     "is_external": (
@@ -636,7 +636,7 @@ class Course(TimestampedModel, PageProperties, ValidateOnSaveMixin):
                     )
                 }
             )
-        elif getattr(self, "externalcoursepage", None):
+        elif getattr(self, "externalcoursepage", None) and not self.is_external:
             raise ValidationError(
                 {
                     "is_external": (


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8197

### Description (What does it do?)
This PR updates the condition of `is_external` in the course to allow updation of this field for bad course data.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Checkout to master branch.
- Create a test course from django admin with `is_external=True`.
- Comment [these lines](https://github.com/mitodl/mitxpro/blob/master/cms/forms.py#L62-L66) from the code.
- Create a Course Page from CMS for the course created above.
- Change the course is_external to False and save, you will see a Validation error.
- Now checkout to this branch try to save again. This time, the course will be saved without any issues.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
