### PR TITLE
Configure bumpver for Concourse release pipeline

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -26,7 +26,7 @@ from redbeat import RedBeatScheduler
 from mitxpro.celery_utils import OffsettingSchedule
 from mitxpro.sentry import init_sentry
 
-VERSION = "0.193.1"
+VERSION = "2026.4.16.1"
 
 env.reset()
 

--- a/mitxpro/settings_test.py
+++ b/mitxpro/settings_test.py
@@ -2,11 +2,12 @@
 Validate that our settings functions work
 """
 
+import re
 import sys
+import tomllib
 from types import SimpleNamespace
 
 import pytest
-import semantic_version
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from mitol.common import envs
@@ -158,13 +159,6 @@ def test_db_ssl_enable(monkeypatch, settings_sandbox):
     assert settings_vars["DATABASES"]["default"]["OPTIONS"] == {"sslmode": "require"}
 
 
-def test_semantic_version(settings):
-    """
-    Verify that we have a semantic compatible version.
-    """
-    semantic_version.Version(settings.VERSION)
-
-
 def test_server_side_cursors_disabled(settings_sandbox):
     """DISABLE_SERVER_SIDE_CURSORS should be true by default"""
     settings_vars = settings_sandbox.get()
@@ -179,3 +173,16 @@ def test_server_side_cursors_enabled(settings_sandbox):
     assert (
         settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"] is False
     )
+
+
+def test_bump_my_version_format(settings):
+    """Verify VERSION is in sync with pyproject.toml and matches a version format."""
+    with open("pyproject.toml", "rb") as f:  # noqa: PTH123
+        pyproject = tomllib.load(f)
+    version_pattern = pyproject["tool"]["bumpversion"]["parse"]
+    package_version = pyproject["project"]["version"]
+    assert package_version == settings.VERSION
+    semver_pattern = r"[0-9]+\.[0-9]+\.[0-9]+"
+    assert re.fullmatch(version_pattern, settings.VERSION) or re.fullmatch(
+        semver_pattern, settings.VERSION
+    ), f'VERSION "{settings.VERSION}" does not match calver or semver format'

--- a/mitxpro/settings_test.py
+++ b/mitxpro/settings_test.py
@@ -2,11 +2,12 @@
 Validate that our settings functions work
 """
 
+import re
 import sys
+import tomllib
 from types import SimpleNamespace
 
 import pytest
-import semantic_version
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from mitol.common import envs
@@ -155,11 +156,18 @@ def test_db_ssl_enable(monkeypatch, settings_sandbox):
     assert settings_vars["DATABASES"]["default"]["OPTIONS"] == {"sslmode": "require"}
 
 
-def test_semantic_version(settings):
+def test_bump_my_version_format(settings):
     """
-    Verify that we have a semantic compatible version.
+    Verify that VERSION matches the bump-my-version calver format.
     """
-    semantic_version.Version(settings.VERSION)
+    with open("pyproject.toml", "rb") as f:  # noqa: PTH123
+        pyproject = tomllib.load(f)
+
+    version_pattern = pyproject["tool"]["bumpversion"]["parse"]
+    package_version = pyproject["project"]["version"]
+
+    assert settings.VERSION == package_version
+    assert re.fullmatch(version_pattern, settings.VERSION)
 
 
 def test_server_side_cursors_disabled(settings_sandbox):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mitxpro"
-version = "0.1.0"
+version = "0.194.2"
 description = "MITx Pro"
 authors = [{ name = "MIT ODL" }]
 requires-python = ">=3.13,<4"
@@ -157,3 +157,36 @@ env = [
     "WAGTAIL_CACHE_URL=",
     "POSTHOG_ENABLED=True",
 ]
+
+[tool.bumpversion]
+commit = false
+tag = false
+parse = "(?P<release>(?:[1-9][0-9]{3})\\.(?:1[0-2]|[1-9])\\.(?:3[0-1]|[12][0-9]|[1-9]))\\.(?P<build>\\d+)"
+serialize = ["{release}.{build}"]
+
+[tool.bumpversion.parts.release]
+calver_format = "{YYYY}.{MM}.{DD}"
+
+[tool.bumpversion.parts.build]
+first_value = "1"
+
+[[tool.bumpversion.files]]
+filename = "mitxpro/settings.py"
+search = 'VERSION = "{current_version}"'
+replace = 'VERSION = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+search = """
+name = "mitxpro"
+version = "{current_version}"
+source = {{ virtual = "." }}"""
+replace = """
+name = "mitxpro"
+version = "{new_version}"
+source = {{ virtual = "." }}"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mitxpro"
-version = "0.1.0"
+version = "2026.4.16.1"
 description = "MITx Pro"
 authors = [{ name = "MIT ODL" }]
 requires-python = ">=3.13,<4"
@@ -15,14 +15,14 @@ dependencies = [
     "Pillow==10.4.0",
     "PyNaCl==1.6.2",
     "beautifulsoup4==4.8.2",
-    "boto3==1.42.88",
-    "celery==5.6.3",
+    "boto3==1.42.73",
+    "celery==5.6.2",
     "celery-redbeat==2.3.3",
     "dj-database-url==3.1.2",
     "django==4.2.30",
     "django-anymail[mailgun]==14.0",
     "django-filter>=23.4,<24",
-    "django-hijack==3.7.7",
+    "django-hijack==3.7.6",
     "django-ipware==7.0.1",
     "django-oauth-toolkit==1.7.1",
     "django-redis>=6.0.0,<7",
@@ -97,5 +97,38 @@ package = false
 no-binary-package = ["lxml", "xmlsec"]
 
 [build-system]
-requires = ["uv_build>=0.11.6,<0.12.0"]
+requires = ["uv_build>=0.10.0,<0.11.0"]
 build-backend = "uv_build"
+
+[tool.bumpversion]
+commit = false
+tag = false
+parse = "(?P<release>(?:[1-9][0-9]{3})\\.(?:1[0-2]|[1-9])\\.(?:3[0-1]|[12][0-9]|[1-9]))\\.(?P<build>\\d+)"
+serialize = ["{release}.{build}"]
+
+[tool.bumpversion.parts.release]
+calver_format = "{YYYY}.{MM}.{DD}"
+
+[tool.bumpversion.parts.build]
+first_value = "1"
+
+[[tool.bumpversion.files]]
+filename = "mitxpro/settings.py"
+search = 'VERSION = "{current_version}"'
+replace = 'VERSION = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+search = """
+name = "mitxpro"
+version = "{current_version}"
+source = {{ virtual = "." }}"""
+replace = """
+name = "mitxpro"
+version = "{new_version}"
+source = {{ virtual = "." }}"""

--- a/uv.lock
+++ b/uv.lock
@@ -159,30 +159,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.88"
+version = "1.42.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/bb/7d4435cca6fccf235dd40c891c731bcb9078e815917b57ebadd1e0ffabaf/boto3-1.42.88.tar.gz", hash = "sha256:2d22c70de5726918676a06f1a03acfb4d5d9ea92fc759354800b67b22aaeef19", size = 113238, upload-time = "2026-04-10T19:41:06.912Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8b/d00575be514744ca4839e7d85bf4a8a3c7b6b4574433291e58d14c68ae09/boto3-1.42.73.tar.gz", hash = "sha256:d37b58d6cd452ca808dd6823ae19ca65b6244096c5125ef9052988b337298bae", size = 112775, upload-time = "2026-03-20T19:39:52.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/2b/8bfddb39a19f5fbc16a869f1a394771e6223f07160dbc0ff6b38e05ea0ae/boto3-1.42.88-py3-none-any.whl", hash = "sha256:2d0f52c971503377e4370d2a83edee6f077ddb8e684366ff38df4f13581d9cfc", size = 140557, upload-time = "2026-04-10T19:41:05.309Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/05/1fcf03d90abaa3d0b42a6bfd10231dd709493ecbacf794aa2eea5eae6841/boto3-1.42.73-py3-none-any.whl", hash = "sha256:1f81b79b873f130eeab14bb556417a7c66d38f3396b7f2fe3b958b3f9094f455", size = 140556, upload-time = "2026-03-20T19:39:50.298Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.96"
+version = "1.42.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/77/2c333622a1d47cf5bf73cdcab0cb6c92addafbef2ec05f81b9f75687d9e5/botocore-1.42.96.tar.gz", hash = "sha256:75b3b841ffacaa944f645196655a21ca777591dd8911e732bfb6614545af0250", size = 15263344, upload-time = "2026-04-24T19:47:05.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/01/b46a3f8b6e9362258f78f1890db1a96d4ed73214d6a36420dc158dcfd221/botocore-1.42.83.tar.gz", hash = "sha256:34bc8cb64b17ac17f8901f073fe4fc9572a5cac9393a37b2b3ea372a83b87f4a", size = 15140337, upload-time = "2026-04-03T19:34:08.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/56/152c3a859ca1b9d77ed16deac3cf81682013677c68cf5715698781fc81bd/botocore-1.42.96-py3-none-any.whl", hash = "sha256:db2c3e2006628be6fde81a24124a6563c363d6982fb92728837cf174bad9d98a", size = 14945920, upload-time = "2026-04-24T19:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/97/0d6f50822dc8c1df7f3eadb0bc6822fc0f98f02287c4efc7c7c88fde129a/botocore-1.42.83-py3-none-any.whl", hash = "sha256:ec0c3ecb3772936ed22a3bdda09883b34858933f71004686d460d829bab39d8e", size = 14818388, upload-time = "2026-04-03T19:34:03.333Z" },
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ wheels = [
 
 [[package]]
 name = "celery"
-version = "5.6.3"
+version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "billiard" },
@@ -226,9 +226,9 @@ dependencies = [
     { name = "tzlocal" },
     { name = "vine" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/a1233943ab5c8ea05fb877a88a0a0622bf47444b99e4991a8045ac37ea1d/celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912", size = 1742243, upload-time = "2026-03-26T12:14:51.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/9d/3d13596519cfa7207a6f9834f4b082554845eb3cd2684b5f8535d50c7c44/celery-5.6.2.tar.gz", hash = "sha256:4a8921c3fcf2ad76317d3b29020772103581ed2454c4c042cc55dcc43585009b", size = 1718802, upload-time = "2026-01-04T12:35:58.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/c9/6eccdda96e098f7ae843162db2d3c149c6931a24fda69fe4ab84d0027eb5/celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6", size = 451235, upload-time = "2026-03-26T12:14:49.491Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/bd/9ecd619e456ae4ba73b6583cc313f26152afae13e9a82ac4fe7f8856bfd1/celery-5.6.2-py3-none-any.whl", hash = "sha256:3ffafacbe056951b629c7abcf9064c4a2366de0bdfc9fdba421b97ebb68619a5", size = 445502, upload-time = "2026-01-04T12:35:55.894Z" },
 ]
 
 [[package]]
@@ -686,14 +686,14 @@ wheels = [
 
 [[package]]
 name = "django-hijack"
-version = "3.7.7"
+version = "3.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/88/82a6f6d09fddeb5ae0d271ee4f3d7a1d3625e83c9493a177ce032d9b52e6/django_hijack-3.7.7.tar.gz", hash = "sha256:48546c6ec80b02d7338b3ef6d707d7e86e3d42ed1d305646954b0137fb81a521", size = 14562, upload-time = "2026-03-24T09:45:43.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/84/9b525b0ae0236f2d7b099809cea4c711adedda853cc63b5f1c1017d46429/django_hijack-3.7.6.tar.gz", hash = "sha256:a1f3b16d0eae3d72c27988692453f0a923c665d96783325034798a8020f0ceb4", size = 14310, upload-time = "2026-01-06T16:49:49.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/75/2b0b13a7367f181060f6628060970f6c0d1f4375beead2b8b67533cb1ed3/django_hijack-3.7.7-py3-none-any.whl", hash = "sha256:ccc796d4b3de618eadc93b4a1cb4c9e271fc3be1aa50273c4a4093012467bf51", size = 31539, upload-time = "2026-03-24T09:45:42.589Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/5e/e076ed1056dec17879f842655e4034cb17c079f40473d53d73c8e9041905/django_hijack-3.7.6-py3-none-any.whl", hash = "sha256:b43703b57b77b17a2f754dced65356899178d8d3664b36e7e26a7d414fd61e7f", size = 31484, upload-time = "2026-01-06T16:49:48.098Z" },
 ]
 
 [[package]]
@@ -1882,7 +1882,7 @@ wheels = [
 
 [[package]]
 name = "mitxpro"
-version = "0.1.0"
+version = "2026.4.16.1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1968,14 +1968,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.8.2" },
-    { name = "boto3", specifier = "==1.42.88" },
-    { name = "celery", specifier = "==5.6.3" },
+    { name = "boto3", specifier = "==1.42.73" },
+    { name = "celery", specifier = "==5.6.2" },
     { name = "celery-redbeat", specifier = "==2.3.3" },
     { name = "dj-database-url", specifier = "==3.1.2" },
     { name = "django", specifier = "==4.2.30" },
     { name = "django-anymail", extras = ["mailgun"], specifier = "==14.0" },
     { name = "django-filter", specifier = ">=23.4,<24" },
-    { name = "django-hijack", specifier = "==3.7.7" },
+    { name = "django-hijack", specifier = "==3.7.6" },
     { name = "django-ipware", specifier = "==7.0.1" },
     { name = "django-oauth-toolkit", specifier = "==1.7.1" },
     { name = "django-redis", specifier = ">=6.0.0,<7" },

--- a/uv.lock
+++ b/uv.lock
@@ -1896,7 +1896,7 @@ wheels = [
 
 [[package]]
 name = "mitxpro"
-version = "0.1.0"
+version = "0.194.2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `[tool.bumpver]` configuration to `pyproject.toml` so the Concourse
release pipeline can update the application version automatically on each
release.

The new version format is `YYYY.MM.DD.N` (e.g., `2026.04.16.1`), which
replaces the previous semver-style version strings. This is required by the
Concourse `release` resource workflow being rolled out in
mitodl/ol-infrastructure#4506.

The `VERSION` constant in Django settings is updated to the initial release
format version as part of this change.

### How can this be tested?
1. With `bumpver` installed (`pip install bumpver`), run `bumpver update --dry` from the repo root and confirm it shows the expected diff with no errors.
2. Check that `VERSION` in Django settings matches `current_version` in `pyproject.toml`.

### Additional Context
Part of the Concourse release pipeline modernization — migrating from the Doof
Slack bot to a Concourse-native release workflow using GitHub Issues as
production gates.