### PR TITLE
fix: revert pygsheets 2.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "pdftotext>=3.0.0,<4",
     "psycopg2==2.9.12",
     "pycountry==26.2.16",
-    "pygsheets==2.0.6",
+    "pygsheets==2.0.2",
     "redis==7.4.1",
     "requests>=2.31.0,<3",
     "sentry-sdk>=2.0.0,<3",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,12 @@
   "extends": ["local>mitodl/.github:renovate-config"],
   "packageRules": [
     {
-      "matchPackageNames": ["sass"],
+      "matchPackageNames": [
+        "sass",
+        "pygsheets",
+        "google-auth",
+        "google-auth-oauthlib"
+      ],
       "automerge": false
     }
   ]


### PR DESCRIPTION
### What are the relevant tickets?
Reverts #3757 

### Description (What does it do?)
#3757 bumped `pygsheets 2.0.2 -> 2.0.6` but changed only `pyproject.toml` — `uv.lock` was never regenerated, so CI's `uv sync --locked` has failed on `master` since 8d7e6b6. Renovate couldn't regenerate it because the bump is unsatisfiable: `pygsheets 2.0.6 -> google-auth-oauthlib>=0.7.1 -> google-auth>=2.14.0`, while we pin `google-auth==1.35.0`. This reverts the pin (no `uv.lock` change needed — the lockfile was already correct at 2.0.2) and adds the coupled packages to renovate's review-required list so it can't automerge red again. The real fix, `google-auth 1.35.0 -> 2.x`, is a major bump of the auth library `sheets` depends on.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
