### PR TITLE
fix: skip the version test to pass the release PR

### DIFF
--- a/mitxpro/settings_test.py
+++ b/mitxpro/settings_test.py
@@ -175,6 +175,9 @@ def test_server_side_cursors_enabled(settings_sandbox):
     )
 
 
+@pytest.mark.skip(
+    reason="conflicts with release in settings.py, need to stabilize that first"
+)
 def test_bump_my_version_format(settings):
     """Verify VERSION is in sync with pyproject.toml and matches a version format."""
     with open("pyproject.toml", "rb") as f:  # noqa: PTH123


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
The bump version test fails on the release branches. See: https://github.com/mitodl/mitxpro/actions/runs/27413469420/job/81020215628 or PR https://github.com/mitodl/mitxpro/pull/3956 which halts the deployment. This was discussed with @blarghmatey and we decided to skip this test for now. See [Slack Thread](https://mitodl.slack.com/archives/GG8B4C3JP/p1781264528744479)
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
CI should pass.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
