### PR TITLE
feat: prevent certificate creation when no cms page or certificate page

### DIFF
--- a/courses/management/commands/update_certificate_revision_to_latest.py
+++ b/courses/management/commands/update_certificate_revision_to_latest.py
@@ -10,17 +10,27 @@ class Command(BaseCommand):
     Change the certificate revision to the latest for the specified course run or program.
     """
 
+    help = """
+    Updates certificate revisions to the latest for a course run or program.
+    By default, only certificates without a revision are updated.
+    Use --all to update all certificates.
+    NOTE: Updating all certificates may result in updating legacy/old certificates.
+    """
+
     def add_arguments(self, parser):
         group = parser.add_mutually_exclusive_group(required=True)
         group.add_argument("--course-run-id", type=int, help="ID of the course run")
         group.add_argument("--program-id", type=int, help="ID of the program")
+        parser.add_argument(
+            "--all", action="store_true", help="Update all certificates"
+        )
 
     def update_certificates(self, model_cls, filter_kwargs, parent_page, label):
         """
         Update the certificate revisions for the specified model class and filter criteria.
 
         Args:
-            model_cls (CourseRunCertificate | ProgramCertificate): certificate model class
+            model_cls (type[CourseRunCertificate] | type[ProgramCertificate]): certificate model class
             filter_kwargs (dict): filter arguments to filter the certificates
             parent_page (Page): ProgramPage or CoursePage object
             label (str): for logging
@@ -56,6 +66,18 @@ class Command(BaseCommand):
         """Handle the command."""
         course_run_id = options.get("course_run_id")
         program_id = options.get("program_id")
+        filter_kwargs = {"certificate_page_revision__isnull": True}
+
+        if options.get("all"):
+            confirm = input(
+                self.style.WARNING(
+                    "Do you want to update all certificates?\nNOTE: It will update certificate revision to latest revision for all certificates.\nPlease confirm with Y/N: "
+                )
+            )
+            if confirm.strip().lower() != "y":
+                self.stdout.write(self.style.ERROR("Operation cancelled."))
+                return
+            filter_kwargs = {}
 
         if course_run_id:
             course_run = CourseRun.objects.filter(id=course_run_id).first()
@@ -64,7 +86,7 @@ class Command(BaseCommand):
 
             self.update_certificates(
                 model_cls=CourseRunCertificate,
-                filter_kwargs={"course_run": course_run},
+                filter_kwargs={"course_run": course_run, **filter_kwargs},
                 parent_page=course_run.course.page,
                 label=f"course run {course_run_id}",
             )
@@ -76,7 +98,7 @@ class Command(BaseCommand):
 
             self.update_certificates(
                 model_cls=ProgramCertificate,
-                filter_kwargs={"program": program},
+                filter_kwargs={"program": program, **filter_kwargs},
                 parent_page=program.page,
                 label=f"program {program_id}",
             )

--- a/courses/models.py
+++ b/courses/models.py
@@ -1126,6 +1126,22 @@ class CourseRunCertificate(TimestampedModel, BaseCertificate):
 
         # If user has not selected a revision, Let create the certificate since we have made the revision nullable
         if not self.certificate_page_revision:
+            if not self.course_run.course.page:
+                raise ValidationError(
+                    {
+                        "course_run": (
+                            "The course run's course is not associated with a course page."
+                        )
+                    }
+                )
+            elif not self.course_run.course.page.certificate_page:
+                raise ValidationError(
+                    {
+                        "course_run": (
+                            "No certificate page is associated with the course run's course."
+                        )
+                    }
+                )
             return
 
         certpage = CertificatePage.objects.filter(
@@ -1205,6 +1221,18 @@ class ProgramCertificate(TimestampedModel, BaseCertificate):
 
         # If user has not selected a revision, Let create the certificate since we have made the revision nullable
         if not self.certificate_page_revision:
+            if not self.program.page:
+                raise ValidationError(
+                    {"program": ("The program is not associated with a program page.")}
+                )
+            elif not self.program.page.certificate_page:
+                raise ValidationError(
+                    {
+                        "program": (
+                            "No certificate page is associated with the program's page."
+                        )
+                    }
+                )
             return
 
         certpage = CertificatePage.objects.filter(

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -55,6 +55,16 @@ def generate_course_certificates():
             0,
             0,
         )
+
+        has_certificate_page = (
+            run.course.page is not None and run.course.page.certificate_page is not None
+        )
+        if not has_certificate_page:
+            log.exception(
+                "Course run %s has no certificate page. Will skip certificate generation.",
+                run,
+            )
+
         for edx_grade, user in edx_grade_user_iter:
             course_run_grade, created, updated = ensure_course_run_grade(
                 user=user, course_run=run, edx_grade=edx_grade, should_update=True
@@ -64,6 +74,9 @@ def generate_course_certificates():
                 created_grades_count += 1
             elif updated:
                 updated_grades_count += 1
+
+            if not has_certificate_page:
+                continue
 
             _, created, deleted = process_course_run_grade_certificate(
                 course_run_grade=course_run_grade

--- a/courses/tasks_test.py
+++ b/courses/tasks_test.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import pytest
 from django.utils.timezone import now
 
+from cms.models import CertificatePage
 from users.factories import UserFactory
 from courses.factories import CourseRunFactory, PlatformFactory
 from courses.sync_external_courses.external_course_sync_api import (
@@ -57,7 +58,8 @@ def test_task_sync_external_course_runs(mocker, settings):
     )
 
 
-def test_task_generate_course_certificates(mocker):
+@pytest.mark.parametrize("has_cert_page", [True, False])
+def test_task_generate_course_certificates(mocker, has_cert_page):
     """Test generate_course_certificates calls the right API functionality making sure external courses are filtered out."""
 
     class MockEdxGrade:
@@ -89,11 +91,17 @@ def test_task_generate_course_certificates(mocker):
         size=3, end_date=now() - timedelta(days=2), force_insert=True
     )
 
+    if not has_cert_page:
+        CertificatePage.objects.all().delete()
+
     generate_course_certificates.delay()
 
     mock_get_edx_grades.assert_called()
     mock_ensure_grades.assert_called()
-    mock_process_grades.assert_called()
+    if has_cert_page:
+        mock_process_grades.assert_called()
+    else:
+        mock_process_grades.assert_not_called()
 
     assert mock_get_edx_grades.call_count == len(course_runs)
     for run in course_runs:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8224

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR enhances certificate creation to avoid bad data.

- Updates `courses/management/commands/sync_grades_and_certificates.py` to update all certificates OR certificates with missing revisions.
- Updates certificate model validations
- Updates the certificate generation task and command to create certificates when there are CMS and certificate pages.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
