### PR TITLE
Prefix PostHog identify id with "xpro:" for global uniqueness

### DIFF
--- a/static/js/components/Header.js
+++ b/static/js/components/Header.js
@@ -31,7 +31,11 @@ const Header = ({
       username: currentUser.username,
       name: currentUser.name,
     });
-    posthog.identify(currentUser.id, {
+    // Prefix with "xpro:" to keep the id globally unique: this posthog
+    // project is shared with other MIT applications that identify by their
+    // own (Keycloak) global ids, and xpro's integer user ids would otherwise
+    // collide with them.
+    posthog.identify(`xpro:${currentUser.id}`, {
       environment: SETTINGS.environment,
       user_id: currentUser.id,
     });

--- a/static/js/components/Header_test.js
+++ b/static/js/components/Header_test.js
@@ -1,0 +1,51 @@
+// @flow
+import React from "react";
+import { assert } from "chai";
+import sinon from "sinon";
+import { shallow } from "enzyme";
+import posthog from "posthog-js";
+
+import Header from "./Header";
+import { makeUser, makeAnonymousUser } from "../factories/user";
+
+describe("Header component", () => {
+  let sandbox, identifyStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    identifyStub = sandbox.stub(posthog, "identify");
+    global.SETTINGS = { environment: "test" };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    delete global.SETTINGS;
+  });
+
+  const render = (currentUser) =>
+    shallow(
+      <Header
+        currentUser={currentUser}
+        location={null}
+        errorPageHeader={false}
+        courseTopics={[]}
+      />,
+    );
+
+  it("identifies the user to PostHog with an xpro-prefixed id", () => {
+    const user = makeUser();
+
+    render(user);
+
+    sinon.assert.calledWith(identifyStub, `xpro:${user.id}`, {
+      environment: "test",
+      user_id: user.id,
+    });
+  });
+
+  it("does not identify an anonymous user", () => {
+    render(makeAnonymousUser());
+
+    sinon.assert.notCalled(identifyStub);
+  });
+});


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/12601 (step 4)

### Description (What does it do?)
Changes how xPro identifies posthog users.
- **Previously:** `identify(pk)`, like pk=123 user id primary key.
    - We use the same posthog project in mit-learn and xpro, so until now, whether Posthog User 123 was xpro or learn user 123 was entirely dependent on where they went first.
- **Now:** Prefixed with `xpro:pk`

Ideally, this would be the same guid used in Learn and MITxOnline an (maybe, one day, ocw). But xpro isn't hooked up to keycloak, so we can't get the guid.

### How can this be tested?
No functional UI change, so this is best verified by manual code review:
- `static/js/components/Header.js`: confirm `identify` is now called with `` `xpro:${currentUser.id}` `` instead of the bare id.
- Unit test added: `Header_test.js`.

### Additional Context
Companion MITxOnline PR for step 3 of the same issue: https://github.com/mitodl/mitxonline/pull/3798