### PR TITLE
config: call create cache table in configure_instance

### DIFF
--- a/mitxpro/management/commands/configure_instance.py
+++ b/mitxpro/management/commands/configure_instance.py
@@ -163,6 +163,11 @@ class Command(BaseCommand):
         call_command("seed_data")
         self.stdout.write(self.style.SUCCESS("Seed Data Created\n\n"))
 
+        # Step 4: create cache table
+        self.stdout.write(self.style.SUCCESS("Creating cache table..."))
+        call_command("createcachetable")
+        self.stdout.write(self.style.SUCCESS("Cache table created.\n\n"))
+
         # Print OAuth2 app details at the end of the file for user convenience
         # This allows the user to access their client ID and secret without needing to scroll up,
         # making it easily accessible after the script completes execution.


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
When setting up a fresh instance of xPRO, the error shown in the screenshot occurs. This is resolved by running the `createcachetable` command. To avoid having to run it manually, we should include this step in the `configure_instance` command.

<img width="1789" height="966" alt="Screenshot 2025-09-19 at 2 55 34 PM" src="https://github.com/user-attachments/assets/c9cb9a93-b16d-46ad-8f61-12ef262f32e0" />


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
