### PR TITLE
fix: remove dead duplicate AUTHENTICATION_BACKENDS declaration

### DIFF
--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -934,10 +934,11 @@ CACHES = {
     },
 }
 
-# the only declaration of AUTHENTICATION_BACKENDS: a duplicate earlier in this
-# file (SAML/MicroMasters backends, dead since authentication.backends.micromasters
-# was removed and no SOCIAL_AUTH_SAML_* config was ever added) silently shadowed
-# this one and has been deleted
+# the only declaration of AUTHENTICATION_BACKENDS: a dead duplicate earlier
+# in this file (SAML/MicroMasters backends, dead since
+# authentication.backends.micromasters was removed and no SOCIAL_AUTH_SAML_*
+# config was ever added), which this declaration silently shadowed, has
+# been deleted
 AUTHENTICATION_BACKENDS = (
     "social_core.backends.email.EmailAuth",
     "oauth2_provider.backends.OAuth2Backend",

--- a/mitxpro/settings.py
+++ b/mitxpro/settings.py
@@ -327,16 +327,6 @@ ROBOTS_CACHE_TIMEOUT = get_int(
 
 SILKY_ANALYZE_QUERIES = True
 
-# social auth
-AUTHENTICATION_BACKENDS = (
-    "authentication.backends.micromasters.MicroMastersAuth",
-    "social_core.backends.email.EmailAuth",
-    "social_core.backends.saml.SAMLAuth",
-    # the following needs to stay here to allow login of local users
-    "django.contrib.auth.backends.ModelBackend",
-    "guardian.backends.ObjectPermissionBackend",
-)
-
 SOCIAL_AUTH_LOGIN_ERROR_URL = "login"
 SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [urlparse(SITE_BASE_URL).netloc]
 
@@ -944,6 +934,10 @@ CACHES = {
     },
 }
 
+# the only declaration of AUTHENTICATION_BACKENDS: a duplicate earlier in this
+# file (SAML/MicroMasters backends, dead since authentication.backends.micromasters
+# was removed and no SOCIAL_AUTH_SAML_* config was ever added) silently shadowed
+# this one and has been deleted
 AUTHENTICATION_BACKENDS = (
     "social_core.backends.email.EmailAuth",
     "oauth2_provider.backends.OAuth2Backend",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found during the 2026-07 SOA identity/auth audit (finding 6.3).

### Description (What does it do?)
`mitxpro/settings.py` declared `AUTHENTICATION_BACKENDS` twice:

- **Line ~331** (the one that looked "real"): `MicroMastersAuth` + `EmailAuth` + `SAMLAuth` + `ModelBackend` + guardian's `ObjectPermissionBackend`
- **Line ~947**: a second top-level reassignment to `EmailAuth` + `OAuth2Backend` + `ModelBackend`

Python executes module-level assignments in order, so the second declaration silently wins and the first block has never actually been in effect. This PR deletes the dead first block and keeps the one that's actually running.

Verified this is genuinely dead code, not "unwired in some environments":
- `authentication.backends.micromasters.MicroMastersAuth` — that module doesn't exist anywhere in this repo. If this backend list were ever loaded, Django would raise `ImportError` on startup.
- `social_core.backends.saml.SAMLAuth` — there is no `SOCIAL_AUTH_SAML_*` configuration anywhere in the codebase, and no SAML dependency in `pyproject.toml`. Non-functional even if reachable.
- `guardian.backends.ObjectPermissionBackend` — `django-guardian` isn't in `pyproject.toml` or `INSTALLED_APPS`, so this import would also fail.

`git log -S"AUTHENTICATION_BACKENDS"` shows this duplication dates back to very early commits in the repo's history (`8b9478d4` "Added authentication app", `4950d34f`), so it's stale copy/paste rather than a recent regression — Touchstone/MicroMasters login has not been reachable for a long time.

### How can this be tested?
- `python -c "import ast; ast.parse(open('mitxpro/settings.py').read())"` — parses cleanly
- `ruff check mitxpro/settings.py` — passes
- Reviewer: `grep -n "^AUTHENTICATION_BACKENDS" mitxpro/settings.py` should show exactly one declaration
- Runtime behavior is unchanged — the effective backend list (`EmailAuth`, `OAuth2Backend`, `ModelBackend`) is identical before and after this change; only the unreachable duplicate is removed.

### Additional Context
Part of the SOA simplification & boundary-hardening remediation backlog (identity/auth audit lens). If Touchstone/SAML or MicroMasters SSO login is actually wanted for mitxpro, that would need a fresh design/spec (Keycloak/SAML config, `python3-saml` dependency, etc.) rather than resurrecting this dead block — flagging that as a separate follow-up if there's a real business need, but no evidence of one was found (no SAML config, no MicroMasters backend module, no docs referencing Touchstone login for mitxpro).