### PR TITLE
fix: resolve program run IDs when processing refund requests

### DIFF
--- a/courses/utils.py
+++ b/courses/utils.py
@@ -376,23 +376,20 @@ def is_program_text_id(item_text_id):
     return item_text_id.startswith(PROGRAM_TEXT_ID_PREFIX)
 
 
-def resolve_courseware_object_from_text_id(text_id):
+def get_courseware_object_from_text_id(text_id):
     """
-    Resolves a text id that references a Program or CourseRun into the matching object,
-    along with the associated ProgramRun when the text id carries a run tag suffix.
+    Resolves a text id that references a Program or CourseRun into the matching object.
 
     Handles program run ids that carry a run tag suffix (e.g. "program-v1:xPRO+QCF+R24"),
     plain program ids, and course run ids. This does not require an associated Product, so
-    callers that only need the courseware object can use it directly (e.g. refund
-    processing, where the product may be inactive/expired); callers that need the product
-    look it up separately.
+    it resolves courseware whose product is inactive/expired (as is common when processing
+    refunds).
 
     Args:
         text_id (str): A text id for a Program/CourseRun (optionally with a program run suffix)
 
     Returns:
-        tuple(Program or CourseRun, ProgramRun or None): The courseware object matching the
-            text id, and the matching ProgramRun if the text id carried a run tag suffix
+        Program or CourseRun: The courseware object matching the given text id
 
     Raises:
         Program.DoesNotExist: if a program (run) text id matches no Program
@@ -401,7 +398,6 @@ def resolve_courseware_object_from_text_id(text_id):
     program_run_match = re.match(PROGRAM_RUN_ID_PATTERN, text_id)
     if program_run_match:
         match_dict = program_run_match.groupdict()
-        run_tag = match_dict["run_tag"]
         # A Program's own readable_id may end in something that looks like a run tag
         # without an associated ProgramRun. Prefer a Program that has a ProgramRun for
         # the suffix; otherwise fall back to a Program whose readable_id is the full
@@ -410,16 +406,16 @@ def resolve_courseware_object_from_text_id(text_id):
         program = (
             Program.objects.filter(
                 readable_id=match_dict["text_id_base"],
-                programruns__run_tag=run_tag,
+                programruns__run_tag=match_dict["run_tag"],
             ).first()
             or Program.objects.filter(readable_id=text_id).first()
         )
         if program is None:
             raise Program.DoesNotExist
-        return program, program.programruns.filter(run_tag=run_tag).first()
+        return program
     if is_program_text_id(text_id):
-        return Program.objects.get(readable_id=text_id), None
-    return CourseRun.objects.get(courseware_id=text_id), None
+        return Program.objects.get(readable_id=text_id)
+    return CourseRun.objects.get(courseware_id=text_id)
 
 
 def get_catalog_course_filter(relative_filter=""):

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -376,20 +376,23 @@ def is_program_text_id(item_text_id):
     return item_text_id.startswith(PROGRAM_TEXT_ID_PREFIX)
 
 
-def get_courseware_object_from_text_id(text_id):
+def resolve_courseware_object_from_text_id(text_id):
     """
-    Resolves a text id that references a Program or CourseRun into the matching object.
+    Resolves a text id that references a Program or CourseRun into the matching object,
+    along with the associated ProgramRun when the text id carries a run tag suffix.
 
     Handles program run ids that carry a run tag suffix (e.g. "program-v1:xPRO+QCF+R24"),
-    plain program ids, and course run ids. Unlike ecommerce.api.get_product_from_text_id,
-    this does not require an associated (active) Product, so it also resolves courseware
-    whose product is inactive/expired (as is common when processing refunds).
+    plain program ids, and course run ids. This does not require an associated Product, so
+    callers that only need the courseware object can use it directly (e.g. refund
+    processing, where the product may be inactive/expired); callers that need the product
+    look it up separately.
 
     Args:
         text_id (str): A text id for a Program/CourseRun (optionally with a program run suffix)
 
     Returns:
-        Program or CourseRun: The courseware object matching the given text id
+        tuple(Program or CourseRun, ProgramRun or None): The courseware object matching the
+            text id, and the matching ProgramRun if the text id carried a run tag suffix
 
     Raises:
         Program.DoesNotExist: if a program (run) text id matches no Program
@@ -398,6 +401,7 @@ def get_courseware_object_from_text_id(text_id):
     program_run_match = re.match(PROGRAM_RUN_ID_PATTERN, text_id)
     if program_run_match:
         match_dict = program_run_match.groupdict()
+        run_tag = match_dict["run_tag"]
         # A Program's own readable_id may end in something that looks like a run tag
         # without an associated ProgramRun. Prefer a Program that has a ProgramRun for
         # the suffix; otherwise fall back to a Program whose readable_id is the full
@@ -406,16 +410,16 @@ def get_courseware_object_from_text_id(text_id):
         program = (
             Program.objects.filter(
                 readable_id=match_dict["text_id_base"],
-                programruns__run_tag=match_dict["run_tag"],
+                programruns__run_tag=run_tag,
             ).first()
             or Program.objects.filter(readable_id=text_id).first()
         )
         if program is None:
             raise Program.DoesNotExist
-        return program
+        return program, program.programruns.filter(run_tag=run_tag).first()
     if is_program_text_id(text_id):
-        return Program.objects.get(readable_id=text_id)
-    return CourseRun.objects.get(courseware_id=text_id)
+        return Program.objects.get(readable_id=text_id), None
+    return CourseRun.objects.get(courseware_id=text_id), None
 
 
 def get_catalog_course_filter(relative_filter=""):

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -10,7 +10,11 @@ from django.db.models import Q
 import re
 from requests.exceptions import HTTPError
 
-from courses.constants import PROGRAM_TEXT_ID_PREFIX, COURSE_KEY_PATTERN
+from courses.constants import (
+    COURSE_KEY_PATTERN,
+    PROGRAM_RUN_ID_PATTERN,
+    PROGRAM_TEXT_ID_PREFIX,
+)
 from courses.models import (
     CourseRun,
     CourseRunCertificate,
@@ -370,6 +374,52 @@ def is_program_text_id(item_text_id):
         bool: True if the given id is a program id
     """
     return item_text_id.startswith(PROGRAM_TEXT_ID_PREFIX)
+
+
+def get_courseware_object_from_text_id(text_id):
+    """
+    Resolves a text id that references a Program or CourseRun into the matching object.
+
+    Handles program run ids that carry a run tag suffix (e.g. "program-v1:xPRO+QCF+R24"),
+    plain program ids, and course run ids. Unlike ecommerce.api.get_product_from_text_id,
+    this does not require an associated (active) Product, so it also resolves courseware
+    whose product is inactive/expired (as is common when processing refunds).
+
+    Args:
+        text_id (str): A text id for a Program/CourseRun (optionally with a program run suffix)
+
+    Returns:
+        Program or CourseRun: The courseware object matching the given text id
+
+    Raises:
+        Program.DoesNotExist: if a program (run) text id matches no Program
+        CourseRun.DoesNotExist: if a course run text id matches no CourseRun
+    """
+    program_run_match = re.match(PROGRAM_RUN_ID_PATTERN, text_id)
+    if program_run_match:
+        match_dict = program_run_match.groupdict()
+        # A Program's own readable_id may end in something that looks like a run tag
+        # without an associated ProgramRun. Match either a Program that has a ProgramRun
+        # for the suffix, or one whose readable_id is the full text id, preferring the former.
+        program = (
+            Program.objects.filter(
+                Q(
+                    readable_id=match_dict["text_id_base"],
+                    programruns__run_tag=match_dict["run_tag"],
+                )
+                | Q(readable_id=text_id)
+            )
+            .order_by("-programruns__run_tag")
+            .first()
+        )
+        if program is None:
+            raise Program.DoesNotExist(  # noqa: EM102
+                f"Program matching text id '{text_id}' does not exist"
+            )
+        return program
+    if is_program_text_id(text_id):
+        return Program.objects.get(readable_id=text_id)
+    return CourseRun.objects.get(courseware_id=text_id)
 
 
 def get_catalog_course_filter(relative_filter=""):

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -413,9 +413,7 @@ def get_courseware_object_from_text_id(text_id):
             .first()
         )
         if program is None:
-            raise Program.DoesNotExist(  # noqa: EM102
-                f"Program matching text id '{text_id}' does not exist"
-            )
+            raise Program.DoesNotExist
         return program
     if is_program_text_id(text_id):
         return Program.objects.get(readable_id=text_id)

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -399,18 +399,16 @@ def get_courseware_object_from_text_id(text_id):
     if program_run_match:
         match_dict = program_run_match.groupdict()
         # A Program's own readable_id may end in something that looks like a run tag
-        # without an associated ProgramRun. Match either a Program that has a ProgramRun
-        # for the suffix, or one whose readable_id is the full text id, preferring the former.
+        # without an associated ProgramRun. Prefer a Program that has a ProgramRun for
+        # the suffix; otherwise fall back to a Program whose readable_id is the full
+        # text id. Two separate queries keep the result deterministic (an OR query that
+        # joins programruns can duplicate the full-id Program across its runs).
         program = (
             Program.objects.filter(
-                Q(
-                    readable_id=match_dict["text_id_base"],
-                    programruns__run_tag=match_dict["run_tag"],
-                )
-                | Q(readable_id=text_id)
-            )
-            .order_by("-programruns__run_tag")
-            .first()
+                readable_id=match_dict["text_id_base"],
+                programruns__run_tag=match_dict["run_tag"],
+            ).first()
+            or Program.objects.filter(readable_id=text_id).first()
         )
         if program is None:
             raise Program.DoesNotExist

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -26,8 +26,8 @@ from courses.factories import (
 from courses.models import CourseRun, Program, ProgramCertificate
 from courses.utils import (
     generate_program_certificate,
+    get_courseware_object_from_text_id,
     process_course_run_grade_certificate,
-    resolve_courseware_object_from_text_id,
     sync_course_runs,
     get_catalog_languages,
 )
@@ -426,20 +426,20 @@ def test_catalog_visible_languages():
 
 def _courseware_program_case(run_tag=None):
     """
-    A program readable id resolves to the Program (and its ProgramRun when the id
-    includes a run tag suffix like "+R24").
+    A program readable id resolves to the Program, optionally via a program run id
+    (i.e. the readable id plus a run tag suffix like "+R24").
     """
     program = ProgramFactory.create()
     if run_tag:
         program_run = ProgramRunFactory.create(program=program, run_tag=run_tag)
-        return program_run.full_readable_id, program, program_run
-    return program.readable_id, program, None
+        return program_run.full_readable_id, program
+    return program.readable_id, program
 
 
 def _courseware_course_run_case():
     """A course run readable id resolves to the CourseRun"""
     course_run = CourseRunFactory.create()
-    return course_run.courseware_id, course_run, None
+    return course_run.courseware_id, course_run
 
 
 def _courseware_run_tag_shaped_readable_id_case():
@@ -448,7 +448,7 @@ def _courseware_run_tag_shaped_readable_id_case():
     ProgramRun) resolves via the full-id fallback rather than being mis-parsed.
     """
     program = ProgramFactory.create(readable_id="program-v1:xPRO+Standalone+R1")
-    return program.readable_id, program, None
+    return program.readable_id, program
 
 
 @pytest.mark.parametrize(
@@ -465,13 +465,11 @@ def _courseware_run_tag_shaped_readable_id_case():
         ),
     ],
 )
-def test_resolve_courseware_object_from_text_id(build_case):
-    """resolve_courseware_object_from_text_id resolves each product id shape and its run"""
-    text_id, expected_object, expected_run = build_case()
+def test_get_courseware_object_from_text_id(build_case):
+    """get_courseware_object_from_text_id resolves each product id shape to its object"""
+    text_id, expected = build_case()
 
-    courseware_object, program_run = resolve_courseware_object_from_text_id(text_id)
-    assert courseware_object == expected_object
-    assert program_run == expected_run
+    assert get_courseware_object_from_text_id(text_id) == expected
 
 
 @pytest.mark.parametrize(
@@ -485,7 +483,7 @@ def test_resolve_courseware_object_from_text_id(build_case):
         ),
     ],
 )
-def test_resolve_courseware_object_from_text_id_missing(text_id, expected_exception):
-    """resolve_courseware_object_from_text_id raises when nothing matches the text id"""
+def test_get_courseware_object_from_text_id_missing(text_id, expected_exception):
+    """get_courseware_object_from_text_id raises when nothing matches the text id"""
     with pytest.raises(expected_exception):
-        resolve_courseware_object_from_text_id(text_id)
+        get_courseware_object_from_text_id(text_id)

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -26,8 +26,8 @@ from courses.factories import (
 from courses.models import CourseRun, Program, ProgramCertificate
 from courses.utils import (
     generate_program_certificate,
-    get_courseware_object_from_text_id,
     process_course_run_grade_certificate,
+    resolve_courseware_object_from_text_id,
     sync_course_runs,
     get_catalog_languages,
 )
@@ -426,20 +426,20 @@ def test_catalog_visible_languages():
 
 def _courseware_program_case(run_tag=None):
     """
-    A program readable id resolves to the Program, optionally via a program run id
-    (i.e. the readable id plus a run tag suffix like "+R24").
+    A program readable id resolves to the Program (and its ProgramRun when the id
+    includes a run tag suffix like "+R24").
     """
     program = ProgramFactory.create()
     if run_tag:
         program_run = ProgramRunFactory.create(program=program, run_tag=run_tag)
-        return program_run.full_readable_id, program
-    return program.readable_id, program
+        return program_run.full_readable_id, program, program_run
+    return program.readable_id, program, None
 
 
 def _courseware_course_run_case():
     """A course run readable id resolves to the CourseRun"""
     course_run = CourseRunFactory.create()
-    return course_run.courseware_id, course_run
+    return course_run.courseware_id, course_run, None
 
 
 def _courseware_run_tag_shaped_readable_id_case():
@@ -448,7 +448,7 @@ def _courseware_run_tag_shaped_readable_id_case():
     ProgramRun) resolves via the full-id fallback rather than being mis-parsed.
     """
     program = ProgramFactory.create(readable_id="program-v1:xPRO+Standalone+R1")
-    return program.readable_id, program
+    return program.readable_id, program, None
 
 
 @pytest.mark.parametrize(
@@ -465,11 +465,13 @@ def _courseware_run_tag_shaped_readable_id_case():
         ),
     ],
 )
-def test_get_courseware_object_from_text_id(build_case):
-    """get_courseware_object_from_text_id resolves each product id shape to its object"""
-    text_id, expected = build_case()
+def test_resolve_courseware_object_from_text_id(build_case):
+    """resolve_courseware_object_from_text_id resolves each product id shape and its run"""
+    text_id, expected_object, expected_run = build_case()
 
-    assert get_courseware_object_from_text_id(text_id) == expected
+    courseware_object, program_run = resolve_courseware_object_from_text_id(text_id)
+    assert courseware_object == expected_object
+    assert program_run == expected_run
 
 
 @pytest.mark.parametrize(
@@ -483,7 +485,7 @@ def test_get_courseware_object_from_text_id(build_case):
         ),
     ],
 )
-def test_get_courseware_object_from_text_id_missing(text_id, expected_exception):
-    """get_courseware_object_from_text_id raises when nothing matches the text id"""
+def test_resolve_courseware_object_from_text_id_missing(text_id, expected_exception):
+    """resolve_courseware_object_from_text_id raises when nothing matches the text id"""
     with pytest.raises(expected_exception):
-        get_courseware_object_from_text_id(text_id)
+        resolve_courseware_object_from_text_id(text_id)

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -424,45 +424,65 @@ def test_catalog_visible_languages():
     ]
 
 
-def test_get_courseware_object_from_text_id_program_run():
-    """A program run id (readable id + run tag) should resolve to the Program"""
+def _courseware_program_run_case():
+    """A program run id (readable id + run tag) resolves to the Program"""
     program = ProgramFactory.create()
     program_run = ProgramRunFactory.create(program=program, run_tag="R24")
+    return program_run.full_readable_id, program
 
-    assert get_courseware_object_from_text_id(program_run.full_readable_id) == program
 
-
-def test_get_courseware_object_from_text_id_program():
-    """A plain program readable id should resolve to the Program"""
+def _courseware_program_case():
+    """A plain program readable id resolves to the Program"""
     program = ProgramFactory.create()
+    return program.readable_id, program
 
-    assert get_courseware_object_from_text_id(program.readable_id) == program
 
-
-def test_get_courseware_object_from_text_id_course_run():
-    """A course run readable id should resolve to the CourseRun"""
+def _courseware_course_run_case():
+    """A course run readable id resolves to the CourseRun"""
     course_run = CourseRunFactory.create()
+    return course_run.courseware_id, course_run
 
-    assert get_courseware_object_from_text_id(course_run.courseware_id) == course_run
 
-
-def test_get_courseware_object_from_text_id_run_tag_shaped_readable_id():
+def _courseware_run_tag_shaped_readable_id_case():
     """
     A Program whose readable_id itself ends in a run-tag-like suffix (with no matching
-    ProgramRun) should resolve via the full-id fallback rather than being mis-parsed.
+    ProgramRun) resolves via the full-id fallback rather than being mis-parsed.
     """
     program = ProgramFactory.create(readable_id="program-v1:xPRO+Standalone+R1")
-
-    assert get_courseware_object_from_text_id(program.readable_id) == program
-
-
-def test_get_courseware_object_from_text_id_missing_program():
-    """An unmatched program (run) id should raise Program.DoesNotExist"""
-    with pytest.raises(Program.DoesNotExist):
-        get_courseware_object_from_text_id("program-v1:xPRO+Missing+R9")
+    return program.readable_id, program
 
 
-def test_get_courseware_object_from_text_id_missing_course_run():
-    """An unmatched course run id should raise CourseRun.DoesNotExist"""
-    with pytest.raises(CourseRun.DoesNotExist):
-        get_courseware_object_from_text_id("course-v1:xPRO+Missing+R9")
+@pytest.mark.parametrize(
+    "build_case",
+    [
+        pytest.param(_courseware_program_run_case, id="program_run_id"),
+        pytest.param(_courseware_program_case, id="program_id"),
+        pytest.param(_courseware_course_run_case, id="course_run_id"),
+        pytest.param(
+            _courseware_run_tag_shaped_readable_id_case,
+            id="run_tag_shaped_readable_id",
+        ),
+    ],
+)
+def test_get_courseware_object_from_text_id(build_case):
+    """get_courseware_object_from_text_id resolves each product id shape to its object"""
+    text_id, expected = build_case()
+
+    assert get_courseware_object_from_text_id(text_id) == expected
+
+
+@pytest.mark.parametrize(
+    ("text_id", "expected_exception"),
+    [
+        pytest.param(
+            "program-v1:xPRO+Missing+R9", Program.DoesNotExist, id="missing_program"
+        ),
+        pytest.param(
+            "course-v1:xPRO+Missing+R9", CourseRun.DoesNotExist, id="missing_course_run"
+        ),
+    ],
+)
+def test_get_courseware_object_from_text_id_missing(text_id, expected_exception):
+    """get_courseware_object_from_text_id raises when nothing matches the text id"""
+    with pytest.raises(expected_exception):
+        get_courseware_object_from_text_id(text_id)

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -424,16 +424,15 @@ def test_catalog_visible_languages():
     ]
 
 
-def _courseware_program_run_case():
-    """A program run id (readable id + run tag) resolves to the Program"""
+def _courseware_program_case(run_tag=None):
+    """
+    A program readable id resolves to the Program, optionally via a program run id
+    (i.e. the readable id plus a run tag suffix like "+R24").
+    """
     program = ProgramFactory.create()
-    program_run = ProgramRunFactory.create(program=program, run_tag="R24")
-    return program_run.full_readable_id, program
-
-
-def _courseware_program_case():
-    """A plain program readable id resolves to the Program"""
-    program = ProgramFactory.create()
+    if run_tag:
+        program_run = ProgramRunFactory.create(program=program, run_tag=run_tag)
+        return program_run.full_readable_id, program
     return program.readable_id, program
 
 
@@ -455,8 +454,10 @@ def _courseware_run_tag_shaped_readable_id_case():
 @pytest.mark.parametrize(
     "build_case",
     [
-        pytest.param(_courseware_program_run_case, id="program_run_id"),
-        pytest.param(_courseware_program_case, id="program_id"),
+        pytest.param(
+            lambda: _courseware_program_case(run_tag="R24"), id="program_run_id"
+        ),
+        pytest.param(lambda: _courseware_program_case(), id="program_id"),
         pytest.param(_courseware_course_run_case, id="course_run_id"),
         pytest.param(
             _courseware_run_tag_shaped_readable_id_case,

--- a/courses/utils_test.py
+++ b/courses/utils_test.py
@@ -18,13 +18,15 @@ from courses.factories import (
     CourseRunCertificateFactory,
     CourseRunGradeFactory,
     ProgramFactory,
+    ProgramRunFactory,
     ProgramCertificateFactory,
     UserFactory,
     CourseLanguageFactory,
 )
-from courses.models import ProgramCertificate
+from courses.models import CourseRun, Program, ProgramCertificate
 from courses.utils import (
     generate_program_certificate,
+    get_courseware_object_from_text_id,
     process_course_run_grade_certificate,
     sync_course_runs,
     get_catalog_languages,
@@ -420,3 +422,47 @@ def test_catalog_visible_languages():
     assert get_catalog_languages() == [
         catalog_language.name for catalog_language in catalog_visible_languages
     ]
+
+
+def test_get_courseware_object_from_text_id_program_run():
+    """A program run id (readable id + run tag) should resolve to the Program"""
+    program = ProgramFactory.create()
+    program_run = ProgramRunFactory.create(program=program, run_tag="R24")
+
+    assert get_courseware_object_from_text_id(program_run.full_readable_id) == program
+
+
+def test_get_courseware_object_from_text_id_program():
+    """A plain program readable id should resolve to the Program"""
+    program = ProgramFactory.create()
+
+    assert get_courseware_object_from_text_id(program.readable_id) == program
+
+
+def test_get_courseware_object_from_text_id_course_run():
+    """A course run readable id should resolve to the CourseRun"""
+    course_run = CourseRunFactory.create()
+
+    assert get_courseware_object_from_text_id(course_run.courseware_id) == course_run
+
+
+def test_get_courseware_object_from_text_id_run_tag_shaped_readable_id():
+    """
+    A Program whose readable_id itself ends in a run-tag-like suffix (with no matching
+    ProgramRun) should resolve via the full-id fallback rather than being mis-parsed.
+    """
+    program = ProgramFactory.create(readable_id="program-v1:xPRO+Standalone+R1")
+
+    assert get_courseware_object_from_text_id(program.readable_id) == program
+
+
+def test_get_courseware_object_from_text_id_missing_program():
+    """An unmatched program (run) id should raise Program.DoesNotExist"""
+    with pytest.raises(Program.DoesNotExist):
+        get_courseware_object_from_text_id("program-v1:xPRO+Missing+R9")
+
+
+def test_get_courseware_object_from_text_id_missing_course_run():
+    """An unmatched course run id should raise CourseRun.DoesNotExist"""
+    with pytest.raises(CourseRun.DoesNotExist):
+        get_courseware_object_from_text_id("course-v1:xPRO+Missing+R9")

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -6,7 +6,6 @@ import decimal
 import hashlib
 import hmac
 import logging
-import re
 import uuid
 from base64 import b64encode
 from collections import defaultdict
@@ -17,7 +16,7 @@ from urllib.parse import quote_plus, urljoin
 
 from django.conf import settings
 from django.db import IntegrityError, transaction
-from django.db.models import Count, F, Max, Prefetch, Q, Subquery
+from django.db.models import Count, F, Max, Q, Subquery
 from django.http import HttpRequest
 from django.urls import reverse
 from ipware import get_client_ip
@@ -30,10 +29,9 @@ from courses.constants import (
     CONTENT_TYPE_MODEL_COURSE,
     CONTENT_TYPE_MODEL_COURSERUN,
     CONTENT_TYPE_MODEL_PROGRAM,
-    PROGRAM_RUN_ID_PATTERN,
 )
-from courses.models import CourseRun, Program, ProgramRun
-from courses.utils import is_program_text_id
+from courses.models import CourseRun, Program
+from courses.utils import resolve_courseware_object_from_text_id
 from ecommerce.constants import (
     CYBERSOURCE_DECISION_ACCEPT,
     CYBERSOURCE_DECISION_CANCEL,
@@ -1498,66 +1496,11 @@ def get_product_from_text_id(text_id):
             the Program/CourseRun associated with the text id, and a matching ProgramRun if the text id
             indicated one
     """
-    program_run_id_match = re.match(PROGRAM_RUN_ID_PATTERN, text_id)
-    # This text id matches the pattern of a program text id with a program run attached
-    if program_run_id_match:
-        match_dict = program_run_id_match.groupdict()
-        potential_prog_run_id = match_dict["run_tag"]
-        potential_text_id_base = match_dict["text_id_base"]
-        # A Program's own text id may end with something that looks like a ProgramRun suffix, but has
-        # no associated ProgramRun (ex: program.readable_id == "program-v1:my+program+R1"). This query looks
-        # for a Program with a ProgramRun that matches the suffix, or one that matches the full given text id
-        # without a ProgramRun. The version with a matching ProgramRun is preferred.
-        program = (
-            Program.objects.filter(
-                Q(
-                    readable_id=potential_text_id_base,
-                    programruns__run_tag=potential_prog_run_id,
-                )
-                | Q(readable_id=text_id)
-            )
-            .order_by("-programruns__run_tag")
-            .prefetch_related(
-                Prefetch(
-                    "programruns",
-                    queryset=ProgramRun.objects.filter(run_tag=potential_prog_run_id),
-                    to_attr="matching_program_runs",
-                )
-            )
-            .prefetch_related("products")
-            .first()
-        )
-        if not program:
-            raise Program.DoesNotExist(
-                f"Could not find Program with readable_id={text_id} "  # noqa: EM102
-                "or readable_id={potential_text_id_base} with program run {potential_prog_run_id}"
-            )
-        program_run = first_or_none(program.matching_program_runs)
-        product = first_or_none(program.products.all())
-        if not product:
-            raise Product.DoesNotExist(f"Product for {program} does not exist")  # noqa: EM102
-        return product, program, program_run
-    # This is a "normal" text id that should match a CourseRun/Program
-    else:
-        if is_program_text_id(text_id):
-            content_object_model = Program
-            content_object_filter = dict(readable_id=text_id)  # noqa: C408
-        else:
-            content_object_model = CourseRun
-            content_object_filter = dict(courseware_id=text_id)  # noqa: C408
-        content_object = (
-            content_object_model.objects.filter(**content_object_filter)
-            .prefetch_related("products")
-            .first()
-        )
-        if not content_object:
-            raise content_object_model.DoesNotExist(
-                f"{content_object_model._meta.model} matching filter {content_object_filter} does not exist"  # noqa: EM102, SLF001
-            )
-        product = first_or_none(content_object.products.all())
-        if not product:
-            raise Product.DoesNotExist(f"Product for {content_object} does not exist")  # noqa: EM102
-        return product, content_object, None
+    content_object, program_run = resolve_courseware_object_from_text_id(text_id)
+    product = first_or_none(content_object.products.all())
+    if not product:
+        raise Product.DoesNotExist(f"Product for {content_object} does not exist")  # noqa: EM102
+    return product, content_object, program_run
 
 
 def get_product_from_querystring_id(qs_product_id):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -6,6 +6,7 @@ import decimal
 import hashlib
 import hmac
 import logging
+import re
 import uuid
 from base64 import b64encode
 from collections import defaultdict
@@ -16,7 +17,7 @@ from urllib.parse import quote_plus, urljoin
 
 from django.conf import settings
 from django.db import IntegrityError, transaction
-from django.db.models import Count, F, Max, Q, Subquery
+from django.db.models import Count, F, Max, Prefetch, Q, Subquery
 from django.http import HttpRequest
 from django.urls import reverse
 from ipware import get_client_ip
@@ -29,9 +30,10 @@ from courses.constants import (
     CONTENT_TYPE_MODEL_COURSE,
     CONTENT_TYPE_MODEL_COURSERUN,
     CONTENT_TYPE_MODEL_PROGRAM,
+    PROGRAM_RUN_ID_PATTERN,
 )
-from courses.models import CourseRun, Program
-from courses.utils import get_courseware_object_from_text_id
+from courses.models import CourseRun, Program, ProgramRun
+from courses.utils import is_program_text_id
 from ecommerce.constants import (
     CYBERSOURCE_DECISION_ACCEPT,
     CYBERSOURCE_DECISION_CANCEL,
@@ -1496,23 +1498,66 @@ def get_product_from_text_id(text_id):
             the Program/CourseRun associated with the text id, and a matching ProgramRun if the text id
             indicated one
     """
-    content_object = get_courseware_object_from_text_id(text_id)
-    program_run = None
-    if isinstance(content_object, Program):
-        # If the text id carried a program run suffix, it matches the run whose full
-        # readable id (program readable id + run tag) equals the given text id.
-        program_run = next(
-            (
-                run
-                for run in content_object.programruns.all()
-                if run.full_readable_id == text_id
-            ),
-            None,
+    program_run_id_match = re.match(PROGRAM_RUN_ID_PATTERN, text_id)
+    # This text id matches the pattern of a program text id with a program run attached
+    if program_run_id_match:
+        match_dict = program_run_id_match.groupdict()
+        potential_prog_run_id = match_dict["run_tag"]
+        potential_text_id_base = match_dict["text_id_base"]
+        # A Program's own text id may end with something that looks like a ProgramRun suffix, but has
+        # no associated ProgramRun (ex: program.readable_id == "program-v1:my+program+R1"). This query looks
+        # for a Program with a ProgramRun that matches the suffix, or one that matches the full given text id
+        # without a ProgramRun. The version with a matching ProgramRun is preferred.
+        program = (
+            Program.objects.filter(
+                Q(
+                    readable_id=potential_text_id_base,
+                    programruns__run_tag=potential_prog_run_id,
+                )
+                | Q(readable_id=text_id)
+            )
+            .order_by("-programruns__run_tag")
+            .prefetch_related(
+                Prefetch(
+                    "programruns",
+                    queryset=ProgramRun.objects.filter(run_tag=potential_prog_run_id),
+                    to_attr="matching_program_runs",
+                )
+            )
+            .prefetch_related("products")
+            .first()
         )
-    product = first_or_none(content_object.products.all())
-    if not product:
-        raise Product.DoesNotExist(f"Product for {content_object} does not exist")  # noqa: EM102
-    return product, content_object, program_run
+        if not program:
+            raise Program.DoesNotExist(
+                f"Could not find Program with readable_id={text_id} "  # noqa: EM102
+                "or readable_id={potential_text_id_base} with program run {potential_prog_run_id}"
+            )
+        program_run = first_or_none(program.matching_program_runs)
+        product = first_or_none(program.products.all())
+        if not product:
+            raise Product.DoesNotExist(f"Product for {program} does not exist")  # noqa: EM102
+        return product, program, program_run
+    # This is a "normal" text id that should match a CourseRun/Program
+    else:
+        if is_program_text_id(text_id):
+            content_object_model = Program
+            content_object_filter = dict(readable_id=text_id)  # noqa: C408
+        else:
+            content_object_model = CourseRun
+            content_object_filter = dict(courseware_id=text_id)  # noqa: C408
+        content_object = (
+            content_object_model.objects.filter(**content_object_filter)
+            .prefetch_related("products")
+            .first()
+        )
+        if not content_object:
+            raise content_object_model.DoesNotExist(
+                f"{content_object_model._meta.model} matching filter {content_object_filter} does not exist"  # noqa: EM102, SLF001
+            )
+        product = first_or_none(content_object.products.all())
+        if not product:
+            raise Product.DoesNotExist(f"Product for {content_object} does not exist")  # noqa: EM102
+        return product, content_object, None
 
 
 def get_product_from_querystring_id(qs_product_id):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -31,7 +31,7 @@ from courses.constants import (
     CONTENT_TYPE_MODEL_PROGRAM,
 )
 from courses.models import CourseRun, Program
-from courses.utils import resolve_courseware_object_from_text_id
+from courses.utils import get_courseware_object_from_text_id
 from ecommerce.constants import (
     CYBERSOURCE_DECISION_ACCEPT,
     CYBERSOURCE_DECISION_CANCEL,
@@ -1496,7 +1496,19 @@ def get_product_from_text_id(text_id):
             the Program/CourseRun associated with the text id, and a matching ProgramRun if the text id
             indicated one
     """
-    content_object, program_run = resolve_courseware_object_from_text_id(text_id)
+    content_object = get_courseware_object_from_text_id(text_id)
+    program_run = None
+    if isinstance(content_object, Program):
+        # If the text id carried a program run suffix, it matches the run whose full
+        # readable id (program readable id + run tag) equals the given text id.
+        program_run = next(
+            (
+                run
+                for run in content_object.programruns.all()
+                if run.full_readable_id == text_id
+            ),
+            None,
+        )
     product = first_or_none(content_object.products.all())
     if not product:
         raise Product.DoesNotExist(f"Product for {content_object} does not exist")  # noqa: EM102

--- a/sheets/refund_request_api.py
+++ b/sheets/refund_request_api.py
@@ -14,7 +14,7 @@ from courses.models import (
     Program,
     ProgramEnrollment,
 )
-from courses.utils import get_courseware_object_from_text_id
+from courses.utils import resolve_courseware_object_from_text_id
 from ecommerce.models import Order
 from mitxpro.utils import now_in_utc
 from sheets.constants import (
@@ -147,7 +147,7 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
         # The product id from the sheet may be a program run readable id (e.g. one
         # with a "+R24" run tag suffix). Resolve it to the underlying Program/CourseRun
         # so the lookup works regardless of whether a run tag was included.
-        courseware_object = get_courseware_object_from_text_id(
+        courseware_object, _ = resolve_courseware_object_from_text_id(
             refund_req_row.product_id
         )
         if isinstance(courseware_object, Program):

--- a/sheets/refund_request_api.py
+++ b/sheets/refund_request_api.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 
-import ecommerce.api
 from courses.api import deactivate_program_enrollment, deactivate_run_enrollment
 from courses.constants import ENROLL_CHANGE_STATUS_REFUNDED
 from courses.models import (
@@ -15,7 +14,8 @@ from courses.models import (
     Program,
     ProgramEnrollment,
 )
-from ecommerce.models import Order, Product
+from courses.utils import get_courseware_object_from_text_id
+from ecommerce.models import Order
 from mitxpro.utils import now_in_utc
 from sheets.constants import (
     GOOGLE_API_TRUE_VAL,
@@ -147,7 +147,7 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
         # The product id from the sheet may be a program run readable id (e.g. one
         # with a "+R24" run tag suffix). Resolve it to the underlying Program/CourseRun
         # so the lookup works regardless of whether a run tag was included.
-        _, courseware_object, _ = ecommerce.api.get_product_from_text_id(
+        courseware_object = get_courseware_object_from_text_id(
             refund_req_row.product_id
         )
         if isinstance(courseware_object, Program):
@@ -274,15 +274,10 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
                 )
             elif isinstance(exc, Order.DoesNotExist):
                 message = f"Order with id {refund_req_row.order_id} and purchaser '{refund_req_row.learner_email}' not found"
+            elif isinstance(exc, (Program.DoesNotExist, CourseRun.DoesNotExist)):  # noqa: UP038
+                message = f"No Program/Course run found for product '{refund_req_row.product_id}'"
             elif isinstance(  # noqa: UP038
-                exc,
-                (
-                    ProgramEnrollment.DoesNotExist,
-                    CourseRunEnrollment.DoesNotExist,
-                    Program.DoesNotExist,
-                    CourseRun.DoesNotExist,
-                    Product.DoesNotExist,
-                ),
+                exc, (ProgramEnrollment.DoesNotExist, CourseRunEnrollment.DoesNotExist)
             ):
                 message = f"Program/Course run enrollment does not exist for product '{refund_req_row.product_id}' and order {refund_req_row.order_id}"
             else:

--- a/sheets/refund_request_api.py
+++ b/sheets/refund_request_api.py
@@ -152,11 +152,11 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
         )
         if isinstance(courseware_object, Program):
             enrollment = ProgramEnrollment.all_objects.get(
-                order=order, program=courseware_object
+                user=user, order=order, program=courseware_object
             )
         else:
             enrollment = CourseRunEnrollment.all_objects.get(
-                order=order, run=courseware_object
+                user=user, order=order, run=courseware_object
             )
         return order, enrollment
 

--- a/sheets/refund_request_api.py
+++ b/sheets/refund_request_api.py
@@ -6,11 +6,16 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 
+import ecommerce.api
 from courses.api import deactivate_program_enrollment, deactivate_run_enrollment
 from courses.constants import ENROLL_CHANGE_STATUS_REFUNDED
-from courses.models import CourseRunEnrollment, ProgramEnrollment
-from courses.utils import is_program_text_id
-from ecommerce.models import Order
+from courses.models import (
+    CourseRun,
+    CourseRunEnrollment,
+    Program,
+    ProgramEnrollment,
+)
+from ecommerce.models import Order, Product
 from mitxpro.utils import now_in_utc
 from sheets.constants import (
     GOOGLE_API_TRUE_VAL,
@@ -139,13 +144,19 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
         """
         user = User.objects.get(email__iexact=refund_req_row.learner_email)
         order = Order.objects.get(id=refund_req_row.order_id, purchaser=user)
-        if is_program_text_id(refund_req_row.product_id):
+        # The product id from the sheet may be a program run readable id (e.g. one
+        # with a "+R24" run tag suffix). Resolve it to the underlying Program/CourseRun
+        # so the lookup works regardless of whether a run tag was included.
+        _, courseware_object, _ = ecommerce.api.get_product_from_text_id(
+            refund_req_row.product_id
+        )
+        if isinstance(courseware_object, Program):
             enrollment = ProgramEnrollment.all_objects.get(
-                order=order, program__readable_id=refund_req_row.product_id
+                order=order, program=courseware_object
             )
         else:
             enrollment = CourseRunEnrollment.all_objects.get(
-                order=order, run__courseware_id=refund_req_row.product_id
+                order=order, run=courseware_object
             )
         return order, enrollment
 
@@ -264,7 +275,14 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
             elif isinstance(exc, Order.DoesNotExist):
                 message = f"Order with id {refund_req_row.order_id} and purchaser '{refund_req_row.learner_email}' not found"
             elif isinstance(  # noqa: UP038
-                exc, (ProgramEnrollment.DoesNotExist, CourseRunEnrollment.DoesNotExist)
+                exc,
+                (
+                    ProgramEnrollment.DoesNotExist,
+                    CourseRunEnrollment.DoesNotExist,
+                    Program.DoesNotExist,
+                    CourseRun.DoesNotExist,
+                    Product.DoesNotExist,
+                ),
             ):
                 message = f"Program/Course run enrollment does not exist for product '{refund_req_row.product_id}' and order {refund_req_row.order_id}"
             else:

--- a/sheets/refund_request_api.py
+++ b/sheets/refund_request_api.py
@@ -14,7 +14,7 @@ from courses.models import (
     Program,
     ProgramEnrollment,
 )
-from courses.utils import resolve_courseware_object_from_text_id
+from courses.utils import get_courseware_object_from_text_id
 from ecommerce.models import Order
 from mitxpro.utils import now_in_utc
 from sheets.constants import (
@@ -147,7 +147,7 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
         # The product id from the sheet may be a program run readable id (e.g. one
         # with a "+R24" run tag suffix). Resolve it to the underlying Program/CourseRun
         # so the lookup works regardless of whether a run tag was included.
-        courseware_object, _ = resolve_courseware_object_from_text_id(
+        courseware_object = get_courseware_object_from_text_id(
             refund_req_row.product_id
         )
         if isinstance(courseware_object, Program):

--- a/sheets/refund_request_api.py
+++ b/sheets/refund_request_api.py
@@ -274,10 +274,14 @@ class RefundRequestHandler(EnrollmentChangeRequestHandler):
                 )
             elif isinstance(exc, Order.DoesNotExist):
                 message = f"Order with id {refund_req_row.order_id} and purchaser '{refund_req_row.learner_email}' not found"
-            elif isinstance(exc, (Program.DoesNotExist, CourseRun.DoesNotExist)):  # noqa: UP038
-                message = f"No Program/Course run found for product '{refund_req_row.product_id}'"
             elif isinstance(  # noqa: UP038
-                exc, (ProgramEnrollment.DoesNotExist, CourseRunEnrollment.DoesNotExist)
+                exc,
+                (
+                    ProgramEnrollment.DoesNotExist,
+                    CourseRunEnrollment.DoesNotExist,
+                    Program.DoesNotExist,
+                    CourseRun.DoesNotExist,
+                ),
             ):
                 message = f"Program/Course run enrollment does not exist for product '{refund_req_row.product_id}' and order {refund_req_row.order_id}"
             else:

--- a/sheets/refund_request_api_test.py
+++ b/sheets/refund_request_api_test.py
@@ -37,13 +37,16 @@ def _make_refund_row(product_id, order_id, learner_email):
     )
 
 
-def _build_program_case(run_tag=None):
+def _build_program_case(run_tag=None, inactive_product=False):
     """
     Program enrollment addressed by its readable id, optionally via a program run id
-    (i.e. the readable id plus a run tag suffix like "+R24").
+    (i.e. the readable id plus a run tag suffix like "+R24"). When ``inactive_product``
+    is set, an inactive Product is attached to mimic an expired offering.
     """
     program = ProgramFactory.create()
     enrollment = ProgramEnrollmentFactory.create(program=program)
+    if inactive_product:
+        ProductFactory.create(content_object=program, is_active=False)
     if run_tag:
         program_run = ProgramRunFactory.create(program=program, run_tag=run_tag)
         return program_run.full_readable_id, enrollment
@@ -63,39 +66,22 @@ def _build_course_run_case():
         pytest.param(lambda: _build_program_case(run_tag="R24"), id="program_run_id"),
         pytest.param(lambda: _build_program_case(), id="program_id"),
         pytest.param(_build_course_run_case, id="course_run_id"),
+        pytest.param(
+            lambda: _build_program_case(run_tag="R24", inactive_product=True),
+            id="program_run_id_inactive_product",
+        ),
     ],
 )
 def test_get_order_objects_resolves_enrollment(build_case):
     """
     get_order_objects should resolve the order and enrollment for any product id shape,
-    including a program run id whose run tag suffix isn't part of the Program's readable id.
+    including a program run id whose run tag suffix isn't part of the Program's readable id,
+    and even when the product is inactive (e.g. an expired offering being refunded).
     """
     product_id, enrollment = build_case()
 
     row = _make_refund_row(
         product_id=product_id,
-        order_id=enrollment.order.id,
-        learner_email=enrollment.order.purchaser.email,
-    )
-
-    order, resolved_enrollment = RefundRequestHandler.get_order_objects(row)
-    assert order == enrollment.order
-    assert resolved_enrollment == enrollment
-
-
-def test_get_order_objects_resolves_with_inactive_product():
-    """
-    get_order_objects should resolve the enrollment even when the product is inactive
-    (e.g. an expired offering), since a refund is processed after the product may have
-    been deactivated.
-    """
-    program = ProgramFactory.create()
-    program_run = ProgramRunFactory.create(program=program, run_tag="R24")
-    ProductFactory.create(content_object=program, is_active=False)
-    enrollment = ProgramEnrollmentFactory.create(program=program)
-
-    row = _make_refund_row(
-        product_id=program_run.full_readable_id,
         order_id=enrollment.order.id,
         learner_email=enrollment.order.purchaser.email,
     )

--- a/sheets/refund_request_api_test.py
+++ b/sheets/refund_request_api_test.py
@@ -1,0 +1,88 @@
+"""Tests for the refund request API"""
+
+import pytest
+
+from courses.factories import (
+    CourseRunEnrollmentFactory,
+    CourseRunFactory,
+    ProgramEnrollmentFactory,
+    ProgramFactory,
+    ProgramRunFactory,
+)
+from ecommerce.factories import ProductFactory
+from sheets.refund_request_api import RefundRequestHandler, RefundRequestRow
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_refund_row(product_id, order_id, learner_email):
+    """Builds a minimal RefundRequestRow for get_order_objects tests"""
+    return RefundRequestRow(
+        row_index=1,
+        response_id=1,
+        request_date=None,
+        learner_email=learner_email,
+        zendesk_ticket_no=None,
+        requester_email=None,
+        product_id=product_id,
+        order_id=order_id,
+        order_type=None,
+        finance_email=None,
+        finance_approve_date=None,
+        finance_notes=None,
+        refund_processor=None,
+        refund_complete_date=None,
+        errors=None,
+        skip_row=False,
+    )
+
+
+def _build_program_run_case():
+    """Program enrollment addressed by a product id that carries a run tag (e.g. "+R24")"""
+    program = ProgramFactory.create()
+    program_run = ProgramRunFactory.create(program=program, run_tag="R24")
+    ProductFactory.create(content_object=program)
+    enrollment = ProgramEnrollmentFactory.create(program=program)
+    return program_run.full_readable_id, enrollment
+
+
+def _build_program_case():
+    """Program enrollment addressed by a plain program readable id"""
+    program = ProgramFactory.create()
+    ProductFactory.create(content_object=program)
+    enrollment = ProgramEnrollmentFactory.create(program=program)
+    return program.readable_id, enrollment
+
+
+def _build_course_run_case():
+    """Course run enrollment addressed by a course run readable id"""
+    course_run = CourseRunFactory.create()
+    ProductFactory.create(content_object=course_run)
+    enrollment = CourseRunEnrollmentFactory.create(run=course_run)
+    return course_run.courseware_id, enrollment
+
+
+@pytest.mark.parametrize(
+    "build_case",
+    [
+        pytest.param(_build_program_run_case, id="program_run_id"),
+        pytest.param(_build_program_case, id="program_id"),
+        pytest.param(_build_course_run_case, id="course_run_id"),
+    ],
+)
+def test_get_order_objects_resolves_enrollment(build_case):
+    """
+    get_order_objects should resolve the order and enrollment for any product id shape,
+    including a program run id whose run tag suffix isn't part of the Program's readable id.
+    """
+    product_id, enrollment = build_case()
+
+    row = _make_refund_row(
+        product_id=product_id,
+        order_id=enrollment.order.id,
+        learner_email=enrollment.order.purchaser.email,
+    )
+
+    order, resolved_enrollment = RefundRequestHandler.get_order_objects(row)
+    assert order == enrollment.order
+    assert resolved_enrollment == enrollment

--- a/sheets/refund_request_api_test.py
+++ b/sheets/refund_request_api_test.py
@@ -11,6 +11,7 @@ from courses.factories import (
 )
 from ecommerce.factories import ProductFactory
 from sheets.refund_request_api import RefundRequestHandler, RefundRequestRow
+from users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -43,8 +44,11 @@ def _build_program_case(run_tag=None, inactive_product=False):
     (i.e. the readable id plus a run tag suffix like "+R24"). When ``inactive_product``
     is set, an inactive Product is attached to mimic an expired offering.
     """
+    user = UserFactory.create()
     program = ProgramFactory.create()
-    enrollment = ProgramEnrollmentFactory.create(program=program)
+    enrollment = ProgramEnrollmentFactory.create(
+        program=program, user=user, order__purchaser=user
+    )
     if inactive_product:
         ProductFactory.create(content_object=program, is_active=False)
     if run_tag:
@@ -55,8 +59,11 @@ def _build_program_case(run_tag=None, inactive_product=False):
 
 def _build_course_run_case():
     """Course run enrollment addressed by a course run readable id"""
+    user = UserFactory.create()
     course_run = CourseRunFactory.create()
-    enrollment = CourseRunEnrollmentFactory.create(run=course_run)
+    enrollment = CourseRunEnrollmentFactory.create(
+        run=course_run, user=user, order__purchaser=user
+    )
     return course_run.courseware_id, enrollment
 
 

--- a/sheets/refund_request_api_test.py
+++ b/sheets/refund_request_api_test.py
@@ -37,27 +37,22 @@ def _make_refund_row(product_id, order_id, learner_email):
     )
 
 
-def _build_program_run_case():
-    """Program enrollment addressed by a product id that carries a run tag (e.g. "+R24")"""
+def _build_program_case(run_tag=None):
+    """
+    Program enrollment addressed by its readable id, optionally via a program run id
+    (i.e. the readable id plus a run tag suffix like "+R24").
+    """
     program = ProgramFactory.create()
-    program_run = ProgramRunFactory.create(program=program, run_tag="R24")
-    ProductFactory.create(content_object=program)
     enrollment = ProgramEnrollmentFactory.create(program=program)
-    return program_run.full_readable_id, enrollment
-
-
-def _build_program_case():
-    """Program enrollment addressed by a plain program readable id"""
-    program = ProgramFactory.create()
-    ProductFactory.create(content_object=program)
-    enrollment = ProgramEnrollmentFactory.create(program=program)
+    if run_tag:
+        program_run = ProgramRunFactory.create(program=program, run_tag=run_tag)
+        return program_run.full_readable_id, enrollment
     return program.readable_id, enrollment
 
 
 def _build_course_run_case():
     """Course run enrollment addressed by a course run readable id"""
     course_run = CourseRunFactory.create()
-    ProductFactory.create(content_object=course_run)
     enrollment = CourseRunEnrollmentFactory.create(run=course_run)
     return course_run.courseware_id, enrollment
 
@@ -65,8 +60,8 @@ def _build_course_run_case():
 @pytest.mark.parametrize(
     "build_case",
     [
-        pytest.param(_build_program_run_case, id="program_run_id"),
-        pytest.param(_build_program_case, id="program_id"),
+        pytest.param(lambda: _build_program_case(run_tag="R24"), id="program_run_id"),
+        pytest.param(lambda: _build_program_case(), id="program_id"),
         pytest.param(_build_course_run_case, id="course_run_id"),
     ],
 )
@@ -79,6 +74,28 @@ def test_get_order_objects_resolves_enrollment(build_case):
 
     row = _make_refund_row(
         product_id=product_id,
+        order_id=enrollment.order.id,
+        learner_email=enrollment.order.purchaser.email,
+    )
+
+    order, resolved_enrollment = RefundRequestHandler.get_order_objects(row)
+    assert order == enrollment.order
+    assert resolved_enrollment == enrollment
+
+
+def test_get_order_objects_resolves_with_inactive_product():
+    """
+    get_order_objects should resolve the enrollment even when the product is inactive
+    (e.g. an expired offering), since a refund is processed after the product may have
+    been deactivated.
+    """
+    program = ProgramFactory.create()
+    program_run = ProgramRunFactory.create(program=program, run_tag="R24")
+    ProductFactory.create(content_object=program, is_active=False)
+    enrollment = ProgramEnrollmentFactory.create(program=program)
+
+    row = _make_refund_row(
+        product_id=program_run.full_readable_id,
         order_id=enrollment.order.id,
         learner_email=enrollment.order.purchaser.email,
     )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11986, https://github.com/mitodl/hq/issues/12013


### Description (What does it do?)
When a program is refunded via the refund request form and the transaction reversal has been filled out, learners should be automatically unenrolled from the program's courses. Previously, any refund row whose product id was a **program run** id (e.g. `program-v1:xPRO+QCF+R24`) failed to unenroll the learner.

The cause: `get_order_objects` matched the raw product id against `Program.readable_id`, which never contains the run tag suffix. So the `ProgramEnrollment` lookup raised `DoesNotExist` and the row errored out with `Program/Course run enrollment does not exist for product '...' and order ...`.

This change adds `courses.utils.get_courseware_object_from_text_id`, which resolves a sheet product text id (a program run id with a run tag suffix, a plain program id, or a course run id) to the underlying `Program`/`CourseRun`, and looks up the enrollment by that resolved object. Unlike `ecommerce.api.get_product_from_text_id`, it does **not** require an associated (active) `Product`, so refunds still resolve when the product is inactive/expired. When nothing resolves, the row fails with the same `Program/Course run enrollment does not exist ...` message the accounts team saw before, rather than a new/verbose message.

- `courses/utils.py`: add `get_courseware_object_from_text_id` (deterministic two-step program-run lookup; product-independent).
- `sheets/refund_request_api.py`: resolve the product id to a Program/CourseRun before the enrollment lookup, constrain the enrollment lookup on `user`, and map the resolver's `DoesNotExist` onto the existing failure message.
- `courses/utils_test.py`, `sheets/refund_request_api_test.py`: parametrized tests covering program-run id, plain program id, course-run id, inactive-product, and not-found cases.


### Screenshots (if appropriate):
N/A — backend-only change.


### How can this be tested?
Unit tests:
```bash
docker-compose run --rm web pytest sheets/refund_request_api_test.py courses/utils_test.py
```

End-to-end (verified locally against a tutor Open edX dev instance):
- Create a learner enrolled (via an order) in a program that has a program run with tag `R24`, plus a course run in that program, and a matching edX user/course/enrollment.
- Add a row to the Refund Request worksheet whose **Product ID** is the program run id (`...+R24`) and **Order ID** is that order, with order type `Paid via Cybersource` and the finance email / approve date filled in.
- Run the task:
  ```bash
  docker-compose run --rm web ./manage.py process_refund_requests
  ```
- Confirm the row is `processed`: the order flips to `refunded`, the program + course-run enrollments deactivate (`change_status=refunded`), and the edX enrollment becomes `is_active=False`. A row with a non-existent product id fails with the `Program/Course run enrollment does not exist ...` message written back to the sheet.

Before the fix, a valid program-run row failed with `Program/Course run enrollment does not exist for product 'program-v1:...+R24'`.


### Additional Context
The naive alternative — string-trimming the `+R24` suffix — is unsafe: a program's own `readable_id` can legitimately end in a run-tag-like suffix. `get_courseware_object_from_text_id` handles this with a deterministic two-step lookup: it first tries a `Program` that has a `ProgramRun` matching the run tag, then falls back to a `Program` whose `readable_id` is the full text id.

Note: previously-failed rows already logged in the sheet won't auto-reprocess (the `is_unchanged_error_row` short-circuit), so existing errored rows need to be re-submitted or have their error cell cleared.
