### PR TITLE
feat: add domain redirect middleware

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,5 @@
 {
-  "addons": [
-    "heroku-postgresql:standard-0",
-    "newrelic:wayne",
-    "rediscloud:30"
-  ],
+  "addons": ["heroku-postgresql:standard-0", "newrelic:wayne", "rediscloud:30"],
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-apt"
@@ -695,12 +691,7 @@
       "required": false
     }
   },
-  "keywords": [
-    "Django",
-    "Python",
-    "MIT",
-    "Office of Digital Learning"
-  ],
+  "keywords": ["Django", "Python", "MIT", "Office of Digital Learning"],
   "name": "mitxpro",
   "repository": "https://github.com/mitodl/mitxpro",
   "scripts": {

--- a/app.json
+++ b/app.json
@@ -371,6 +371,10 @@
       "description": "E-mail to send 500 reports to.",
       "required": true
     },
+    "MITXPRO_BASE_URL": {
+      "description": "Base url for the application in the format PROTOCOL://HOSTNAME[:PORT]",
+      "required": true
+    },
     "MITXPRO_DB_CONN_MAX_AGE": {
       "description": "Maximum age of connection to Postgres in seconds",
       "required": false

--- a/app.json
+++ b/app.json
@@ -1,5 +1,9 @@
 {
-  "addons": ["heroku-postgresql:standard-0", "newrelic:wayne", "rediscloud:30"],
+  "addons": [
+    "heroku-postgresql:standard-0",
+    "newrelic:wayne",
+    "rediscloud:30"
+  ],
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-apt"
@@ -45,6 +49,10 @@
     },
     "BLOG_CACHE_TIMEOUT": {
       "description": "How long the blog should be cached",
+      "required": false
+    },
+    "CANONICAL_HOSTNAME_REDIRECT_ENABLED": {
+      "description": "Whether to enable redirecting to the canonical hostname defined in SITE_BASE_URL when a request comes in with a different hostname",
       "required": false
     },
     "CELERY_BROKER_URL": {
@@ -367,10 +375,6 @@
       "description": "E-mail to send 500 reports to.",
       "required": true
     },
-    "MITXPRO_BASE_URL": {
-      "description": "Base url for the application in the format PROTOCOL://HOSTNAME[:PORT]",
-      "required": true
-    },
     "MITXPRO_DB_CONN_MAX_AGE": {
       "description": "Maximum age of connection to Postgres in seconds",
       "required": false
@@ -691,7 +695,12 @@
       "required": false
     }
   },
-  "keywords": ["Django", "Python", "MIT", "Office of Digital Learning"],
+  "keywords": [
+    "Django",
+    "Python",
+    "MIT",
+    "Office of Digital Learning"
+  ],
   "name": "mitxpro",
   "repository": "https://github.com/mitodl/mitxpro",
   "scripts": {

--- a/conftest.py
+++ b/conftest.py
@@ -99,3 +99,9 @@ def django_db_setup(django_db_setup, django_db_blocker):  # noqa: ARG001
             if not index_page_class.objects.filter(**index_page_content).exists():
                 index_page = index_page_class(**index_page_content)
                 home_page.add_child(instance=index_page)
+
+
+@pytest.fixture(autouse=True)
+def canonical_hostname_redirect_disabled_by_default(settings):
+    """Disable canonical hostname redirects in tests unless explicitly enabled."""
+    settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED = False

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -3,3 +3,4 @@
 DIGITAL_CREDENTIALS = "xpro-digital-credentials"
 ENABLE_ENTERPRISE = "xpro-enterprise"
 ENROLLMENT_WELCOME_EMAIL = "xpro-enrollment-welcome-email"
+HOSTNAME_REDIRECT = "xpro-hostname-redirect"

--- a/mitxpro/features.py
+++ b/mitxpro/features.py
@@ -3,4 +3,3 @@
 DIGITAL_CREDENTIALS = "xpro-digital-credentials"
 ENABLE_ENTERPRISE = "xpro-enterprise"
 ENROLLMENT_WELCOME_EMAIL = "xpro-enrollment-welcome-email"
-HOSTNAME_REDIRECT = "xpro-hostname-redirect"

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -29,17 +29,18 @@ class HostnameRedirectMiddleware:
         canonical_host = parsed.netloc
         canonical_scheme = parsed.scheme
 
-        request_host = request.get_host()
+        # Use the actual HTTP_HOST header to avoid following USE_X_FORWARDED_HOST
+        # when determining if a redirect is needed. This prevents infinite redirects
+        # in cases where X-Forwarded-Host points to the wrong domain through a proxy.
+        request_host = request.META.get("HTTP_HOST", request.get_host())
+
         if request_host == canonical_host:
             return self.get_response(request)
 
-        if not is_enabled(features.HOSTNAME_REDIRECT, default=False):
+        if not is_enabled(features.HOSTNAME_REDIRECT, default=True):
             return self.get_response(request)
 
-        if request_host != canonical_host:
-            redirect_url = "{}://{}{}".format(
-                canonical_scheme, canonical_host, request.get_full_path()
-            )
-            return HttpResponseRedirect(redirect_url)
-
-        return self.get_response(request)
+        redirect_url = "{}://{}{}".format(
+            canonical_scheme, canonical_host, request.get_full_path()
+        )
+        return HttpResponseRedirect(redirect_url)

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -18,7 +18,7 @@ class HostnameRedirectMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if not is_enabled(features.HOSTNAME_REDIRECT, default=False):
+        if request.path.startswith("/api/"):
             return self.get_response(request)
 
         site_base_url = getattr(settings, "SITE_BASE_URL", None)
@@ -29,7 +29,14 @@ class HostnameRedirectMiddleware:
         canonical_host = parsed.netloc
         canonical_scheme = parsed.scheme
 
-        if request.get_host() != canonical_host:
+        request_host = request.get_host()
+        if request_host == canonical_host:
+            return self.get_response(request)
+
+        if not is_enabled(features.HOSTNAME_REDIRECT, default=False):
+            return self.get_response(request)
+
+        if request_host != canonical_host:
             redirect_url = "{}://{}{}".format(
                 canonical_scheme, canonical_host, request.get_full_path()
             )

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -22,10 +22,10 @@ class HostnameRedirectMiddleware:
         canonical_host = parsed.netloc
         canonical_scheme = parsed.scheme
 
-        if request.get_host() == canonical_host:
-            return self.get_response(request)
-
-        if not settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED:
+        if (
+            not settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED
+            or request.get_host() == canonical_host
+        ):
             return self.get_response(request)
 
         redirect_url = "{}://{}{}".format(

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -1,0 +1,38 @@
+"""Middleware for MIT xPRO"""
+
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.http import HttpResponseRedirect
+
+from mitol.olposthog.features import is_enabled
+
+from mitxpro import features
+
+
+class HostnameRedirectMiddleware:
+    """Middleware that redirects requests arriving at an incorrect hostname to the
+    canonical hostname configured in SITE_BASE_URL."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not is_enabled(features.HOSTNAME_REDIRECT, default=False):
+            return self.get_response(request)
+
+        site_base_url = getattr(settings, "SITE_BASE_URL", None)
+        if not site_base_url:
+            return self.get_response(request)
+
+        parsed = urlparse(site_base_url)
+        canonical_host = parsed.netloc
+        canonical_scheme = parsed.scheme
+
+        if request.get_host() != canonical_host:
+            redirect_url = "{}://{}{}".format(
+                canonical_scheme, canonical_host, request.get_full_path()
+            )
+            return HttpResponseRedirect(redirect_url)
+
+        return self.get_response(request)

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -5,10 +5,6 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.http import HttpResponseRedirect
 
-from mitol.olposthog.features import is_enabled
-
-from mitxpro import features
-
 
 class HostnameRedirectMiddleware:
     """Middleware that redirects requests arriving at an incorrect hostname to the

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -18,9 +18,6 @@ class HostnameRedirectMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.path.startswith("/api/"):
-            return self.get_response(request)
-
         site_base_url = getattr(settings, "SITE_BASE_URL", None)
         if not site_base_url:
             return self.get_response(request)
@@ -29,15 +26,10 @@ class HostnameRedirectMiddleware:
         canonical_host = parsed.netloc
         canonical_scheme = parsed.scheme
 
-        # Use the actual HTTP_HOST header to avoid following USE_X_FORWARDED_HOST
-        # when determining if a redirect is needed. This prevents infinite redirects
-        # in cases where X-Forwarded-Host points to the wrong domain through a proxy.
-        request_host = request.META.get("HTTP_HOST", request.get_host())
-
-        if request_host == canonical_host:
+        if request.get_host() == canonical_host:
             return self.get_response(request)
 
-        if not is_enabled(features.HOSTNAME_REDIRECT, default=False):
+        if not settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED:
             return self.get_response(request)
 
         redirect_url = "{}://{}{}".format(

--- a/mitxpro/middleware.py
+++ b/mitxpro/middleware.py
@@ -37,7 +37,7 @@ class HostnameRedirectMiddleware:
         if request_host == canonical_host:
             return self.get_response(request)
 
-        if not is_enabled(features.HOSTNAME_REDIRECT, default=True):
+        if not is_enabled(features.HOSTNAME_REDIRECT, default=False):
             return self.get_response(request)
 
         redirect_url = "{}://{}{}".format(

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -1,0 +1,82 @@
+"""Tests for mitxpro middleware"""
+
+import pytest
+from rest_framework import status
+
+from mitxpro.middleware import HostnameRedirectMiddleware
+
+
+CANONICAL_URL = "https://xpro.mit.edu"
+CANONICAL_HOST = "xpro.mit.edu"
+WRONG_HOST = "xpro-web.odl.mit.edu"
+
+
+@pytest.fixture()
+def middleware(mocker):
+    return HostnameRedirectMiddleware(get_response=mocker.Mock(return_value=None))
+
+
+def test_hostname_matches_no_redirect(rf, settings, middleware, mocker):
+    """If the request host matches the canonical host, the request passes through."""
+    settings.SITE_BASE_URL = CANONICAL_URL
+    mocker.patch(
+        "mitxpro.middleware.is_enabled",
+        return_value=True,
+    )
+    request = rf.get("/some/path/", SERVER_NAME=CANONICAL_HOST)
+    middleware(request)
+    middleware.get_response.assert_called_once_with(request)
+
+
+def test_wrong_hostname_feature_enabled_redirects(rf, settings, middleware, mocker):
+    """If the host is wrong and the feature is enabled, a redirect is returned."""
+    settings.SITE_BASE_URL = CANONICAL_URL
+    mocker.patch(
+        "mitxpro.middleware.is_enabled",
+        return_value=True,
+    )
+    request = rf.get("/some/path/", SERVER_NAME=WRONG_HOST)
+    response = middleware(request)
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response["Location"] == f"{CANONICAL_URL}/some/path/"
+
+
+def test_wrong_hostname_feature_disabled_no_redirect(rf, settings, middleware, mocker):
+    """If the host is wrong but the feature is disabled, the request passes through."""
+    settings.SITE_BASE_URL = CANONICAL_URL
+    mocker.patch(
+        "mitxpro.middleware.is_enabled",
+        return_value=False,
+    )
+    request = rf.get("/some/path/", SERVER_NAME=WRONG_HOST)
+    middleware(request)
+    middleware.get_response.assert_called_once_with(request)
+
+
+def test_no_site_base_url_no_redirect(rf, settings, middleware, mocker):
+    """If SITE_BASE_URL is not configured, the request passes through safely."""
+    settings.SITE_BASE_URL = None
+    mocker.patch(
+        "mitxpro.middleware.is_enabled",
+        return_value=True,
+    )
+    request = rf.get("/some/path/", SERVER_NAME=WRONG_HOST)
+    middleware(request)
+    middleware.get_response.assert_called_once_with(request)
+
+
+def test_wrong_hostname_preserves_query_string(rf, settings, middleware, mocker):
+    """The redirect preserves the full path including query string."""
+    settings.SITE_BASE_URL = CANONICAL_URL
+    mocker.patch(
+        "mitxpro.middleware.is_enabled",
+        return_value=True,
+    )
+    request = rf.get(
+        "/some/path/", {"foo": "bar", "baz": "qux"}, SERVER_NAME=WRONG_HOST
+    )
+    response = middleware(request)
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response["Location"].startswith(f"{CANONICAL_URL}/some/path/?")
+    assert "foo=bar" in response["Location"]
+    assert "baz=qux" in response["Location"]

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -20,46 +20,36 @@ def middleware(mocker):
     (
         "site_base_url",
         "server_name",
-        "feature_enabled",
+        "redirect_enabled",
         "expect_redirect",
         "expected_location",
-        "expect_is_enabled_called",
     ),
     [
-        # Matching host → passes through
-        (CANONICAL_URL, CANONICAL_HOST, True, False, None, False),
-        # Wrong host + feature enabled → redirect
-        (CANONICAL_URL, WRONG_HOST, True, True, f"{CANONICAL_URL}/some/path/", True),
-        # Wrong host + feature disabled → passes through
-        (CANONICAL_URL, WRONG_HOST, False, False, None, True),
-        # No SITE_BASE_URL configured → passes through
-        (None, WRONG_HOST, True, False, None, False),
+        # Matching host -> passes through
+        (CANONICAL_URL, CANONICAL_HOST, True, False, None),
+        # Wrong host + redirect enabled -> redirect
+        (CANONICAL_URL, WRONG_HOST, True, True, f"{CANONICAL_URL}/some/path/"),
+        # Wrong host + redirect disabled -> passes through
+        (CANONICAL_URL, WRONG_HOST, False, False, None),
+        # No SITE_BASE_URL configured -> passes through
+        (None, WRONG_HOST, True, False, None),
     ],
 )
 def test_hostname_redirect_middleware(
     rf,
     settings,
     middleware,
-    mocker,
     site_base_url,
     server_name,
-    feature_enabled,
+    redirect_enabled,
     expect_redirect,
     expected_location,
-    expect_is_enabled_called,
 ):
-    """Tests HostnameRedirectMiddleware redirects or passes through based on host and feature flag."""
+    """Tests HostnameRedirectMiddleware redirects or passes through based on host and setting."""
     settings.SITE_BASE_URL = site_base_url
-    is_enabled_mock = mocker.patch(
-        "mitxpro.middleware.is_enabled", return_value=feature_enabled
-    )
+    settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED = redirect_enabled
     request = rf.get("/some/path/", SERVER_NAME=server_name)
     response = middleware(request)
-
-    if expect_is_enabled_called:
-        is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
-    else:
-        is_enabled_mock.assert_not_called()
 
     if expect_redirect:
         assert response.status_code == status.HTTP_302_FOUND
@@ -68,32 +58,31 @@ def test_hostname_redirect_middleware(
         middleware.get_response.assert_called_once_with(request)
 
 
-def test_redirect_preserves_query_string(rf, settings, middleware, mocker):
+def test_redirect_preserves_query_string(rf, settings, middleware):
     """The redirect preserves the full path including query string."""
     settings.SITE_BASE_URL = CANONICAL_URL
-    is_enabled_mock = mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
+    settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED = True
     request = rf.get(
         "/some/path/", {"foo": "bar", "baz": "qux"}, SERVER_NAME=WRONG_HOST
     )
     response = middleware(request)
-    is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
     assert response.status_code == status.HTTP_302_FOUND
     assert response["Location"].startswith(f"{CANONICAL_URL}/some/path/?")
     assert "foo=bar" in response["Location"]
     assert "baz=qux" in response["Location"]
 
 
-def test_api_path_bypasses_redirect_checks(rf, settings, middleware, mocker):
-    """API routes bypass redirect and feature-flag checks for performance."""
+def test_api_path_bypasses_redirect_checks(rf, settings, middleware):
+    """API routes still follow the same redirect setting behavior."""
     settings.SITE_BASE_URL = CANONICAL_URL
-    is_enabled_mock = mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
+    settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED = True
     request = rf.get("/api/v1/topics/", SERVER_NAME=WRONG_HOST)
-    middleware(request)
-    is_enabled_mock.assert_not_called()
-    middleware.get_response.assert_called_once_with(request)
+    response = middleware(request)
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response["Location"] == f"{CANONICAL_URL}/api/v1/topics/"
 
 
-def test_hostname_redirect_checks_actual_http_host(rf, settings, middleware, mocker):
+def test_hostname_redirect_checks_actual_http_host(rf, settings, middleware):
     """Redirect decision is based on actual HTTP_HOST, not X-Forwarded-Host.
 
     This prevents infinite redirects when X-Forwarded-Host persists through
@@ -102,7 +91,7 @@ def test_hostname_redirect_checks_actual_http_host(rf, settings, middleware, moc
     which respects USE_X_FORWARDED_HOST.
     """
     settings.SITE_BASE_URL = CANONICAL_URL
-    mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
+    settings.CANONICAL_HOSTNAME_REDIRECT_ENABLED = True
     # Create request with wrong actual HTTP_HOST
     request = rf.get("/some/path/")
     # Manually set the actual HTTP_HOST to a non-canonical value

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -57,7 +57,7 @@ def test_hostname_redirect_middleware(
     response = middleware(request)
 
     if expect_is_enabled_called:
-        is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=True)
+        is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
     else:
         is_enabled_mock.assert_not_called()
 
@@ -76,7 +76,7 @@ def test_redirect_preserves_query_string(rf, settings, middleware, mocker):
         "/some/path/", {"foo": "bar", "baz": "qux"}, SERVER_NAME=WRONG_HOST
     )
     response = middleware(request)
-    is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=True)
+    is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
     assert response.status_code == status.HTTP_302_FOUND
     assert response["Location"].startswith(f"{CANONICAL_URL}/some/path/?")
     assert "foo=bar" in response["Location"]

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -17,7 +17,13 @@ def middleware(mocker):
 
 
 @pytest.mark.parametrize(
-    ("site_base_url", "server_name", "feature_enabled", "expect_redirect", "expected_location"),
+    (
+        "site_base_url",
+        "server_name",
+        "feature_enabled",
+        "expect_redirect",
+        "expected_location",
+    ),
     [
         # Matching host → passes through
         (CANONICAL_URL, CANONICAL_HOST, True, False, None),

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -23,16 +23,17 @@ def middleware(mocker):
         "feature_enabled",
         "expect_redirect",
         "expected_location",
+        "expect_is_enabled_called",
     ),
     [
         # Matching host → passes through
-        (CANONICAL_URL, CANONICAL_HOST, True, False, None),
+        (CANONICAL_URL, CANONICAL_HOST, True, False, None, False),
         # Wrong host + feature enabled → redirect
-        (CANONICAL_URL, WRONG_HOST, True, True, f"{CANONICAL_URL}/some/path/"),
+        (CANONICAL_URL, WRONG_HOST, True, True, f"{CANONICAL_URL}/some/path/", True),
         # Wrong host + feature disabled → passes through
-        (CANONICAL_URL, WRONG_HOST, False, False, None),
+        (CANONICAL_URL, WRONG_HOST, False, False, None, True),
         # No SITE_BASE_URL configured → passes through
-        (None, WRONG_HOST, True, False, None),
+        (None, WRONG_HOST, True, False, None, False),
     ],
 )
 def test_hostname_redirect_middleware(
@@ -45,12 +46,21 @@ def test_hostname_redirect_middleware(
     feature_enabled,
     expect_redirect,
     expected_location,
+    expect_is_enabled_called,
 ):
     """Tests HostnameRedirectMiddleware redirects or passes through based on host and feature flag."""
     settings.SITE_BASE_URL = site_base_url
-    mocker.patch("mitxpro.middleware.is_enabled", return_value=feature_enabled)
+    is_enabled_mock = mocker.patch(
+        "mitxpro.middleware.is_enabled", return_value=feature_enabled
+    )
     request = rf.get("/some/path/", SERVER_NAME=server_name)
     response = middleware(request)
+
+    if expect_is_enabled_called:
+        is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
+    else:
+        is_enabled_mock.assert_not_called()
+
     if expect_redirect:
         assert response.status_code == status.HTTP_302_FOUND
         assert response["Location"] == expected_location
@@ -61,14 +71,23 @@ def test_hostname_redirect_middleware(
 def test_redirect_preserves_query_string(rf, settings, middleware, mocker):
     """The redirect preserves the full path including query string."""
     settings.SITE_BASE_URL = CANONICAL_URL
-    mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
+    is_enabled_mock = mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
     request = rf.get(
         "/some/path/", {"foo": "bar", "baz": "qux"}, SERVER_NAME=WRONG_HOST
     )
     response = middleware(request)
+    is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
     assert response.status_code == status.HTTP_302_FOUND
     assert response["Location"].startswith(f"{CANONICAL_URL}/some/path/?")
     assert "foo=bar" in response["Location"]
     assert "baz=qux" in response["Location"]
-    assert "foo=bar" in response["Location"]
-    assert "baz=qux" in response["Location"]
+
+
+def test_api_path_bypasses_redirect_checks(rf, settings, middleware, mocker):
+    """API routes bypass redirect and feature-flag checks for performance."""
+    settings.SITE_BASE_URL = CANONICAL_URL
+    is_enabled_mock = mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
+    request = rf.get("/api/v1/topics/", SERVER_NAME=WRONG_HOST)
+    middleware(request)
+    is_enabled_mock.assert_not_called()
+    middleware.get_response.assert_called_once_with(request)

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -57,7 +57,7 @@ def test_hostname_redirect_middleware(
     response = middleware(request)
 
     if expect_is_enabled_called:
-        is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
+        is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=True)
     else:
         is_enabled_mock.assert_not_called()
 
@@ -76,7 +76,7 @@ def test_redirect_preserves_query_string(rf, settings, middleware, mocker):
         "/some/path/", {"foo": "bar", "baz": "qux"}, SERVER_NAME=WRONG_HOST
     )
     response = middleware(request)
-    is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=False)
+    is_enabled_mock.assert_called_once_with("xpro-hostname-redirect", default=True)
     assert response.status_code == status.HTTP_302_FOUND
     assert response["Location"].startswith(f"{CANONICAL_URL}/some/path/?")
     assert "foo=bar" in response["Location"]
@@ -91,3 +91,23 @@ def test_api_path_bypasses_redirect_checks(rf, settings, middleware, mocker):
     middleware(request)
     is_enabled_mock.assert_not_called()
     middleware.get_response.assert_called_once_with(request)
+
+
+def test_hostname_redirect_checks_actual_http_host(rf, settings, middleware, mocker):
+    """Redirect decision is based on actual HTTP_HOST, not X-Forwarded-Host.
+
+    This prevents infinite redirects when X-Forwarded-Host persists through
+    redirects in proxy scenarios. The middleware checks the real incoming
+    HTTP_HOST header, not Django's interpretation via request.get_host()
+    which respects USE_X_FORWARDED_HOST.
+    """
+    settings.SITE_BASE_URL = CANONICAL_URL
+    mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
+    # Create request with wrong actual HTTP_HOST
+    request = rf.get("/some/path/")
+    # Manually set the actual HTTP_HOST to a non-canonical value
+    request.META["HTTP_HOST"] = WRONG_HOST
+    response = middleware(request)
+    # Should redirect because actual HTTP_HOST doesn't match canonical
+    assert response.status_code == 302
+    assert response["Location"] == f"{CANONICAL_URL}/some/path/"

--- a/mitxpro/middleware_test.py
+++ b/mitxpro/middleware_test.py
@@ -16,67 +16,53 @@ def middleware(mocker):
     return HostnameRedirectMiddleware(get_response=mocker.Mock(return_value=None))
 
 
-def test_hostname_matches_no_redirect(rf, settings, middleware, mocker):
-    """If the request host matches the canonical host, the request passes through."""
-    settings.SITE_BASE_URL = CANONICAL_URL
-    mocker.patch(
-        "mitxpro.middleware.is_enabled",
-        return_value=True,
-    )
-    request = rf.get("/some/path/", SERVER_NAME=CANONICAL_HOST)
-    middleware(request)
-    middleware.get_response.assert_called_once_with(request)
-
-
-def test_wrong_hostname_feature_enabled_redirects(rf, settings, middleware, mocker):
-    """If the host is wrong and the feature is enabled, a redirect is returned."""
-    settings.SITE_BASE_URL = CANONICAL_URL
-    mocker.patch(
-        "mitxpro.middleware.is_enabled",
-        return_value=True,
-    )
-    request = rf.get("/some/path/", SERVER_NAME=WRONG_HOST)
+@pytest.mark.parametrize(
+    ("site_base_url", "server_name", "feature_enabled", "expect_redirect", "expected_location"),
+    [
+        # Matching host → passes through
+        (CANONICAL_URL, CANONICAL_HOST, True, False, None),
+        # Wrong host + feature enabled → redirect
+        (CANONICAL_URL, WRONG_HOST, True, True, f"{CANONICAL_URL}/some/path/"),
+        # Wrong host + feature disabled → passes through
+        (CANONICAL_URL, WRONG_HOST, False, False, None),
+        # No SITE_BASE_URL configured → passes through
+        (None, WRONG_HOST, True, False, None),
+    ],
+)
+def test_hostname_redirect_middleware(
+    rf,
+    settings,
+    middleware,
+    mocker,
+    site_base_url,
+    server_name,
+    feature_enabled,
+    expect_redirect,
+    expected_location,
+):
+    """Tests HostnameRedirectMiddleware redirects or passes through based on host and feature flag."""
+    settings.SITE_BASE_URL = site_base_url
+    mocker.patch("mitxpro.middleware.is_enabled", return_value=feature_enabled)
+    request = rf.get("/some/path/", SERVER_NAME=server_name)
     response = middleware(request)
-    assert response.status_code == status.HTTP_302_FOUND
-    assert response["Location"] == f"{CANONICAL_URL}/some/path/"
+    if expect_redirect:
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response["Location"] == expected_location
+    else:
+        middleware.get_response.assert_called_once_with(request)
 
 
-def test_wrong_hostname_feature_disabled_no_redirect(rf, settings, middleware, mocker):
-    """If the host is wrong but the feature is disabled, the request passes through."""
-    settings.SITE_BASE_URL = CANONICAL_URL
-    mocker.patch(
-        "mitxpro.middleware.is_enabled",
-        return_value=False,
-    )
-    request = rf.get("/some/path/", SERVER_NAME=WRONG_HOST)
-    middleware(request)
-    middleware.get_response.assert_called_once_with(request)
-
-
-def test_no_site_base_url_no_redirect(rf, settings, middleware, mocker):
-    """If SITE_BASE_URL is not configured, the request passes through safely."""
-    settings.SITE_BASE_URL = None
-    mocker.patch(
-        "mitxpro.middleware.is_enabled",
-        return_value=True,
-    )
-    request = rf.get("/some/path/", SERVER_NAME=WRONG_HOST)
-    middleware(request)
-    middleware.get_response.assert_called_once_with(request)
-
-
-def test_wrong_hostname_preserves_query_string(rf, settings, middleware, mocker):
+def test_redirect_preserves_query_string(rf, settings, middleware, mocker):
     """The redirect preserves the full path including query string."""
     settings.SITE_BASE_URL = CANONICAL_URL
-    mocker.patch(
-        "mitxpro.middleware.is_enabled",
-        return_value=True,
-    )
+    mocker.patch("mitxpro.middleware.is_enabled", return_value=True)
     request = rf.get(
         "/some/path/", {"foo": "bar", "baz": "qux"}, SERVER_NAME=WRONG_HOST
     )
     response = middleware(request)
     assert response.status_code == status.HTTP_302_FOUND
     assert response["Location"].startswith(f"{CANONICAL_URL}/some/path/?")
+    assert "foo=bar" in response["Location"]
+    assert "baz=qux" in response["Location"]
     assert "foo=bar" in response["Location"]
     assert "baz=qux" in response["Location"]

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1520,6 +1520,6 @@ EXTERNAL_COURSE_SYNC_EMAIL_RECIPIENTS = get_delimited_list(
 
 CANONICAL_HOSTNAME_REDIRECT_ENABLED = get_bool(
     name="CANONICAL_HOSTNAME_REDIRECT_ENABLED",
-    default=True,
+    default=False,
     description="Whether to enable redirecting to the canonical hostname defined in SITE_BASE_URL when a request comes in with a different hostname",
 )

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -204,6 +204,7 @@ if not WEBPACK_DISABLE_LOADER_STATS:  # noqa: F821
 
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
+    "mitxpro.middleware.HostnameRedirectMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "affiliate.middleware.AffiliateMiddleware",
     "oauth2_provider.middleware.OAuth2TokenMiddleware",

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -1517,3 +1517,9 @@ EXTERNAL_COURSE_SYNC_EMAIL_RECIPIENTS = get_delimited_list(
     default=[],
     description="Comma-separated list of email addresses to receive notifications about external data syncs",
 )
+
+CANONICAL_HOSTNAME_REDIRECT_ENABLED = get_bool(
+    name="CANONICAL_HOSTNAME_REDIRECT_ENABLED",
+    default=True,
+    description="Whether to enable redirecting to the canonical hostname defined in SITE_BASE_URL when a request comes in with a different hostname",
+)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10930

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a redirect middleware to redirect to canonical domain name if user is coming from other domains.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Enable `xpro-hostname-redirect` flag, for local testing, you can set the default to True in the Middleware.
- Visit localhost:8053 and it should redirect to xpro.odl.local as it is configured as SITE_BASE_URL.
- Testing with flag set to False and it should not redirect.
- To set X-Forwarded-Host, you can use modheader browser extension in Chrome and set to a different host like localhost:8053 and test it out.

