### PR TITLE
Add django-health-check endpoints

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -194,6 +194,7 @@ INSTALLED_APPS = (
     "mitol.oauth_toolkit_extensions.apps.OAuthToolkitExtensionsApp",
     "mitol.authentication.apps.TransitionalAuthenticationApp",
     "mitol.olposthog.apps.OlPosthog",
+    "health_check",
 )
 # Only include the seed data app if this isn't running in prod
 if ENVIRONMENT not in ("production", "prod"):

--- a/mitxpro/urls.py
+++ b/mitxpro/urls.py
@@ -56,6 +56,7 @@ WAGTAIL_IMG_CACHE_AGE = 31_536_000  # 1 year
 
 urlpatterns = (
     [
+        path("", include("mitxpro.urls_healthcheck")),
         path("admin/", admin.site.urls),
         # NOTE: we only bring in base_urlpatterns so applications can only be created via django-admin
         path(

--- a/mitxpro/urls_healthcheck.py
+++ b/mitxpro/urls_healthcheck.py
@@ -1,0 +1,59 @@
+"""Healthcheck urls"""
+
+from django.conf import settings
+from django.urls import include, path, re_path
+from health_check.views import HealthCheckView
+from redis.asyncio import Redis as RedisClient
+
+BASE_CHECKS = [
+    "health_check.Cache",
+    "health_check.Database",
+    (
+        "health_check.contrib.redis.Redis",
+        {"client_factory": lambda: RedisClient.from_url(settings.CELERY_BROKER_URL)},
+    ),
+]
+
+
+urlpatterns = [
+    path(
+        "health/",
+        include(
+            [
+                re_path(
+                    r"startup\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                        ]
+                    ),
+                ),
+                re_path(
+                    r"liveness\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            "health_check.Database",
+                        ]
+                    ),
+                ),
+                re_path(
+                    r"readiness\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                        ]
+                    ),
+                ),
+                re_path(
+                    r"full\/?",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                            "health_check.contrib.celery.Ping",
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "django==5.2.15",
     "django-anymail[mailgun]==15.0",
     "django-filter>=24",
+    "django-health-check[celery,redis]>=4.0.0",
     "django-hijack==3.7.8",
     "django-ipware==7.0.1",
     "django-oauth-toolkit==3.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,27 @@ wheels = [
 ]
 
 [[package]]
+name = "django-health-check"
+version = "4.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/9b/1b48973dfeb13fe5bce8669a328a06d31b71e2b9ee28099b5a499ee4d5f3/django_health_check-4.4.3.tar.gz", hash = "sha256:a99fe9f13da26cf055d81e90f237ef3ad40a31f365b280812a590707854b8d2b", size = 21800, upload-time = "2026-06-23T09:42:09.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/42/0497bb62bb6df5af67ea211a79f8ba158a3b4896b222f747833f5dd0e407/django_health_check-4.4.3-py3-none-any.whl", hash = "sha256:dfbb27e4c63e8e419a4852f0d9c1c49d6de342e1b00438144905761c2a1386a7", size = 26916, upload-time = "2026-06-23T09:42:07.72Z" },
+]
+
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "django-hijack"
 version = "3.7.8"
 source = { registry = "https://pypi.org/simple" }
@@ -922,6 +943,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/01/4a/d5bb069b49199c9fd0dc33c25dd7a6c15152926c47d73a560b6fde3bd2fb/djoser-2.3.1.tar.gz", hash = "sha256:4e7e2716b5b961f1289b5e49b2216ba5c18eb2a3b4b597dd6430638716ff5107", size = 33806, upload-time = "2024-11-09T16:57:50.682Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/77/eae6f6ae6b71d578d08f7eee7c0965cff59a270cf024ecdcbb8048fc7a4b/djoser-2.3.1-py3-none-any.whl", hash = "sha256:386f337b9e05cb82354525fe2b6fec19fb1743e93e53b5b4b9dfaffccc38789f", size = 64215, upload-time = "2024-11-09T16:57:49.603Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -1907,6 +1937,7 @@ dependencies = [
     { name = "django" },
     { name = "django-anymail" },
     { name = "django-filter" },
+    { name = "django-health-check", extra = ["celery", "redis"] },
     { name = "django-hijack" },
     { name = "django-ipware" },
     { name = "django-oauth-toolkit" },
@@ -1988,6 +2019,7 @@ requires-dist = [
     { name = "django", specifier = "==5.2.15" },
     { name = "django-anymail", extras = ["mailgun"], specifier = "==15.0" },
     { name = "django-filter", specifier = ">=24" },
+    { name = "django-health-check", extras = ["celery", "redis"], specifier = ">=4.0.0" },
     { name = "django-hijack", specifier = "==3.7.8" },
     { name = "django-ipware", specifier = "==7.0.1" },
     { name = "django-oauth-toolkit", specifier = "==3.2.0" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
mitxpro had NO health-check endpoint at all before this change (no STATUS_TOKEN, no HEALTH_CHECK setting, nothing — k8s probes rely solely on the nginx-only `/nginx-health` check). Adds `django-health-check` (v4.4.3, resolved), matching the production pattern already used in mit-learn/learn-ai/mitxonline. Mounts `/health/{startup,liveness,readiness,full}/` endpoints checking cache, database, redis, and celery.

### How can this be tested?
`manage.py check` passes with a stubbed env (sqlite DATABASE_URL, dummy SECRET_KEY, local redis broker URL, etc); static import and URL-resolution checked via a one-off script confirming `mitxpro.urls` imports cleanly, all four `/health/...` routes resolve to the expected health-check view, and no existing named routes collide. A full live smoke test against real Postgres/Redis/Celery should happen in a review app or CI before merge.

### Additional Context
Companion PRs applying the same migration exist for micromasters, ocw-studio, and odl-video-service (parallel effort). A follow-up ol-infrastructure PR will point this app's Kubernetes probes at these new endpoints instead of the current nginx-only `/nginx-health` check — do not merge that infra change before this PR is merged and deployed.