### PR TITLE
fix: Product and User CMS pages fixed

### DIFF
--- a/ecommerce/wagtail_views.py
+++ b/ecommerce/wagtail_views.py
@@ -52,7 +52,7 @@ class ProductReadOnlyIndexView(AbstractReadOnlyIndexView):
     """
 
     model = Product
-    queryset = Product.all_objects
+    queryset = Product.all_objects.all()
 
 
 class ProductInspectView(InspectView):

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -152,7 +152,7 @@ INSTALLED_APPS = (
     "wagtail.contrib.routable_page",
     "wagtail.embeds",
     "wagtail.sites",
-    "wagtail.users",
+    "users.apps.MitxproWagtailUsersAppConfig",
     "wagtail.snippets",
     "wagtail.documents",
     "wagtail.images",

--- a/users/apps.py
+++ b/users/apps.py
@@ -1,9 +1,21 @@
 """Users application"""
 
 from django.apps import AppConfig
+from wagtail.users.apps import WagtailUsersAppConfig
 
 
 class UsersConfig(AppConfig):
     """Config for users app"""
 
     name = "users"
+
+
+class MitxproWagtailUsersAppConfig(WagtailUsersAppConfig):
+    """
+    Custom WagtailUsersAppConfig for the mitxpro User model.
+
+    The viewset string is resolved lazily by Wagtail after the app registry is
+    ready, so no Django model imports are needed here.
+    """
+
+    user_viewset = "users.wagtail_views.UserViewSet"

--- a/users/wagtail_views.py
+++ b/users/wagtail_views.py
@@ -1,0 +1,28 @@
+"""Wagtail admin views for the users app"""
+
+from wagtail.users.views.users import (
+    IndexView as WagtailUserIndexView,
+    UserViewSet as WagtailUserViewSet,
+)
+
+
+class UserIndexView(WagtailUserIndexView):
+    """
+    Custom IndexView for the mitxpro User model.
+
+    The mitxpro User model uses a single `name` field instead of the standard
+    Django `first_name` / `last_name` fields. Wagtail 6.x's built-in
+    order_queryset() maps ordering="name" to order_by("last_name", "first_name"),
+    which raises a FieldError. This overrides that behaviour.
+    """
+
+    def order_queryset(self, queryset):
+        if self.ordering == "name":
+            return queryset.order_by("name")
+        if self.ordering == "-name":
+            return queryset.order_by("-name")
+        return super().order_queryset(queryset)
+
+
+class UserViewSet(WagtailUserViewSet):
+    index_view_class = UserIndexView

--- a/users/wagtail_views.py
+++ b/users/wagtail_views.py
@@ -17,10 +17,9 @@ class UserIndexView(WagtailUserIndexView):
     """
 
     def order_queryset(self, queryset):
-        if self.ordering == "name":
-            return queryset.order_by("name")
-        if self.ordering == "-name":
-            return queryset.order_by("-name")
+        ordering = self.ordering
+        if ordering in ("name", "-name"):
+            return queryset.order_by(ordering)
         return super().order_queryset(queryset)
 
 

--- a/users/wagtail_views_test.py
+++ b/users/wagtail_views_test.py
@@ -1,0 +1,69 @@
+"""Tests for users Wagtail admin views"""
+
+import pytest
+from unittest.mock import patch
+
+from wagtail.users.views.users import IndexView as WagtailUserIndexView
+
+from users.factories import UserFactory
+from users.models import User
+from users.wagtail_views import UserIndexView, UserViewSet
+
+pytestmark = pytest.mark.django_db
+
+
+class TestUserIndexViewOrderQueryset:
+    """Tests for UserIndexView.order_queryset"""
+
+    def _make_view(self, ordering):
+        view = UserIndexView()
+        view.ordering = ordering
+        view.model = User
+        return view
+
+    def test_order_by_name_ascending(self):
+        """ordering='name' sorts by name ascending"""
+        UserFactory(name="Zebra")
+        UserFactory(name="Alpha")
+        view = self._make_view("name")
+        result = list(
+            view.order_queryset(User.objects.all()).values_list("name", flat=True)
+        )
+        assert result == sorted(result)
+
+    def test_order_by_name_descending(self):
+        """ordering='-name' sorts by name descending"""
+        UserFactory(name="Zebra")
+        UserFactory(name="Alpha")
+        view = self._make_view("-name")
+        result = list(
+            view.order_queryset(User.objects.all()).values_list("name", flat=True)
+        )
+        assert result == sorted(result, reverse=True)
+
+    @pytest.mark.parametrize("ordering", ["name", "-name"])
+    def test_name_ordering_does_not_reference_last_name(self, ordering):
+        """name/−name ordering must not raise FieldError for last_name"""
+        UserFactory.create_batch(3)
+        view = self._make_view(ordering)
+        # Evaluating the queryset would raise FieldError if last_name is used
+        list(view.order_queryset(User.objects.all()))
+
+    def test_unknown_ordering_delegates_to_super(self):
+        """Unrecognised ordering falls through to Wagtail's default implementation"""
+        view = self._make_view("email")
+        qs = User.objects.all()
+        with patch.object(
+            WagtailUserIndexView, "order_queryset", return_value=qs
+        ) as mock_super:
+            result = view.order_queryset(qs)
+            mock_super.assert_called_once()
+        assert result is qs
+
+
+class TestUserViewSet:
+    """Tests for UserViewSet"""
+
+    def test_index_view_class_is_custom(self):
+        """UserViewSet must use the custom UserIndexView"""
+        assert UserViewSet.index_view_class is UserIndexView


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mitxpro/pull/3876

### Description (What does it do?)
This pull request introduces a custom integration of the Wagtail users admin with the mitxpro User model, which uses a single `name` field instead of the standard Django `first_name` and `last_name` fields. The main changes involve replacing the default Wagtail users app with a custom app config, implementing a custom `UserViewSet` and `IndexView` to handle ordering by the `name` field, and making small adjustments to queryset usage elsewhere.

**Wagtail users admin customization:**

* Added a new `MitxproWagtailUsersAppConfig` in `users/apps.py` to replace the default Wagtail users app, specifying a custom viewset for the users admin. (`users/apps.py`, `mitxpro/settings.py`) [[1]](diffhunk://#diff-65cd00db484c3262a55d976a64836c120c0ad9709d9731f39a908278f6561893R4-R21) [[2]](diffhunk://#diff-6c3289f4b19d7abb5d5b86ca2504d84b0973079422c33c85b3a9d3eb9be43909L155-R155)
* Implemented `UserIndexView` and `UserViewSet` in `users/wagtail_views.py` to override ordering logic for the custom `name` field, preventing errors when sorting users in the admin. (`users/wagtail_views.py`)

**Project settings update:**

* Updated `INSTALLED_APPS` in `mitxpro/settings.py` to use the new custom users app config instead of the default Wagtail users app.

**Other improvements:**

* Fixed the queryset definition in `ProductReadOnlyIndexView` to ensure it is evaluated correctly by changing `Product.all_objects` to `Product.all_objects.all()`. (`ecommerce/wagtail_views.py`)

### How can this be tested?
1. Make sure the xPro is running fine and wagtail is on 6.4.x
2. Navigate to Product page (/cms/product/)
3. The page should work just fine
4. Navigate to users page (/cms/users/) -- It should work fine