### PR TITLE
Create /static/hash.txt file on production builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,9 @@ FROM runtime AS production
 COPY --from=node_builder --chown=mitodl:mitodl /src/static /src/static
 COPY --from=node_builder --chown=mitodl:mitodl /src/webpack-stats.json /src/webpack-stats.json
 
+ARG GIT_REF
+RUN echo "$GIT_REF" >> /src/static/hash.txt
+
 from builder as dev
 
 RUN uv sync --locked --dev


### PR DESCRIPTION
### Description (What does it do?)
Adds a GIT_REF build argument to the xpro dockerfile. This argument will be populated automatically by the CI/CD pipeline (see: https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py#L264-L281)

When set, this argument will result in a /static/hash.txt file being added to the docker image.
