### PR TITLE
fix: pass service worker for course sync

### DIFF
--- a/courses/utils.py
+++ b/courses/utils.py
@@ -4,6 +4,7 @@ Utilities for courses/certificates
 
 import logging
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 import re
@@ -294,7 +295,10 @@ def sync_course_runs(runs):
 
     try:
         received_course_ids = set()
-        for course_detail in api_client.get_courses(course_keys=valid_course_keys):
+        for course_detail in api_client.get_courses(
+            course_keys=valid_course_keys,
+            username=settings.OPENEDX_SERVICE_WORKER_USERNAME,
+        ):
             received_course_ids.add(course_detail.course_id)
 
             if course_detail.course_id not in runs_by_courseware_id:

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -352,11 +352,11 @@ def test_sync_course_runs(
             if re.match(COURSE_KEY_PATTERN, data["courseware_id"])
         ]
         mock_course_list.get_courses.assert_called_once_with(
-            course_keys=valid_course_keys
+            course_keys=valid_course_keys, username=None
         )
     elif not api_error:
         mock_course_list.get_courses.assert_called_once_with(
-            course_keys=[data["courseware_id"] for data in local_data]
+            course_keys=[data["courseware_id"] for data in local_data], username=None
         )
     else:
         mock_course_list.get_courses.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
[#7160](https://github.com/mitodl/hq/issues/7160)

### Description (What does it do?)
Course List API was returning empty results in RC, causing sync to show "No data received for requested courses" warnings for valid courses. This was because Courselist API requires username parameter for course access permissions.

This PR adds `username=settings.OPENEDX_SERVICE_WORKER_USERNAME` to the `get_courses()` call.

Note: This was working locally because the local edX instance had different API configuration/permissions than RC.

### How can this be tested?

1. Run management command: Execute `python manage.py sync_courseruns` to test bulk sync functionality
2. Test specific course: Run `python manage.py sync_courseruns --run <courseware_id>` to test single course sync
3. Check Celery task: Trigger the `sync_courseruns_data` task and verify it uses bulk sync
4. Importantly, Should sync courses in RC 
