### PR TITLE
fix: make sync_db_to_hubspot resilient to bad data

### DIFF
--- a/hubspot_xpro/api.py
+++ b/hubspot_xpro/api.py
@@ -5,6 +5,7 @@ import re
 from decimal import Decimal
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
 from django.db.models import Q
 from hubspot.crm.objects import SimplePublicObject, SimplePublicObjectInput
 from mitol.hubspot_api.api import (
@@ -433,11 +434,25 @@ def get_hubspot_id_for_object(
             raise_count_error=raise_error,
         )
     if hubspot_obj and hubspot_obj.id:  # noqa: RET503
-        HubspotObject.objects.update_or_create(
-            object_id=obj.id,
-            content_type=content_type,
-            defaults={"hubspot_id": hubspot_obj.id},
-        )
+        try:
+            HubspotObject.objects.update_or_create(
+                object_id=obj.id,
+                content_type=content_type,
+                defaults={"hubspot_id": hubspot_obj.id},
+            )
+        except IntegrityError:
+            # The found hubspot id is already mapped to a different object of
+            # this content type (e.g. a duplicate-named product). Don't create a
+            # conflicting mapping, but still return the hubspot id so callers can
+            # proceed instead of failing the whole sync.
+            log.warning(
+                "Hubspot %s %s is already mapped to a different object; not "
+                "remapping %s %s",
+                content_type.model,
+                hubspot_obj.id,
+                content_type.model,
+                obj.id,
+            )
         return hubspot_obj.id
     elif raise_error:
         raise ValueError(

--- a/hubspot_xpro/api.py
+++ b/hubspot_xpro/api.py
@@ -5,7 +5,7 @@ import re
 from decimal import Decimal
 
 from django.contrib.contenttypes.models import ContentType
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from hubspot.crm.objects import SimplePublicObject, SimplePublicObjectInput
 from mitol.hubspot_api.api import (
@@ -435,12 +435,30 @@ def get_hubspot_id_for_object(
         )
     if hubspot_obj and hubspot_obj.id:  # noqa: RET503
         try:
-            HubspotObject.objects.update_or_create(
-                object_id=obj.id,
-                content_type=content_type,
-                defaults={"hubspot_id": hubspot_obj.id},
-            )
+            # Savepoint so we can catch IntegrityError and keep querying: on
+            # Postgres a failed statement aborts the whole transaction, and the
+            # atomic() block rolls back to the savepoint to keep the connection
+            # usable. See
+            # https://docs.djangoproject.com/en/stable/topics/db/transactions/#controlling-transactions-explicitly
+            with transaction.atomic():
+                HubspotObject.objects.update_or_create(
+                    object_id=obj.id,
+                    content_type=content_type,
+                    defaults={"hubspot_id": hubspot_obj.id},
+                )
         except IntegrityError:
+            mapping_conflict = (
+                HubspotObject.objects.filter(
+                    content_type=content_type, hubspot_id=hubspot_obj.id
+                )
+                .exclude(object_id=obj.id)
+                .exists()
+            )
+            if not mapping_conflict:
+                # Not the expected duplicate-mapping conflict; surface the real
+                # DB integrity error rather than returning a hubspot id and
+                # continuing with a potentially inconsistent DB state.
+                raise
             # The found hubspot id is already mapped to a different object of
             # this content type (e.g. a duplicate-named product). Don't create a
             # conflicting mapping, but still return the hubspot id so callers can

--- a/hubspot_xpro/api_test.py
+++ b/hubspot_xpro/api_test.py
@@ -357,6 +357,41 @@ def test_sync_product_hubspot_ids_dupe_names(mocker, mock_hubspot_api):
     assert HubspotObject.objects.filter(content_type__model="product").count() == 2
 
 
+def test_get_hubspot_id_for_object_skips_conflicting_mapping(mocker):
+    """
+    When a lookup resolves to a hubspot id already mapped to a different object
+    (e.g. a duplicate-named product), get_hubspot_id_for_object should return the
+    hubspot id without raising IntegrityError or creating a conflicting mapping.
+    """
+    existing_product = ProductFactory.create()
+    conflicting_product = ProductFactory.create()
+    content_type = ContentType.objects.get_for_model(Product)
+    HubspotObject.objects.create(
+        content_type=content_type,
+        object_id=existing_product.id,
+        hubspot_id="999",
+    )
+    mocker.patch(
+        "hubspot_xpro.api.find_product",
+        return_value=SimplePublicObjectFactory(id="999"),
+    )
+
+    result = api.get_hubspot_id_for_object(conflicting_product)
+
+    assert result == "999"
+    # No conflicting mapping was created for the second product
+    assert not HubspotObject.objects.filter(
+        content_type=content_type, object_id=conflicting_product.id
+    ).exists()
+    # The original owner's mapping is intact
+    assert (
+        HubspotObject.objects.get(
+            content_type=content_type, hubspot_id="999"
+        ).object_id
+        == existing_product.id
+    )
+
+
 @pytest.mark.parametrize("match_all_lines", [True, False])
 @pytest.mark.parametrize("match_all_deals", [True, False])
 def test_sync_deal_hubspot_ids_to_hubspot(

--- a/hubspot_xpro/api_test.py
+++ b/hubspot_xpro/api_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
 from mitol.hubspot_api.factories import HubspotObjectFactory, SimplePublicObjectFactory
 from mitol.hubspot_api.models import HubspotObject
 
@@ -388,6 +389,25 @@ def test_get_hubspot_id_for_object_skips_conflicting_mapping(mocker):
         HubspotObject.objects.get(content_type=content_type, hubspot_id="999").object_id
         == existing_product.id
     )
+
+
+def test_get_hubspot_id_for_object_reraises_unexpected_integrity_error(mocker):
+    """
+    An IntegrityError that is not the expected duplicate-mapping conflict should
+    propagate rather than returning a hubspot id with an inconsistent DB state.
+    """
+    product = ProductFactory.create()
+    mocker.patch(
+        "hubspot_xpro.api.find_product",
+        return_value=SimplePublicObjectFactory(id="555"),
+    )
+    mocker.patch(
+        "hubspot_xpro.api.HubspotObject.objects.update_or_create",
+        side_effect=IntegrityError("unexpected db problem"),
+    )
+
+    with pytest.raises(IntegrityError):
+        api.get_hubspot_id_for_object(product)
 
 
 @pytest.mark.parametrize("match_all_lines", [True, False])

--- a/hubspot_xpro/api_test.py
+++ b/hubspot_xpro/api_test.py
@@ -385,9 +385,7 @@ def test_get_hubspot_id_for_object_skips_conflicting_mapping(mocker):
     ).exists()
     # The original owner's mapping is intact
     assert (
-        HubspotObject.objects.get(
-            content_type=content_type, hubspot_id="999"
-        ).object_id
+        HubspotObject.objects.get(content_type=content_type, hubspot_id="999").object_id
         == existing_product.id
     )
 

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -389,8 +389,17 @@ def batch_create_hubspot_objects_chunked(
             for obj_id in chunk:
                 try:
                     inputs.append(api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id))
-                except (TooManyRequestsException, ApiException):
+                except TooManyRequestsException:
                     raise
+                except ApiException as ae:
+                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
+                        raise
+                    log.exception(
+                        "Could not build hubspot %s sync message for %s %s; skipping",
+                        hubspot_type,
+                        ct_model_name,
+                        obj_id,
+                    )
                 except Exception:  # noqa: BLE001
                     log.exception(
                         "Could not build hubspot %s sync message for %s %s; skipping",
@@ -513,8 +522,17 @@ def batch_update_hubspot_objects_chunked(
                             ).properties,
                         }
                     )
-                except (TooManyRequestsException, ApiException):
+                except TooManyRequestsException:
                     raise
+                except ApiException as ae:
+                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
+                        raise
+                    log.exception(
+                        "Could not build hubspot %s update message for %s %s; skipping",
+                        hubspot_type,
+                        ct_model_name,
+                        obj_id[0],
+                    )
                 except Exception:  # noqa: BLE001
                     log.exception(
                         "Could not build hubspot %s update message for %s %s; skipping",

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -9,7 +9,7 @@ from math import ceil
 import celery
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
 from hubspot.crm.objects import (
     ApiException,
@@ -31,6 +31,18 @@ from mitxpro.celery import app
 from users.models import User
 
 log = logging.getLogger()
+
+
+def reraise_if_rate_limited(exc: Exception) -> None:
+    """
+    Re-raise HubSpot rate-limit (429) errors so Celery's autoretry/backoff can
+    handle them. Any other exception is left for the caller to handle.
+    """
+    if isinstance(exc, TooManyRequestsException) or (
+        isinstance(exc, ApiException)
+        and getattr(exc, "status", None) == 429  # noqa: PLR2004
+    ):
+        raise exc
 
 
 def task_obj_lock(func_name: str, args: list[object], kwargs: dict) -> str:
@@ -251,15 +263,8 @@ def batch_upsert_hubspot_deals_chunked(ids: list[int]):
     for order in Order.objects.filter(id__in=ids):
         try:
             results.append(api.sync_deal_with_hubspot(order.id).id)
-        except TooManyRequestsException:
-            raise
-        except ApiException as ae:
-            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                raise
-            log.exception(
-                "Could not sync hubspot deal for order %s; skipping", order.id
-            )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_if_rate_limited(exc)
             log.exception(
                 "Could not sync hubspot deal for order %s; skipping", order.id
             )
@@ -289,15 +294,8 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: list[int]) -> list[str]:
     for order in B2BOrder.objects.filter(id__in=ids):
         try:
             results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
-        except TooManyRequestsException:
-            raise
-        except ApiException as ae:
-            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                raise
-            log.exception(
-                "Could not sync hubspot b2b deal for order %s; skipping", order.id
-            )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_if_rate_limited(exc)
             log.exception(
                 "Could not sync hubspot b2b deal for order %s; skipping", order.id
             )
@@ -389,18 +387,8 @@ def batch_create_hubspot_objects_chunked(
             for obj_id in chunk:
                 try:
                     inputs.append(api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id))
-                except TooManyRequestsException:
-                    raise
-                except ApiException as ae:
-                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                        raise
-                    log.exception(
-                        "Could not build hubspot %s sync message for %s %s; skipping",
-                        hubspot_type,
-                        ct_model_name,
-                        obj_id,
-                    )
-                except Exception:  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
+                    reraise_if_rate_limited(exc)
                     log.exception(
                         "Could not build hubspot %s sync message for %s %s; skipping",
                         hubspot_type,
@@ -408,7 +396,6 @@ def batch_create_hubspot_objects_chunked(
                         obj_id,
                     )
             if not inputs:
-                time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
                 continue
             response = HubspotApi().crm.objects.batch_api.create(
                 hubspot_type,
@@ -433,16 +420,39 @@ def batch_create_hubspot_objects_chunked(
                     else:
                         object_id = result.properties["unique_app_id"].split("-")[-1]
                     try:
-                        HubspotObject.objects.update_or_create(
-                            content_type=content_type,
-                            hubspot_id=result.id,
-                            object_id=object_id,
-                        )
+                        # Savepoint so we can catch IntegrityError and keep
+                        # querying: on Postgres a failed statement aborts the
+                        # whole transaction, and the atomic() block rolls back to
+                        # the savepoint to keep the connection usable. See
+                        # https://docs.djangoproject.com/en/stable/topics/db/transactions/#controlling-transactions-explicitly
+                        with transaction.atomic():
+                            HubspotObject.objects.update_or_create(
+                                content_type=content_type,
+                                hubspot_id=result.id,
+                                object_id=object_id,
+                            )
                     except IntegrityError:
+                        mapping_conflict = (
+                            HubspotObject.objects.filter(
+                                content_type=content_type, hubspot_id=result.id
+                            )
+                            .exclude(object_id=object_id)
+                            .exists()
+                            or HubspotObject.objects.filter(
+                                content_type=content_type, object_id=object_id
+                            )
+                            .exclude(hubspot_id=result.id)
+                            .exists()
+                        )
+                        if not mapping_conflict:
+                            # Not the expected (hubspot_id/object_id, content_type)
+                            # conflict; surface the real DB integrity problem
+                            # instead of silently skipping the record.
+                            raise
                         # The hubspot_id (or object_id) is already mapped to a
                         # different object for this content type. Skip rather than
                         # violating the unique (hubspot_id, content_type) constraint.
-                        log.exception(
+                        log.warning(
                             "Could not map hubspot %s %s to %s %s; an existing "
                             "mapping already claims it, skipping",
                             hubspot_type,
@@ -452,7 +462,7 @@ def batch_create_hubspot_objects_chunked(
                         )
                         continue
                     created_ids.append(result.id)
-                except (TooManyRequestsException, ApiException):
+                except (TooManyRequestsException, ApiException, IntegrityError):
                     raise
                 except Exception:  # noqa: BLE001
                     log.exception(
@@ -461,12 +471,9 @@ def batch_create_hubspot_objects_chunked(
                         getattr(result, "id", None),
                     )
                     continue
-        except TooManyRequestsException:
-            raise
-        except ApiException as ae:
-            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                raise
-            last_error_status = ae.status
+        except ApiException as exc:
+            reraise_if_rate_limited(exc)
+            last_error_status = exc.status
             still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
             if still_failed:
                 errored_chunks.append(still_failed)
@@ -521,18 +528,8 @@ def batch_update_hubspot_objects_chunked(
                             ).properties,
                         }
                     )
-                except TooManyRequestsException:
-                    raise
-                except ApiException as ae:
-                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                        raise
-                    log.exception(
-                        "Could not build hubspot %s update message for %s %s; skipping",
-                        hubspot_type,
-                        ct_model_name,
-                        obj_id[0],
-                    )
-                except Exception:  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
+                    reraise_if_rate_limited(exc)
                     log.exception(
                         "Could not build hubspot %s update message for %s %s; skipping",
                         hubspot_type,
@@ -540,18 +537,14 @@ def batch_update_hubspot_objects_chunked(
                         obj_id[0],
                     )
             if not inputs:
-                time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
                 continue
             response = HubspotApi().crm.objects.batch_api.update(
                 hubspot_type, BatchInputSimplePublicObjectBatchInput(inputs=inputs)
             )
             updated_ids.extend([result.id for result in response.results])
-        except TooManyRequestsException:
-            raise
-        except ApiException as ae:
-            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                raise
-            last_error_status = ae.status
+        except ApiException as exc:
+            reraise_if_rate_limited(exc)
+            last_error_status = exc.status
             still_failed = handle_failed_batch_chunk(
                 [item[0] for item in chunk], hubspot_type
             )
@@ -655,16 +648,8 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             type=HubspotAssociationType.LINE_DEAL.value,
                         )
                     )
-        except TooManyRequestsException:
-            raise
-        except ApiException as ae:
-            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                raise
-            log.exception(
-                "Could not gather hubspot associations for order %s; skipping",
-                order_id,
-            )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_if_rate_limited(exc)
             log.exception(
                 "Could not gather hubspot associations for order %s; skipping",
                 order_id,
@@ -683,11 +668,8 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             inputs=line_associations_batch
                         ),
                     )
-                except TooManyRequestsException:
-                    raise
-                except ApiException as ae:
-                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                        raise
+                except ApiException as exc:
+                    reraise_if_rate_limited(exc)
                     log.exception(
                         "Could not create hubspot line-deal associations batch; skipping"
                     )
@@ -701,11 +683,8 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             inputs=contact_associations_batch
                         ),
                     )
-                except TooManyRequestsException:
-                    raise
-                except ApiException as ae:
-                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
-                        raise
+                except ApiException as exc:
+                    reraise_if_rate_limited(exc)
                     log.exception(
                         "Could not create hubspot deal-contact associations batch; skipping"
                     )

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -9,6 +9,7 @@ from math import ceil
 import celery
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
 from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
 from hubspot.crm.objects import (
     ApiException,
@@ -102,6 +103,11 @@ def sync_failed_contacts(chunk: list[int]) -> list[int]:
             api.sync_contact_with_hubspot(user_id)
             time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
         except ApiException:
+            failed_ids.append(user_id)
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "Could not sync hubspot contact for user %s; skipping", user_id
+            )
             failed_ids.append(user_id)
     return failed_ids
 
@@ -239,7 +245,14 @@ def batch_upsert_hubspot_deals_chunked(ids: list[int]):
     """
     results = []
     for order in Order.objects.filter(id__in=ids):
-        results.append(api.sync_deal_with_hubspot(order.id).id)
+        try:
+            results.append(api.sync_deal_with_hubspot(order.id).id)
+        except (TooManyRequestsException, ApiException):
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "Could not sync hubspot deal for order %s; skipping", order.id
+            )
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
     return results
 
@@ -264,7 +277,14 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: list[int]) -> list[str]:
     """
     results = []
     for order in B2BOrder.objects.filter(id__in=ids):
-        results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
+        try:
+            results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
+        except (TooManyRequestsException, ApiException):
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "Could not sync hubspot b2b deal for order %s; skipping", order.id
+            )
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
     return results
 
@@ -349,28 +369,73 @@ def batch_create_hubspot_objects_chunked(
     last_error_status = None
     for chunk in chunked_ids:
         try:
+            inputs = []
+            for obj_id in chunk:
+                try:
+                    inputs.append(api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id))
+                except (TooManyRequestsException, ApiException):
+                    raise
+                except Exception:  # noqa: BLE001
+                    log.exception(
+                        "Could not build hubspot %s sync message for %s %s; skipping",
+                        hubspot_type,
+                        ct_model_name,
+                        obj_id,
+                    )
+            if not inputs:
+                time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+                continue
             response = HubspotApi().crm.objects.batch_api.create(
                 hubspot_type,
-                BatchInputSimplePublicObjectBatchInputForCreate(
-                    inputs=[
-                        api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id)
-                        for obj_id in chunk
-                    ]
-                ),
+                BatchInputSimplePublicObjectBatchInputForCreate(inputs=inputs),
             )
             for result in response.results:
-                if ct_model_name == "user":
-                    object_id = User.objects.get(
-                        email__iexact=result.properties["email"], is_active=True
-                    ).id
-                else:
-                    object_id = result.properties["unique_app_id"].split("-")[-1]
-                HubspotObject.objects.update_or_create(
-                    content_type=content_type,
-                    hubspot_id=result.id,
-                    object_id=object_id,
-                )
-                created_ids.append(result.id)
+                try:
+                    if ct_model_name == "user":
+                        try:
+                            object_id = User.objects.get(
+                                email__iexact=result.properties["email"],
+                                is_active=True,
+                            ).id
+                        except (User.DoesNotExist, User.MultipleObjectsReturned):
+                            log.exception(
+                                "Could not resolve a unique active user for hubspot "
+                                "contact %s (email %s); skipping",
+                                result.id,
+                                result.properties.get("email"),
+                            )
+                            continue
+                    else:
+                        object_id = result.properties["unique_app_id"].split("-")[-1]
+                    try:
+                        HubspotObject.objects.update_or_create(
+                            content_type=content_type,
+                            hubspot_id=result.id,
+                            object_id=object_id,
+                        )
+                    except IntegrityError:
+                        # The hubspot_id (or object_id) is already mapped to a
+                        # different object for this content type. Skip rather than
+                        # violating the unique (hubspot_id, content_type) constraint.
+                        log.exception(
+                            "Could not map hubspot %s %s to %s %s; an existing "
+                            "mapping already claims it, skipping",
+                            hubspot_type,
+                            result.id,
+                            ct_model_name,
+                            object_id,
+                        )
+                        continue
+                    created_ids.append(result.id)
+                except (TooManyRequestsException, ApiException):
+                    raise
+                except Exception:  # noqa: BLE001
+                    log.exception(
+                        "Could not process hubspot %s result %s; skipping",
+                        hubspot_type,
+                        getattr(result, "id", None),
+                    )
+                    continue
         except ApiException as ae:
             last_error_status = ae.status
             still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
@@ -421,15 +486,29 @@ def batch_update_hubspot_objects_chunked(
     last_error_status = None
     for chunk in chunked_ids:
         try:
-            inputs = [
-                {
-                    "id": obj_id[1],
-                    "properties": api.MODEL_FUNCTION_MAPPING[ct_model_name](
-                        obj_id[0]
-                    ).properties,
-                }
-                for obj_id in chunk
-            ]
+            inputs = []
+            for obj_id in chunk:
+                try:
+                    inputs.append(
+                        {
+                            "id": obj_id[1],
+                            "properties": api.MODEL_FUNCTION_MAPPING[ct_model_name](
+                                obj_id[0]
+                            ).properties,
+                        }
+                    )
+                except (TooManyRequestsException, ApiException):
+                    raise
+                except Exception:  # noqa: BLE001
+                    log.exception(
+                        "Could not build hubspot %s update message for %s %s; skipping",
+                        hubspot_type,
+                        ct_model_name,
+                        obj_id[0],
+                    )
+            if not inputs:
+                time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+                continue
             response = HubspotApi().crm.objects.batch_api.update(
                 hubspot_type, BatchInputSimplePublicObjectBatchInput(inputs=inputs)
             )
@@ -517,32 +596,41 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
     hubspot_client = HubspotApi()
     deal_count = len(order_ids)
     for idx, order_id in enumerate(order_ids):
-        deal = Order.objects.get(id=order_id)
-        contact_id = get_hubspot_id_for_object(deal.purchaser)
-        deal_id = get_hubspot_id_for_object(deal)
-        for line in deal.lines.iterator():
-            line_id = get_hubspot_id_for_object(line)
-            if contact_id and deal_id:
-                contact_associations_batch.append(
-                    PublicAssociation(
-                        _from=deal_id,
-                        to=contact_id,
-                        type=HubspotAssociationType.DEAL_CONTACT.value,
+        try:
+            deal = Order.objects.get(id=order_id)
+            contact_id = get_hubspot_id_for_object(deal.purchaser)
+            deal_id = get_hubspot_id_for_object(deal)
+            for line in deal.lines.iterator():
+                line_id = get_hubspot_id_for_object(line)
+                if contact_id and deal_id:
+                    contact_associations_batch.append(
+                        PublicAssociation(
+                            _from=deal_id,
+                            to=contact_id,
+                            type=HubspotAssociationType.DEAL_CONTACT.value,
+                        )
                     )
-                )
-            if line_id and deal_id:
-                line_associations_batch.append(
-                    PublicAssociation(
-                        _from=line_id,
-                        to=deal_id,
-                        type=HubspotAssociationType.LINE_DEAL.value,
+                if line_id and deal_id:
+                    line_associations_batch.append(
+                        PublicAssociation(
+                            _from=line_id,
+                            to=deal_id,
+                            type=HubspotAssociationType.LINE_DEAL.value,
+                        )
                     )
-                )
-            if (
-                len(contact_associations_batch) == 100  # noqa: PLR2004
-                or len(line_associations_batch) == 100  # noqa: PLR2004
-                or idx == deal_count - 1
-            ):
+        except (TooManyRequestsException, ApiException):
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "Could not gather hubspot associations for order %s; skipping",
+                order_id,
+            )
+        if (
+            len(contact_associations_batch) == 100  # noqa: PLR2004
+            or len(line_associations_batch) == 100  # noqa: PLR2004
+            or idx == deal_count - 1
+        ):
+            try:
                 hubspot_client.crm.associations.batch_api.create(
                     HubspotObjectType.LINES.value,
                     HubspotObjectType.DEALS.value,
@@ -550,7 +638,14 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                         inputs=line_associations_batch
                     ),
                 )
-                line_associations_batch = []
+            except ApiException as ae:
+                if ae.status == 429:  # noqa: PLR2004
+                    raise
+                log.exception(
+                    "Could not create hubspot line-deal associations batch; skipping"
+                )
+            line_associations_batch = []
+            try:
                 hubspot_client.crm.associations.batch_api.create(
                     HubspotObjectType.DEALS.value,
                     HubspotObjectType.CONTACTS.value,
@@ -558,7 +653,13 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                         inputs=contact_associations_batch
                     ),
                 )
-                contact_associations_batch = []
+            except ApiException as ae:
+                if ae.status == 429:  # noqa: PLR2004
+                    raise
+                log.exception(
+                    "Could not create hubspot deal-contact associations batch; skipping"
+                )
+            contact_associations_batch = []
     return order_ids
 
 

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -461,18 +461,17 @@ def batch_create_hubspot_objects_chunked(
                         getattr(result, "id", None),
                     )
                     continue
+        except TooManyRequestsException:
+            raise
         except ApiException as ae:
+            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
+                raise
             last_error_status = ae.status
             still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
             if still_failed:
                 errored_chunks.append(still_failed)
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
     if errored_chunks:
-        if last_error_status == 429:  # noqa: PLR2004
-            raise ApiException(
-                status=last_error_status,
-                reason=f"Batch hubspot create failed for the following chunks: {errored_chunks}",
-            )
         log.error(
             "Batch hubspot create failed for type %s, chunks: %s (status %s)",
             hubspot_type,
@@ -547,7 +546,11 @@ def batch_update_hubspot_objects_chunked(
                 hubspot_type, BatchInputSimplePublicObjectBatchInput(inputs=inputs)
             )
             updated_ids.extend([result.id for result in response.results])
+        except TooManyRequestsException:
+            raise
         except ApiException as ae:
+            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
+                raise
             last_error_status = ae.status
             still_failed = handle_failed_batch_chunk(
                 [item[0] for item in chunk], hubspot_type

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -102,7 +102,11 @@ def sync_failed_contacts(chunk: list[int]) -> list[int]:
         try:
             api.sync_contact_with_hubspot(user_id)
             time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
-        except ApiException:
+        except TooManyRequestsException:
+            raise
+        except ApiException as ae:
+            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
+                raise
             failed_ids.append(user_id)
         except Exception:  # noqa: BLE001
             log.exception(

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -247,8 +247,12 @@ def batch_upsert_hubspot_deals_chunked(ids: list[int]):
     for order in Order.objects.filter(id__in=ids):
         try:
             results.append(api.sync_deal_with_hubspot(order.id).id)
-        except (TooManyRequestsException, ApiException):
-            raise
+        except ApiException as ae:
+            if ae.status == 429:  # noqa: PLR2004
+                raise
+            log.exception(
+                "Could not sync hubspot deal for order %s; skipping", order.id
+            )
         except Exception:  # noqa: BLE001
             log.exception(
                 "Could not sync hubspot deal for order %s; skipping", order.id
@@ -279,8 +283,12 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: list[int]) -> list[str]:
     for order in B2BOrder.objects.filter(id__in=ids):
         try:
             results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
-        except (TooManyRequestsException, ApiException):
-            raise
+        except ApiException as ae:
+            if ae.status == 429:  # noqa: PLR2004
+                raise
+            log.exception(
+                "Could not sync hubspot b2b deal for order %s; skipping", order.id
+            )
         except Exception:  # noqa: BLE001
             log.exception(
                 "Could not sync hubspot b2b deal for order %s; skipping", order.id
@@ -600,16 +608,16 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
             deal = Order.objects.get(id=order_id)
             contact_id = get_hubspot_id_for_object(deal.purchaser)
             deal_id = get_hubspot_id_for_object(deal)
+            if contact_id and deal_id:
+                contact_associations_batch.append(
+                    PublicAssociation(
+                        _from=deal_id,
+                        to=contact_id,
+                        type=HubspotAssociationType.DEAL_CONTACT.value,
+                    )
+                )
             for line in deal.lines.iterator():
                 line_id = get_hubspot_id_for_object(line)
-                if contact_id and deal_id:
-                    contact_associations_batch.append(
-                        PublicAssociation(
-                            _from=deal_id,
-                            to=contact_id,
-                            type=HubspotAssociationType.DEAL_CONTACT.value,
-                        )
-                    )
                 if line_id and deal_id:
                     line_associations_batch.append(
                         PublicAssociation(
@@ -618,8 +626,13 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             type=HubspotAssociationType.LINE_DEAL.value,
                         )
                     )
-        except (TooManyRequestsException, ApiException):
-            raise
+        except ApiException as ae:
+            if ae.status == 429:  # noqa: PLR2004
+                raise
+            log.exception(
+                "Could not gather hubspot associations for order %s; skipping",
+                order_id,
+            )
         except Exception:  # noqa: BLE001
             log.exception(
                 "Could not gather hubspot associations for order %s; skipping",
@@ -630,36 +643,38 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
             or len(line_associations_batch) == 100  # noqa: PLR2004
             or idx == deal_count - 1
         ):
-            try:
-                hubspot_client.crm.associations.batch_api.create(
-                    HubspotObjectType.LINES.value,
-                    HubspotObjectType.DEALS.value,
-                    batch_input_public_association=BatchInputPublicAssociation(
-                        inputs=line_associations_batch
-                    ),
-                )
-            except ApiException as ae:
-                if ae.status == 429:  # noqa: PLR2004
-                    raise
-                log.exception(
-                    "Could not create hubspot line-deal associations batch; skipping"
-                )
-            line_associations_batch = []
-            try:
-                hubspot_client.crm.associations.batch_api.create(
-                    HubspotObjectType.DEALS.value,
-                    HubspotObjectType.CONTACTS.value,
-                    batch_input_public_association=BatchInputPublicAssociation(
-                        inputs=contact_associations_batch
-                    ),
-                )
-            except ApiException as ae:
-                if ae.status == 429:  # noqa: PLR2004
-                    raise
-                log.exception(
-                    "Could not create hubspot deal-contact associations batch; skipping"
-                )
-            contact_associations_batch = []
+            if line_associations_batch:
+                try:
+                    hubspot_client.crm.associations.batch_api.create(
+                        HubspotObjectType.LINES.value,
+                        HubspotObjectType.DEALS.value,
+                        batch_input_public_association=BatchInputPublicAssociation(
+                            inputs=line_associations_batch
+                        ),
+                    )
+                except ApiException as ae:
+                    if ae.status == 429:  # noqa: PLR2004
+                        raise
+                    log.exception(
+                        "Could not create hubspot line-deal associations batch; skipping"
+                    )
+                line_associations_batch = []
+            if contact_associations_batch:
+                try:
+                    hubspot_client.crm.associations.batch_api.create(
+                        HubspotObjectType.DEALS.value,
+                        HubspotObjectType.CONTACTS.value,
+                        batch_input_public_association=BatchInputPublicAssociation(
+                            inputs=contact_associations_batch
+                        ),
+                    )
+                except ApiException as ae:
+                    if ae.status == 429:  # noqa: PLR2004
+                        raise
+                    log.exception(
+                        "Could not create hubspot deal-contact associations batch; skipping"
+                    )
+                contact_associations_batch = []
     return order_ids
 
 

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -39,8 +39,7 @@ def reraise_if_rate_limited(exc: Exception) -> None:
     handle them. Any other exception is left for the caller to handle.
     """
     if isinstance(exc, TooManyRequestsException) or (
-        isinstance(exc, ApiException)
-        and getattr(exc, "status", None) == 429  # noqa: PLR2004
+        isinstance(exc, ApiException) and getattr(exc, "status", None) == 429  # noqa: PLR2004
     ):
         raise exc
 

--- a/hubspot_xpro/tasks.py
+++ b/hubspot_xpro/tasks.py
@@ -247,8 +247,10 @@ def batch_upsert_hubspot_deals_chunked(ids: list[int]):
     for order in Order.objects.filter(id__in=ids):
         try:
             results.append(api.sync_deal_with_hubspot(order.id).id)
+        except TooManyRequestsException:
+            raise
         except ApiException as ae:
-            if ae.status == 429:  # noqa: PLR2004
+            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
                 raise
             log.exception(
                 "Could not sync hubspot deal for order %s; skipping", order.id
@@ -283,8 +285,10 @@ def batch_upsert_hubspot_b2b_deals_chunked(ids: list[int]) -> list[str]:
     for order in B2BOrder.objects.filter(id__in=ids):
         try:
             results.append(api.sync_b2b_deal_with_hubspot(order.id).id)
+        except TooManyRequestsException:
+            raise
         except ApiException as ae:
-            if ae.status == 429:  # noqa: PLR2004
+            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
                 raise
             log.exception(
                 "Could not sync hubspot b2b deal for order %s; skipping", order.id
@@ -626,8 +630,10 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             type=HubspotAssociationType.LINE_DEAL.value,
                         )
                     )
+        except TooManyRequestsException:
+            raise
         except ApiException as ae:
-            if ae.status == 429:  # noqa: PLR2004
+            if getattr(ae, "status", None) == 429:  # noqa: PLR2004
                 raise
             log.exception(
                 "Could not gather hubspot associations for order %s; skipping",
@@ -652,8 +658,10 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             inputs=line_associations_batch
                         ),
                     )
+                except TooManyRequestsException:
+                    raise
                 except ApiException as ae:
-                    if ae.status == 429:  # noqa: PLR2004
+                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
                         raise
                     log.exception(
                         "Could not create hubspot line-deal associations batch; skipping"
@@ -668,8 +676,10 @@ def batch_upsert_associations_chunked(order_ids: list[int]):
                             inputs=contact_associations_batch
                         ),
                     )
+                except TooManyRequestsException:
+                    raise
                 except ApiException as ae:
-                    if ae.status == 429:  # noqa: PLR2004
+                    if getattr(ae, "status", None) == 429:  # noqa: PLR2004
                         raise
                     log.exception(
                         "Could not create hubspot deal-contact associations batch; skipping"

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -297,8 +297,9 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
             chunk,
         )
     if status == 429:  # noqa: PLR2004
-        # A 429 during individual retry propagates immediately for backoff
-        mock_sync_contacts.assert_called_once_with(chunk[0][0])
+        # A 429 from the batch call is re-raised immediately for backoff,
+        # without attempting individual retries
+        mock_sync_contacts.assert_not_called()
     else:
         for item in chunk:
             mock_sync_contacts.assert_any_call(item[0])
@@ -386,8 +387,9 @@ def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_err
                 "user",
                 chunk,
             )
-        # A 429 during individual retry propagates immediately for backoff
-        mock_sync_contact.assert_called_once_with(chunk[0])
+        # A 429 from the batch call is re-raised immediately for backoff,
+        # without attempting individual retries
+        mock_sync_contact.assert_not_called()
     else:
         result = tasks.batch_create_hubspot_objects_chunked(
             HubspotObjectType.CONTACTS.value,

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -7,6 +7,7 @@ from math import ceil
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
 from faker import Faker
 from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
 from hubspot.crm.objects import (
@@ -439,7 +440,33 @@ def test_batch_create_hubspot_objects_chunked_duplicate_hubspot_id(mocker):
     assert mappings.first().object_id == existing_user.id
 
 
-def test_batch_create_hubspot_objects_chunked_skips_unserializable(mocker):
+def test_batch_create_hubspot_objects_chunked_reraises_unexpected_integrity_error(
+    mocker,
+):
+    """
+    An IntegrityError that is not a known (hubspot_id/object_id, content_type)
+    mapping conflict should propagate rather than being silently skipped.
+    """
+    user = UserFactory.create()
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
+        mocker.Mock(
+            results=[
+                SimplePublicObjectFactory(
+                    id="123", properties={"email": user.email}
+                )
+            ]
+        )
+    )
+    mocker.patch(
+        "hubspot_xpro.tasks.HubspotObject.objects.update_or_create",
+        side_effect=IntegrityError("unexpected db problem"),
+    )
+
+    with pytest.raises(IntegrityError):
+        tasks.batch_create_hubspot_objects_chunked(
+            HubspotObjectType.CONTACTS.value, "user", [user.id]
+        )
     """An object that can't be serialized is skipped while the rest still sync"""
     users = sorted(UserFactory.create_batch(3), key=lambda contact: contact.id)
     object_ids = [contact.id for contact in users]

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -452,9 +452,7 @@ def test_batch_create_hubspot_objects_chunked_reraises_unexpected_integrity_erro
     mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
         mocker.Mock(
             results=[
-                SimplePublicObjectFactory(
-                    id="123", properties={"email": user.email}
-                )
+                SimplePublicObjectFactory(id="123", properties={"email": user.email})
             ]
         )
     )

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -465,6 +465,9 @@ def test_batch_create_hubspot_objects_chunked_reraises_unexpected_integrity_erro
         tasks.batch_create_hubspot_objects_chunked(
             HubspotObjectType.CONTACTS.value, "user", [user.id]
         )
+
+
+def test_batch_create_hubspot_objects_chunked_skips_unserializable(mocker):
     """An object that can't be serialized is skipped while the rest still sync"""
     users = sorted(UserFactory.create_batch(3), key=lambda contact: contact.id)
     object_ids = [contact.id for contact in users]

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -332,6 +332,44 @@ def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_err
         mock_sync_contact.assert_any_call(item)
 
 
+def test_batch_create_hubspot_objects_chunked_duplicate_hubspot_id(mocker):
+    """
+    A hubspot_id already mapped to a different object should be skipped (logged)
+    rather than raising the unique (hubspot_id, content_type) IntegrityError.
+    """
+    existing_user, new_user = UserFactory.create_batch(2)
+    content_type = ContentType.objects.get_for_model(existing_user)
+    shared_hubspot_id = "420637415"
+    HubspotObject.objects.create(
+        content_type=content_type,
+        object_id=existing_user.id,
+        hubspot_id=shared_hubspot_id,
+    )
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
+        mocker.Mock(
+            results=[
+                SimplePublicObjectFactory(
+                    id=shared_hubspot_id,
+                    properties={"email": new_user.email},
+                )
+            ]
+        )
+    )
+
+    # Should not raise, and should skip the conflicting mapping
+    result = tasks.batch_create_hubspot_objects_chunked(
+        HubspotObjectType.CONTACTS.value, "user", [new_user.id]
+    )
+
+    assert result == []
+    mappings = HubspotObject.objects.filter(
+        content_type=content_type, hubspot_id=shared_hubspot_id
+    )
+    assert mappings.count() == 1
+    assert mappings.first().object_id == existing_user.id
+
+
 def test_batch_upsert_associations(settings, mocker, mocked_celery):
     """
     batch_upsert_associations should call batch_upsert_associations_chunked w/correct lists of ids

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -296,8 +296,12 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
             "user",
             chunk,
         )
-    for item in chunk:
-        mock_sync_contacts.assert_any_call(item[0])
+    if status == 429:  # noqa: PLR2004
+        # A 429 during individual retry propagates immediately for backoff
+        mock_sync_contacts.assert_called_once_with(chunk[0][0])
+    else:
+        for item in chunk:
+            mock_sync_contacts.assert_any_call(item[0])
 
 
 def test_batch_update_hubspot_objects_chunked_skips_unserializable(mocker):
@@ -382,6 +386,8 @@ def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_err
                 "user",
                 chunk,
             )
+        # A 429 during individual retry propagates immediately for backoff
+        mock_sync_contact.assert_called_once_with(chunk[0])
     else:
         result = tasks.batch_create_hubspot_objects_chunked(
             HubspotObjectType.CONTACTS.value,
@@ -389,8 +395,8 @@ def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_err
             chunk,
         )
         assert result == []
-    for item in chunk:
-        mock_sync_contact.assert_any_call(item)
+        for item in chunk:
+            mock_sync_contact.assert_any_call(item)
 
 
 def test_batch_create_hubspot_objects_chunked_duplicate_hubspot_id(mocker):
@@ -653,21 +659,36 @@ def test_task_obj_lock(func_name, args, kwargs, result):
 
 
 def test_sync_failed_contacts(mocker):
-    """sync_failed_contacts should try to sync each contact and return a list of failed contact ids"""
-    user_ids = sorted(user.id for user in UserFactory.create_batch(5))
+    """sync_failed_contacts should collect failed ids and not abort on non-429 errors"""
+    user_ids = sorted(user.id for user in UserFactory.create_batch(4))
     mock_sync = mocker.patch(
         "hubspot_xpro.tasks.api.sync_contact_with_hubspot",
         side_effect=[
             mocker.Mock(),
             ApiException(status=500, reason="err"),
             mocker.Mock(),
-            ApiException(status=429, reason="tmr"),
             ValueError("unexpected"),
         ],
     )
     result = tasks.sync_failed_contacts(user_ids)
-    assert mock_sync.call_count == 5
-    assert result == [user_ids[1], user_ids[3], user_ids[4]]
+    assert mock_sync.call_count == 4
+    assert result == [user_ids[1], user_ids[3]]
+
+
+def test_sync_failed_contacts_reraises_429(mocker):
+    """A 429 should propagate so Celery retry/backoff can apply, not be swallowed"""
+    user_ids = sorted(user.id for user in UserFactory.create_batch(3))
+    mocker.patch(
+        "hubspot_xpro.tasks.api.sync_contact_with_hubspot",
+        side_effect=[
+            mocker.Mock(),
+            ApiException(status=429, reason="tmr"),
+            mocker.Mock(),
+        ],
+    )
+    with pytest.raises(ApiException) as exc_info:
+        tasks.sync_failed_contacts(user_ids)
+    assert exc_info.value.status == 429
 
 
 @pytest.mark.parametrize("for_contacts", [True, False])

--- a/hubspot_xpro/tasks_test.py
+++ b/hubspot_xpro/tasks_test.py
@@ -115,6 +115,37 @@ def test_batch_upsert_hubspot_deals_chunked(mocker):
     assert result == [result.id for result in mock_results]
 
 
+@pytest.mark.parametrize(
+    "order_factory, sync_func, task_func",  # noqa: PT006
+    [
+        [OrderFactory, "sync_deal_with_hubspot", "batch_upsert_hubspot_deals_chunked"],  # noqa: PT007
+        [  # noqa: PT007
+            B2BOrderFactory,
+            "sync_b2b_deal_with_hubspot",
+            "batch_upsert_hubspot_b2b_deals_chunked",
+        ],
+    ],
+)
+def test_batch_upsert_deals_chunked_skips_bad_order(
+    mocker, order_factory, sync_func, task_func
+):
+    """A bad-data order is skipped while the rest of the chunk still syncs"""
+    orders = sorted(order_factory.create_batch(3), key=lambda order: order.id)
+    good_result = SimplePublicObjectFactory()
+
+    def fake_sync(order_id):
+        if order_id == orders[1].id:
+            raise ValueError("bad data")
+        return good_result
+
+    mock_sync_deal = mocker.patch(
+        f"hubspot_xpro.tasks.api.{sync_func}", side_effect=fake_sync
+    )
+    result = getattr(tasks, task_func)([order.id for order in orders])
+    assert mock_sync_deal.call_count == 3
+    assert result == [good_result.id, good_result.id]
+
+
 @pytest.mark.parametrize("create", [True, False])
 @pytest.mark.parametrize("max_batches", [20, 1])
 def test_batch_upsert_b2b_hubspot_deals(
@@ -269,6 +300,36 @@ def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_err
         mock_sync_contacts.assert_any_call(item[0])
 
 
+def test_batch_update_hubspot_objects_chunked_skips_unserializable(mocker):
+    """An object that can't be serialized is skipped while the rest still update"""
+    users = sorted(UserFactory.create_batch(2), key=lambda contact: contact.id)
+    chunk = [(contact.id, str(contact.id)) for contact in users]
+    good_message = SimplePublicObjectFactory()
+
+    def fake_message(obj_id):
+        if obj_id == users[0].id:
+            raise ValueError("bad data")
+        return good_message
+
+    mocker.patch.dict(
+        "hubspot_xpro.tasks.api.MODEL_FUNCTION_MAPPING", {"user": fake_message}
+    )
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.update.return_value = (
+        mocker.Mock(results=[SimplePublicObjectFactory(id="999")])
+    )
+    result = tasks.batch_update_hubspot_objects_chunked(
+        HubspotObjectType.CONTACTS.value, "user", chunk
+    )
+    sent_inputs = (
+        mock_hubspot_api.return_value.crm.objects.batch_api.update.call_args.args[
+            1
+        ].inputs
+    )
+    assert len(sent_inputs) == 1
+    assert result == ["999"]
+
+
 @pytest.mark.parametrize("id_count", [5, 15])
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
@@ -370,6 +431,84 @@ def test_batch_create_hubspot_objects_chunked_duplicate_hubspot_id(mocker):
     assert mappings.first().object_id == existing_user.id
 
 
+def test_batch_create_hubspot_objects_chunked_skips_unserializable(mocker):
+    """An object that can't be serialized is skipped while the rest still sync"""
+    users = sorted(UserFactory.create_batch(3), key=lambda contact: contact.id)
+    object_ids = [contact.id for contact in users]
+    good_message = SimplePublicObjectFactory()
+
+    def fake_message(obj_id):
+        if obj_id == object_ids[1]:
+            raise ValueError("bad data")
+        return good_message
+
+    mocker.patch.dict(
+        "hubspot_xpro.tasks.api.MODEL_FUNCTION_MAPPING", {"user": fake_message}
+    )
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
+        mocker.Mock(results=[])
+    )
+    tasks.batch_create_hubspot_objects_chunked(
+        HubspotObjectType.CONTACTS.value, "user", object_ids
+    )
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.assert_called_once()
+    sent_inputs = (
+        mock_hubspot_api.return_value.crm.objects.batch_api.create.call_args.args[
+            1
+        ].inputs
+    )
+    assert len(sent_inputs) == 2
+
+
+def test_batch_create_hubspot_objects_chunked_skips_bad_result(mocker):
+    """A result missing unique_app_id is skipped without aborting the batch"""
+    product = ProductFactory.create()
+    content_type = ContentType.objects.get_for_model(Product)
+    mocker.patch.dict(
+        "hubspot_xpro.tasks.api.MODEL_FUNCTION_MAPPING",
+        {"product": lambda _obj_id: SimplePublicObjectFactory()},
+    )
+    bad_result = SimplePublicObjectFactory(id="222", properties={})
+    good_result = SimplePublicObjectFactory(
+        id="111", properties={"unique_app_id": f"xpro-{product.id}"}
+    )
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
+        mocker.Mock(results=[bad_result, good_result])
+    )
+    result = tasks.batch_create_hubspot_objects_chunked(
+        HubspotObjectType.PRODUCTS.value, "product", [product.id]
+    )
+    assert result == ["111"]
+    assert HubspotObject.objects.filter(
+        content_type=content_type, hubspot_id="111", object_id=product.id
+    ).exists()
+    assert not HubspotObject.objects.filter(hubspot_id="222").exists()
+
+
+def test_batch_create_hubspot_objects_chunked_skips_unresolved_user(mocker):
+    """A contact result whose email matches no active user is skipped"""
+    user = UserFactory.create()
+    mocker.patch.dict(
+        "hubspot_xpro.tasks.api.MODEL_FUNCTION_MAPPING",
+        {"user": lambda _obj_id: SimplePublicObjectFactory()},
+    )
+    unknown_result = SimplePublicObjectFactory(
+        id="333", properties={"email": "nobody@example.com"}
+    )
+    good_result = SimplePublicObjectFactory(id="444", properties={"email": user.email})
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.return_value = (
+        mocker.Mock(results=[unknown_result, good_result])
+    )
+    result = tasks.batch_create_hubspot_objects_chunked(
+        HubspotObjectType.CONTACTS.value, "user", [user.id]
+    )
+    assert result == ["444"]
+    assert not HubspotObject.objects.filter(hubspot_id="333").exists()
+
+
 def test_batch_upsert_associations(settings, mocker, mocked_celery):
     """
     batch_upsert_associations should call batch_upsert_associations_chunked w/correct lists of ids
@@ -451,6 +590,53 @@ def test_batch_upsert_associations_chunked(mocker):
     )
 
 
+def test_batch_upsert_associations_chunked_skips_bad_order(mocker):
+    """A bad-data order is skipped while gathering associations; others still process"""
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    orders = sorted(OrderFactory.create_batch(3), key=lambda order: order.id)
+    for order in orders:
+        LineFactory.create(
+            order=order,
+            product_version=ProductVersionFactory.create(price=Decimal("200.00")),
+        )
+    bad_order = orders[1]
+
+    def fake_id(obj):
+        if isinstance(obj, Order) and obj.id == bad_order.id:
+            raise ValueError("bad data")
+        return f"hs-{type(obj).__name__}-{obj.id}"
+
+    mocker.patch("hubspot_xpro.tasks.get_hubspot_id_for_object", side_effect=fake_id)
+    result = tasks.batch_upsert_associations_chunked([order.id for order in orders])
+    assert result == [order.id for order in orders]
+    assert mock_hubspot_api.return_value.crm.associations.batch_api.create.called
+
+
+@pytest.mark.parametrize(
+    "status, expected_error",  # noqa: PT006
+    [[400, None], [429, TooManyRequestsException]],  # noqa: PT007
+)
+def test_batch_upsert_associations_chunked_api_error(mocker, status, expected_error):
+    """A non-429 association API error is swallowed; a 429 still propagates"""
+    mock_hubspot_api = mocker.patch("hubspot_xpro.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.associations.batch_api.create.side_effect = (
+        ApiException(status=status)
+    )
+    orders = OrderFactory.create_batch(2)
+    for order in orders:
+        LineFactory.create(
+            order=order,
+            product_version=ProductVersionFactory.create(price=Decimal("200.00")),
+        )
+    mocker.patch("hubspot_xpro.tasks.get_hubspot_id_for_object", return_value="hs-1")
+    order_ids = [order.id for order in orders]
+    if expected_error:
+        with pytest.raises(expected_error):
+            tasks.batch_upsert_associations_chunked(order_ids)
+    else:
+        assert tasks.batch_upsert_associations_chunked(order_ids) == order_ids
+
+
 @pytest.mark.parametrize(
     "func_name,args,kwargs,result",  # noqa: PT006
     [
@@ -468,7 +654,7 @@ def test_task_obj_lock(func_name, args, kwargs, result):
 
 def test_sync_failed_contacts(mocker):
     """sync_failed_contacts should try to sync each contact and return a list of failed contact ids"""
-    user_ids = sorted(user.id for user in UserFactory.create_batch(4))
+    user_ids = sorted(user.id for user in UserFactory.create_batch(5))
     mock_sync = mocker.patch(
         "hubspot_xpro.tasks.api.sync_contact_with_hubspot",
         side_effect=[
@@ -476,11 +662,12 @@ def test_sync_failed_contacts(mocker):
             ApiException(status=500, reason="err"),
             mocker.Mock(),
             ApiException(status=429, reason="tmr"),
+            ValueError("unexpected"),
         ],
     )
     result = tasks.sync_failed_contacts(user_ids)
-    assert mock_sync.call_count == 4
-    assert result == [user_ids[1], user_ids[3]]
+    assert mock_sync.call_count == 5
+    assert result == [user_ids[1], user_ids[3], user_ids[4]]
 
 
 @pytest.mark.parametrize("for_contacts", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11149

### Description (What does it do?)
The changes prevent a single malformed record from aborting the entire
sync_db_to_hubspot run (previously surfaced as a Celery ChordError).

- Guard get_hubspot_id_for_object against IntegrityError when a lookup
  resolves to a hubspot_id already mapped to a different object of the
  same content type (e.g. a duplicate-named product with a drifted
  price); log and reuse the existing id instead of crashing
- Build batch create/update sync messages per-object so a bad record
  (DoesNotExist, KeyError on ORDER_STATUS_MAPPING, AttributeError from
  format_product_name on invalid ProgramRun products, etc.) is logged
  and skipped rather than failing the whole chunk
- Wrap per-order deal/b2b-deal syncing and association gathering so one
  bad order does not abort the chunk
- Handle missing unique_app_id and other errors in the batch-create
  result loop, and non-429 ApiException on association batch creation
- Broaden sync_failed_contacts fallback to skip unresolvable contacts

Rate-limit retry semantics are preserved: TooManyRequestsException and
ApiException(429) are always re-raised so backoff/retry still applies.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

These steps seed a corrupt `Product` whose `content_type` points at a `ProgramRun` (invalid — only `CourseRun`/`Program` are allowed). Serializing it raises `AttributeError` in `format_product_name` while building the sync message, reproducing the bad-data crash locally without HubSpot credentials.

**Prerequisite — start the DB, Redis, and Celery worker** (the sync command dispatches to Celery):

```sh
docker-compose up -d db redis celery
```

**1. Seed bad data**

Save the following as `scripts/hubspot_bad_data.py`:

```python
#!/usr/bin/env python
"""Seed corrupt Product data for locally testing hubspot sync error handling."""

import os
import sys
import uuid

import django

sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mitxpro.settings")
django.setup()

from django.contrib.contenttypes.models import ContentType  # noqa: E402

from courses.models import Platform, Program, ProgramRun  # noqa: E402
from ecommerce.models import Product  # noqa: E402


def main():
    platform, _ = Platform.objects.get_or_create(name="Bad Data Platform")
    program = Program.objects.create(
        title="Bad Data Program",
        readable_id=f"program-baddata-{uuid.uuid4().hex[:8]}",
        live=True,
        platform=platform,
    )
    program_run = ProgramRun.objects.create(program=program, run_tag="R1")
    # bulk_create bypasses Product.save()/clean() (which reject non-CourseRun/
    # Program content types), reproducing how corrupt rows appear in production.
    (product,) = Product.all_objects.bulk_create(
        [
            Product(
                content_type=ContentType.objects.get_for_model(program_run),
                object_id=program_run.id,
                is_active=True,
            )
        ]
    )
    program_run_ct = ContentType.objects.get_for_model(ProgramRun)
    bad_ids = sorted(
        Product.all_objects.filter(content_type=program_run_ct).values_list(
            "id", flat=True
        )
    )
    print(f"Created corrupt Product id={product.id}")
    print(f"All corrupt product ids: {bad_ids}")


if __name__ == "__main__":
    main()
```

Run it and note the printed ids (used as `--ids` below):

```sh
docker-compose run --rm web python scripts/hubspot_bad_data.py
```

**2. Run the sync on this branch — should PASS**

```sh
docker-compose run --rm web ./manage.py sync_db_to_hubspot create --products --ids <BAD_IDS>
```

Expected — the bad products are logged and skipped, and the command finishes:

```
Syncing products with hubspot products...
  Syncing of products to hubspot finished, took N seconds
Hubspot sync complete
```

**3. Run the same sync on master — should FAIL**

The running worker caches the loaded code, so restart it after switching branches:

```sh
git checkout master
docker-compose restart celery
docker-compose run --rm web ./manage.py sync_db_to_hubspot create --products --ids <BAD_IDS>
```

Expected — the sync aborts on the bad data:

```
celery.exceptions.ChordError: Dependency ... raised AttributeError("'ProgramRun' object has no attribute 'text_id'")
```

Restore the feature branch afterward:

```sh
git checkout anas/add-error-handling
docker-compose restart celery
```

**4. Automated coverage**

```sh
docker-compose run --rm web pytest hubspot_xpro/tasks_test.py hubspot_xpro/api_test.py
```

**Cleanup — remove the seeded corrupt rows**

```sh
docker-compose run --rm web ./manage.py shell -c "
from django.contrib.contenttypes.models import ContentType
from courses.models import ProgramRun
from ecommerce.models import Product
ct = ContentType.objects.get_for_model(ProgramRun)
print(Product.all_objects.filter(content_type=ct).delete())
"
```


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
