### PR TITLE
fix: watch now video popup

### DIFF
--- a/mitxpro/templates/base.html
+++ b/mitxpro/templates/base.html
@@ -42,6 +42,8 @@
       content="{{ domain_verification_tag }}"
     />
     {% endif %}
+    {% block extrahead %}
+    {% endblock %}
     {% endspaceless %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8543

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes watch now pop up on homepage. Block extrahead was removed unintentionally in https://github.com/mitodl/mitxpro/commit/4ff84c6eea13ca788ee330de3084556aee25aecc that caused it.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
<img width="1894" height="906" alt="Screenshot 2025-09-16 at 1 19 38 PM" src="https://github.com/user-attachments/assets/c7b375b6-aa30-48ef-b37c-1d9a8abef02c" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Checkout master branch
- Create a text video section under homepage in CMS
- Notice that the watch now on homepage is not working
- Repeat the steps with this branch and restart the web.