### PR TITLE
fix: filter empty rows in get_data_rows_after_start to prevent ValueError on pagination boundary

### DIFF
--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -350,7 +350,9 @@ def get_data_rows_after_start(
             **kwargs,
         )
         request_count += 1
-        yield from values
+        for row in values:
+            if any(cell.strip() for cell in row):
+                yield row
         start_row = end_row + 1
 
 

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -350,6 +350,9 @@ def get_data_rows_after_start(
             **kwargs,
         )
         request_count += 1
+        # Filter out empty trailing rows that pygsheets fails to strip when
+        # returnas="matrix" (its include_tailing_empty_rows flag is a no-op
+        # for matrix mode). Only trailing empty rows are expected here.
         for row in values:
             if any(cell.strip() for cell in row):
                 yield row

--- a/sheets/utils.py
+++ b/sheets/utils.py
@@ -354,7 +354,7 @@ def get_data_rows_after_start(
         # returnas="matrix" (its include_tailing_empty_rows flag is a no-op
         # for matrix mode). Only trailing empty rows are expected here.
         for row in values:
-            if any(cell.strip() for cell in row):
+            if row[0].strip():
                 yield row
         start_row = end_row + 1
 

--- a/sheets/utils_test.py
+++ b/sheets/utils_test.py
@@ -51,6 +51,34 @@ def test_get_data_rows(mocker):
     assert data_rows == non_header_rows
 
 
+def test_get_data_rows_after_start_filters_empty_rows(mocker):
+    """get_data_rows_after_start should filter out empty trailing rows returned by the API"""
+    page_size = 2
+    data_rows = [
+        ["1", "data1"],
+        ["2", "data2"],
+    ]
+    empty_row = ["", ""]
+    mock_worksheet = mocker.MagicMock(spec=Worksheet)
+    mock_worksheet.get_values.side_effect = [
+        # First page: full page of data rows
+        data_rows,
+        # Second page: one empty row (pagination boundary triggers extra fetch)
+        [empty_row],
+    ]
+    result = list(
+        utils.get_data_rows_after_start(
+            mock_worksheet,
+            start_row=1,
+            start_col=1,
+            end_col=2,
+            page_size=page_size,
+        )
+    )
+    assert result == data_rows
+    assert mock_worksheet.get_values.call_count == 2
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "use_sheet_id, value, force, sheet_modified_offset, existing_modified_offset, expect_error, force_processing",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10892

### Description (What does it do?)
See the Root Cause Analysis in this comment: https://github.com/mitodl/hq/issues/10892#issuecomment-4236155189

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Create a sheet with exactly 50 requests
- Verify that the issue occurs on the master branch when running: docker compose exec web python manage.py process_deferral_requests
- Verify that it works fine on this branch 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
