### PR TITLE
feat: adopt mitodl/ol-python-base:3.13, granian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # ─── Dependency install ───────────────────────────────────────────────────────
 FROM base AS deps
 
-COPY pyproject.toml uv.lock /src/
-RUN chown mitodl:mitodl /src/pyproject.toml /src/uv.lock
+COPY --chown=mitodl:mitodl pyproject.toml uv.lock /src/
 
 USER mitodl
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,36 @@
-# Build stage
-FROM python:3.13-slim AS builder
+# syntax=docker/dockerfile:1
+# hadolint global ignore=DL3008
+
+FROM mitodl/ol-python-base:3.13 AS base
 LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 
-# Set environment variables for build
+# App-specific apt extras; common-core packages (git, curl, libjpeg-dev,
+# zlib1g-dev, net-tools, build-essential, libpq-dev, postgresql-client,
+# pkg-config, libxmlsec1-dev) are in mitodl/ol-python-base:3.13.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libmagic1 \
+      libpoppler-cpp-dev
+
 ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
-
-# Install build dependencies
-WORKDIR /tmp
-COPY apt.txt /tmp/apt.txt
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        $(grep -vE "^\s*#" apt.txt | tr "\n" " ") \
-        build-essential \
-        libpq-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        libxmlsec1-dev \
-        libjpeg-dev \
-        zlib1g-dev \
-        pkg-config \
-        libpoppler-cpp-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -f /tmp/apt.txt
-
-# Add, and run as, non-root user.
-RUN mkdir /src \
-    && adduser --disabled-password --gecos "" mitodl \
-    && mkdir /var/media && chown -R mitodl:mitodl /var/media
-
-# Install Python packages
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    UV_PROJECT_ENVIRONMENT="/opt/venv"
+    PYTHONDONTWRITEBYTECODE=1
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+# ─── Dependency install ───────────────────────────────────────────────────────
+FROM base AS deps
 
 COPY pyproject.toml uv.lock /src/
-RUN mkdir -p /opt/venv && chown -R mitodl:mitodl /src /opt/venv
+RUN chown mitodl:mitodl /src/pyproject.toml /src/uv.lock
 
 USER mitodl
 WORKDIR /src
-RUN uv sync --frozen --no-install-project --no-dev
+# BuildKit cache mount keeps the uv download cache across builds.
+RUN --mount=type=cache,target=/opt/uv-cache,uid=1000,gid=1000 \
+    uv sync --frozen --no-install-project --no-dev
 
-
+# ─── Node / frontend asset build ─────────────────────────────────────────────
 FROM node:24-slim AS node_builder
 COPY . /src
 WORKDIR /src
@@ -55,67 +38,36 @@ ENV NODE_ENV=production
 RUN yarn install --immutable \
     && node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js --bail
 
+# ─── Code stage ───────────────────────────────────────────────────────────────
+FROM deps AS code
 
-# Runtime stage
-FROM python:3.13-slim AS runtime
-
-# Set environment variables for production
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    VIRTUAL_ENV="/opt/venv" \
-    XDG_CACHE_HOME=/tmp/.cache
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-# Install only runtime dependencies
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        curl \
-        libxml2 \
-        libxslt1.1 \
-        libpq5 \
-        libxmlsec1 \
-        libjpeg62-turbo \
-        zlib1g \
-        libmagic1 \
-        net-tools \
-        postgresql-client \
-        libpoppler-cpp2 \
-    && rm -rf /var/lib/apt/lists/*
-
-# Add non-root user
-RUN adduser --disabled-password --gecos "" mitodl \
-    && mkdir -p /src /var/media \
-    && chown -R mitodl:mitodl /src /var/media
-
-# Copy virtual environment from builder
-COPY --from=builder --chown=mitodl:mitodl /opt/venv /opt/venv
-
-# Copy uv binary from builder
-COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
-COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-
-# Add project
 COPY --chown=mitodl:mitodl . /src
 WORKDIR /src
-RUN find /src -type f -name "*.py" -exec chmod 644 {} \; \
-    && find /src -type f -name "*.sh" -exec chmod 755 {} \; \
-    && find /src -type d -exec chmod 755 {} \;
+ENV XDG_CACHE_HOME=/tmp/.cache
 
-USER mitodl
+# ─── Runtime target ───────────────────────────────────────────────────────────
+FROM code AS runtime
 
 EXPOSE 8053
 ENV PORT=8053
+CMD ["sh", "-c", "exec granian --interface wsgi --host 0.0.0.0 --port ${PORT:-8053} --workers 2 mitxpro.wsgi:application"]
 
-CMD ["uwsgi", "uwsgi.ini"]
-
-
+# ─── Production target ────────────────────────────────────────────────────────
 FROM runtime AS production
 
 COPY --from=node_builder --chown=mitodl:mitodl /src/static /src/static
 COPY --from=node_builder --chown=mitodl:mitodl /src/webpack-stats.json /src/webpack-stats.json
 
-from builder as dev
+# ─── Development target ───────────────────────────────────────────────────────
+FROM deps AS dev
 
-RUN uv sync --locked --dev
+COPY --chown=mitodl:mitodl . /src
+WORKDIR /src
+ENV XDG_CACHE_HOME=/tmp/.cache
+
+RUN --mount=type=cache,target=/opt/uv-cache,uid=1000,gid=1000 \
+    uv sync --locked --dev
+
+EXPOSE 8053
+ENV PORT=8053
+CMD ["sh", "-c", "exec granian --interface wsgi --host 0.0.0.0 --port ${PORT:-8053} --workers 2 mitxpro.wsgi:application"]

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: bash scripts/heroku-release-phase.sh
-web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
+web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program granian --interface wsgi --host 0.0.0.0 --port 8051 --workers 2 mitxpro.wsgi:application
 worker: bin/start-pgbouncer newrelic-admin run-program celery -A mitxpro.celery:app worker -E -B -l $MITXPRO_LOG_LEVEL
 extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A mitxpro.celery:app worker -E -l $MITXPRO_LOG_LEVEL

--- a/apt.txt
+++ b/apt.txt
@@ -1,9 +1,7 @@
-# Core requirements
-git
-curl
-libjpeg-dev
-libxmlsec1-dev
-zlib1g-dev
-net-tools
-pkg-config
-libpoppler-cpp-dev
+# App-specific apt extras for mitxpro.
+# Common packages (git, curl, libjpeg-dev, zlib1g-dev, net-tools,
+# build-essential, libpq-dev, postgresql-client, pkg-config, libxmlsec1-dev)
+# are in mitodl/ol-python-base:3.13.
+# App extras installed inline in the Dockerfile:
+#   libmagic1          - python-magic file-type detection
+#   libpoppler-cpp-dev - PDF processing

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -3,9 +3,6 @@ server {
     listen 8053 default_server;
     root /src;
 
-    include uwsgi_params;
-    uwsgi_pass_request_headers on;
-    uwsgi_pass_request_body on;
     client_max_body_size 25M;
 
     location = /.well-known/dnt-policy.txt {
@@ -26,12 +23,11 @@ server {
         try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
     }
 
-    location ~* /images/.*$ {
-        uwsgi_hide_header Vary;
-        uwsgi_pass web:8051;
-    }
-
     location / {
-        uwsgi_pass web:8051;
+        proxy_pass http://web:8051;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -44,24 +44,6 @@ http {
         server_name _;
         root /app;
 
-        uwsgi_param QUERY_STRING $query_string;
-        uwsgi_param REQUEST_METHOD $request_method;
-        uwsgi_param CONTENT_TYPE $content_type;
-        uwsgi_param CONTENT_LENGTH $content_length;
-        uwsgi_param REQUEST_URI $request_uri;
-        uwsgi_param PATH_INFO $document_uri;
-        uwsgi_param DOCUMENT_ROOT $document_root;
-        uwsgi_param SERVER_PROTOCOL $server_protocol;
-        uwsgi_param REMOTE_ADDR $remote_addr;
-        uwsgi_param REMOTE_PORT $remote_port;
-        uwsgi_param SERVER_ADDR $server_addr;
-        uwsgi_param SERVER_PORT $server_port;
-        uwsgi_param SERVER_NAME $server_name;
-
-        uwsgi_pass_request_headers on;
-        uwsgi_pass_request_body on;
-        uwsgi_ignore_client_abort on;
-
         client_max_body_size 25M;
 
         location = /favicon.ico {
@@ -87,13 +69,13 @@ http {
             try_files /fastly_verification.html =404;
         }
 
-        location ~* /images/.*$ {
-            uwsgi_hide_header Vary;
-            uwsgi_pass unix:/tmp/nginx.socket;
-        }
-
         location / {
-            uwsgi_pass unix:/tmp/nginx.socket;
+            proxy_pass http://<%= ENV["NGINX_UPSTREAM"] || "localhost:8051" %>;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --noinput &&
-      granian --interface wsgi --host 0.0.0.0 --port 8051 --workers 2 mitxpro.wsgi:application'
+      exec granian --interface wsgi --host 0.0.0.0 --port 8051 --workers 2 mitxpro.wsgi:application'
     stdin_open: true
     tty: true
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --noinput &&
-      uwsgi uwsgi.ini --honour-stdin'
+      granian --interface wsgi --host 0.0.0.0 --port 8051 --workers 2 mitxpro.wsgi:application'
     stdin_open: true
     tty: true
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dependencies = [
     "ulid-py>=1.1.0,<2",
     "user-agents==2.2.0",
     "user-util==2.0.0",
-    "uwsgi==2.0.31",
     "wagtail==6.4.2",
     "wagtail-metadata==5.0.0",
     "xmltodict>=1.0.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -1946,7 +1946,6 @@ dependencies = [
     { name = "ulid-py" },
     { name = "user-agents" },
     { name = "user-util" },
-    { name = "uwsgi" },
     { name = "wagtail" },
     { name = "wagtail-metadata" },
     { name = "xmltodict" },
@@ -2028,7 +2027,6 @@ requires-dist = [
     { name = "ulid-py", specifier = ">=1.1.0,<2" },
     { name = "user-agents", specifier = "==2.2.0" },
     { name = "user-util", specifier = "==2.0.0" },
-    { name = "uwsgi", specifier = "==2.0.31" },
     { name = "wagtail", specifier = "==6.4.2" },
     { name = "wagtail-metadata", specifier = "==5.0.0" },
     { name = "xmltodict", specifier = ">=1.0.0,<2" },
@@ -3362,12 +3360,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/d9/d0/e9842ec9dc0f7dbd9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/27/d1ea6f409aec1fa56a0698ddd635ebadf0b1e6bfe52fab6755c2f9dfbee4/user_util-2.0.0-py2.py3-none-any.whl", hash = "sha256:348d6c337ed84650b0d6ab25c9590a36c381363729440979d7a7a6c77f05493a", size = 16849, upload-time = "2025-05-12T16:54:49.407Z" },
 ]
-
-[[package]]
-name = "uwsgi"
-version = "2.0.31"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/49/2f57640e889ba509fd1fae10cccec1b58972a07c2724486efba94c5ea448/uwsgi-2.0.31.tar.gz", hash = "sha256:e8f8b350ccc106ff93a65247b9136f529c14bf96b936ac5b264c6ff9d0c76257", size = 822796, upload-time = "2025-10-11T19:17:28.794Z" }
 
 [[package]]
 name = "vine"


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `FROM python:3.13-slim` multi-stage build with `FROM mitodl/ol-python-base:3.13`; app-specific extras (`libmagic1`, `libpoppler-cpp-dev`) installed inline with BuildKit apt cache
- Switches the WSGI server from uwsgi → granian (`--interface wsgi`) in docker-compose, Procfile, and CMD
- Updates `config/nginx.conf` (dev) and `config/nginx.conf.erb` (Heroku) from `uwsgi_pass` to `proxy_pass http://`; removes server-level `uwsgi_params` blocks
- Adds BuildKit `--mount=type=cache` on `uv sync` for faster layer rebuilds
- Removes `uwsgi==2.0.31` from `pyproject.toml` and regenerates `uv.lock`

## Test plan

- [x] `docker build --target runtime .` succeeds
- [x] `docker build --target dev .` succeeds
- [x] `uv.lock` regenerated — uwsgi v2.0.31 removed
- [x] nginx.conf and nginx.conf.erb use `proxy_pass http://` (not `uwsgi_pass`)
- [x] Procfile runs granian on port 8051