### PR TITLE
fix: pass the passed object Ids to the batch upsert task

### DIFF
--- a/hubspot_xpro/management/commands/sync_db_to_hubspot.py
+++ b/hubspot_xpro/management/commands/sync_db_to_hubspot.py
@@ -41,6 +41,7 @@ class Command(BaseCommand):
             ContentType.objects.get_for_model(User).model,
             User._meta.app_label,  # noqa: SLF001
             create=self.create,
+            object_ids=self.object_ids,
         )
         self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()
@@ -60,6 +61,7 @@ class Command(BaseCommand):
             ContentType.objects.get_for_model(Product).model,
             Product._meta.app_label,  # noqa: SLF001
             create=self.create,
+            object_ids=self.object_ids,
         )
         self.stdout.write(f"  Task id is {task.id}")
         start = now_in_utc()


### PR DESCRIPTION
### What are the relevant tickets?
None. Noticed this while working on https://github.com/mitodl/hq/issues/10669

### Description (What does it do?)
This pull request makes a small update to the `sync_db_to_hubspot.py` management command to support syncing only specific objects when syncing contacts or products. The change ensures that the `object_ids` parameter is passed to the relevant sync tasks.

- Added support for passing the `object_ids` parameter to both the `sync_contacts` and `sync_products` methods, enabling selective syncing of objects. 

### How can this be tested?
- If you run the command `sync_db_to_hubspot create/update --contacts/--products --ids 1 2 3` 
- The command should only process the provided IDs and not the whole unsynced model
