### PR TITLE
fix: add course key validation and invalid course tracking

### DIFF
--- a/courses/constants.py
+++ b/courses/constants.py
@@ -39,3 +39,5 @@ COURSE_BG_IMG_WAGTAIL_FILL = "fill-{}x{}".format(*COURSE_BG_IMG_W_H)
 
 COURSE_BG_IMG_MOBILE_W_H = (1024, 350)
 COURSE_BG_IMG_MOBILE_WAGTAIL_FILL = "fill-{}x{}".format(*COURSE_BG_IMG_MOBILE_W_H)
+
+COURSE_KEY_PATTERN = r"^course-v1:[^+]+\+[^+]+\+[^+]+$"

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -347,16 +347,16 @@ def test_sync_course_runs(
         mock_course_list.get_courses.assert_not_called()
     elif test_scenario == "invalid_course_keys":
         valid_course_keys = [
-            c["courseware_id"]
-            for c in local_data
-            if re.match(COURSE_KEY_PATTERN, c["courseware_id"])
+            data["courseware_id"]
+            for data in local_data
+            if re.match(COURSE_KEY_PATTERN, data["courseware_id"])
         ]
         mock_course_list.get_courses.assert_called_once_with(
             course_keys=valid_course_keys
         )
     elif not api_error:
         mock_course_list.get_courses.assert_called_once_with(
-            course_keys=[c["courseware_id"] for c in local_data]
+            course_keys=[data["courseware_id"] for data in local_data]
         )
     else:
         mock_course_list.get_courses.assert_called_once()

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -4,6 +4,7 @@ Tests for signals
 
 from datetime import timedelta, datetime
 import pytz
+import re
 
 import factory
 import pytest
@@ -11,6 +12,7 @@ from edx_api.course_detail import CourseDetail
 from requests.exceptions import HTTPError
 from requests import Response
 
+from courses.constants import COURSE_KEY_PATTERN
 from courses.factories import (
     CourseFactory,
     CourseRunFactory,
@@ -293,6 +295,24 @@ def test_generate_program_certificate_success(user, program):
             None,
             None,
         ),
+        (
+            "invalid_course_keys",
+            [
+                make_api_course("course-v1:edX+DemoX+2020_T1", "Updated Course 1"),
+                make_api_course("course-v1:edX+DemoX+2020_T2", "Updated Course 2"),
+            ],
+            [
+                make_local_course("course-v1:edX+DemoX+2020_T1", "Old Course 1"),
+                make_local_course("invalid-course-key", "Invalid Course 1"),
+                make_local_course("course-v1:missing+part", "Invalid Course 2"),
+                make_local_course("course-v1:edX+DemoX+2020_T2", "Old Course 2"),
+            ],
+            2,
+            0,
+            0,
+            None,
+            None,
+        ),
     ],
 )
 def test_sync_course_runs(
@@ -325,6 +345,15 @@ def test_sync_course_runs(
 
     if test_scenario == "empty_list":
         mock_course_list.get_courses.assert_not_called()
+    elif test_scenario == "invalid_course_keys":
+        valid_course_keys = [
+            c["courseware_id"]
+            for c in local_data
+            if re.match(COURSE_KEY_PATTERN, c["courseware_id"])
+        ]
+        mock_course_list.get_courses.assert_called_once_with(
+            course_keys=valid_course_keys
+        )
     elif not api_error:
         mock_course_list.get_courses.assert_called_once_with(
             course_keys=[c["courseware_id"] for c in local_data]


### PR DESCRIPTION
### What are the relevant tickets?
[#7160](https://github.com/mitodl/hq/issues/7160)

### Description (What does it do?)

edX API rejects malformed course keys with 400 errors. Many courses in xPRO have invalid courseware IDs that don't follow the required format `course-v1:ORGANIZATION+COURSE_ID+RUN_ID`. This PR adds the validation to filter out malformed course keys before making API calls, preventing 400 errors and allowing the sync to continue with valid courses.

### How can this be tested?

1. Add a course with an invalid course key via django-admin e.g. `course-v1:NotMITx-0.000x-4T2029`
2. Run management command: Execute `python manage.py sync_courseruns` to test bulk sync functionality
    - Verify all valid course keys are sent to edX and some courses are updated 
    - Verify invalid course keys are logged for identification
3. Check Celery task: Trigger the `sync_courseruns_data` task and verify it also skips the invalid course

