### PR TITLE
fix: the version mismatch for bump-my-version and settings.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mitxpro"
-version = "0.194.2"
+version = "0.195.0"
 description = "MITx Pro"
 authors = [{ name = "MIT ODL" }]
 requires-python = ">=3.13,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -1896,7 +1896,7 @@ wheels = [
 
 [[package]]
 name = "mitxpro"
-version = "0.194.2"
+version = "0.195.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
The CI is failing because of a mismatch between the version in settings and the pyproject.toml/lock files. This PR fixes the problem by matching version in all relevant files.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
CI should pass.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
