### PR TITLE
fix: scope external course readable_id to the vendor

### DIFF
--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -4,13 +4,14 @@ import json
 import logging
 import re
 import time
+from contextlib import contextmanager
 from datetime import timedelta
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
 
 from django.contrib.contenttypes.models import ContentType
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Prefetch
 from wagtail.images.models import Image
 from wagtail.models import Page
@@ -281,6 +282,46 @@ def fetch_external_courses(keymap):
         log.error("Something unexpected happened!")
 
 
+@contextmanager
+def atomic_or_record_failure(stats_collector, external_course, course_index_page):
+    """
+    Sync a single course in a transaction, recording integrity errors instead of raising.
+
+    A course that collides with an existing one on a unique constraint (e.g. two vendors
+    shipping the same course tag) would otherwise abort the sync for the rest of the
+    platform's catalog and suppress the stats email entirely.
+
+    Args:
+        stats_collector(StatsCollector): collector to record the failure in
+        external_course(ExternalCourse): the course being synced
+        course_index_page(CourseIndexPage): the cached parent of the course pages
+    """
+    stats_snapshot = stats_collector.snapshot()
+    try:
+        with transaction.atomic():
+            yield
+    except IntegrityError:
+        # The course code is deliberately not interpolated into the log message: the
+        # sync data is derived from an API-key-bearing request, so static analysis
+        # treats it as sensitive. It is recorded in the stat (and the sync email)
+        # instead, and the traceback identifies the course in Sentry.
+        log.exception("Failed to sync an external course due to an integrity error.")
+        # Everything recorded for this course describes work the rollback just undid,
+        # so drop it rather than report it as created.
+        stats_collector.restore(stats_snapshot)
+        # `add_child()` increments the cached index page's `numchild` in memory while
+        # the database copy is updated separately, so the rollback leaves the cached
+        # value too high and the next course would compute a child path from a
+        # `get_last_child()` that no longer exists.
+        course_index_page.refresh_from_db()
+        stats_collector.add_stat(
+            "courses_failed",
+            external_course.course_code,
+            external_course.course_title,
+            "Database integrity error, see the logs for details.",
+        )
+
+
 def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR0915
     """
     Updates or creates the required course data i.e. Course, CourseRun,
@@ -352,7 +393,9 @@ def update_external_course_runs(external_courses, keymap):  # noqa: C901, PLR091
             )
             continue
 
-        with transaction.atomic():
+        with atomic_or_record_failure(
+            stats_collector, external_course, course_index_page
+        ):
             course, course_created = Course.objects.get_or_create(
                 external_course_id=external_course.course_code,
                 platform=platform,

--- a/courses/sync_external_courses/external_course_sync_api.py
+++ b/courses/sync_external_courses/external_course_sync_api.py
@@ -126,10 +126,12 @@ class ExternalCourse:
         self.course_title = program_name.strip() if program_name else None
         self.course_code = external_course_json.get("course_code")
 
-        # External course code format is `<MXP | MO>-<COURSE_TAG>`, where course tag can contain `.`,
-        # we will replace `.` with `_` to follow the internal readable id format.
+        # External course code format is `<MXP | MO>-<COURSE_TAG>`. The prefix identifies
+        # the vendor and has to stay in the readable ID: two vendors can ship the same
+        # course tag, and `Course.readable_id` is unique across all courses. Neither `-`
+        # nor `.` is a valid readable ID character, so both are replaced with `_`.
         self.course_readable_id = generate_course_readable_id(
-            self.course_code.split("-")[1].replace(".", "_")
+            self.course_code.replace("-", "_").replace(".", "_")
         )
 
         self.course_run_code = external_course_json.get("course_run_code")

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -1316,3 +1316,83 @@ def test_create_or_update_external_course_page_kept_as_draft(external_course_dat
     # The live (published) version still has the old marketing URL.
     assert external_course_page.external_marketing_url == "https://old-url.com"
     assert external_course_page.has_unpublished_changes
+
+
+def _external_course_row(course_code, course_run_code):
+    """An external course JSON row with future dates and the given codes."""
+    with Path(
+        "courses/sync_external_courses/test_data/batch_test.json"
+    ).open() as test_data_file:
+        row = json.load(test_data_file)["rows"][0]
+
+    return {
+        **row,
+        "course_code": course_code,
+        "course_run_code": course_run_code,
+        "start_date": "2099-09-30",
+        "end_date": "2099-11-30",
+    }
+
+
+def test_external_course_readable_id_is_vendor_scoped():
+    """
+    The same course tag from two vendors must produce two distinct readable IDs.
+
+    `Course.readable_id` is unique across all courses, so dropping the vendor prefix
+    made the second vendor's course impossible to create.
+    """
+    emeritus_course = ExternalCourse(
+        _external_course_row("MO-DBIP", "MO-DBIP-99-09#1"), EmeritusKeyMap()
+    )
+    global_alumni_course = ExternalCourse(
+        _external_course_row("MXP-DBIP", "MXP-DBIP-99-09#1"), GlobalAlumniKeyMap()
+    )
+
+    assert emeritus_course.course_readable_id == "course-v1:xPRO+MO_DBIP"
+    assert global_alumni_course.course_readable_id == "course-v1:xPRO+MXP_DBIP"
+
+
+def test_external_course_readable_id_keeps_full_course_tag():
+    """Course tags containing `.` or `-` are preserved (as `_`), never truncated."""
+    external_course = ExternalCourse(
+        _external_course_row("MO-MTE.SEPO", "MO-MTE.SEPO-99-09#1"), EmeritusKeyMap()
+    )
+    assert external_course.course_readable_id == "course-v1:xPRO+MO_MTE_SEPO"
+
+
+@pytest.mark.django_db
+def test_update_external_course_runs_syncs_same_tag_from_two_vendors():
+    """
+    A course tag already used by another vendor syncs into its own course.
+
+    Regression test for the `courses_course_readable_id_23dff66f_uniq` IntegrityError.
+    """
+    home_page = HomePageFactory.create(title="Home Page", subhead="<p>subhead</p>")
+    CourseIndexPageFactory.create(parent=home_page, title="Courses")
+
+    global_alumni_platform = PlatformFactory.create(name=GLOBAL_ALUMNI_PLATFORM_NAME)
+    # Courses synced before the vendor prefix was added keep their original readable_id,
+    # so this is the shape the colliding course actually has in the database.
+    CourseFactory.create(
+        title="Materials Characterization and Process Optimization",
+        readable_id="course-v1:xPRO+MCPO",
+        platform=global_alumni_platform,
+        external_course_id="MXP-MCPO",
+        page=None,
+        is_external=True,
+    )
+
+    stats_collector = update_external_course_runs(
+        [_external_course_row("MO-MCPO", "MO-MCPO-99-09#1")], keymap=EmeritusKeyMap()
+    )
+    stats = stats_collector.get_unformatted_stats()
+
+    assert len(stats["courses_created"]) == 1
+
+    emeritus_course = Course.objects.get(external_course_id="MO-MCPO")
+    assert emeritus_course.readable_id == "course-v1:xPRO+MO_MCPO"
+    assert emeritus_course.platform.name == EMERITUS_PLATFORM_NAME
+    assert (
+        Course.objects.filter(readable_id__endswith="MCPO", is_external=True).count()
+        == 2
+    )

--- a/courses/sync_external_courses/external_course_sync_api_test.py
+++ b/courses/sync_external_courses/external_course_sync_api_test.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from pathlib import Path
 
 import pytest
+from django.db import IntegrityError
 from wagtail.test.utils.wagtail_factories import ImageFactory
 
 from cms.factories import (
@@ -1396,3 +1397,114 @@ def test_update_external_course_runs_syncs_same_tag_from_two_vendors():
         Course.objects.filter(readable_id__endswith="MCPO", is_external=True).count()
         == 2
     )
+
+
+@pytest.mark.django_db
+def test_update_external_course_runs_reports_integrity_error_and_continues():
+    """
+    A course that violates a unique constraint is reported, not raised.
+
+    Without this the exception escapes to `task_sync_external_course_runs`, which
+    abandons the platform's remaining courses and never sends the stats email.
+    """
+    home_page = HomePageFactory.create(title="Home Page", subhead="<p>subhead</p>")
+    CourseIndexPageFactory.create(parent=home_page, title="Courses")
+
+    # Squat on the readable_id that syncing `MO-DBIP` is going to generate.
+    CourseFactory.create(
+        title="Squatter",
+        readable_id="course-v1:xPRO+MO_DBIP",
+        platform=PlatformFactory.create(name="Some Other Platform"),
+        external_course_id="OTHER-DBIP",
+        page=None,
+        is_external=True,
+    )
+
+    stats_collector = update_external_course_runs(
+        [
+            _external_course_row("MO-DBIP", "MO-DBIP-99-09#1"),
+            _external_course_row("MO-PCCY", "MO-PCCY-99-09#1"),
+        ],
+        keymap=EmeritusKeyMap(),
+    )
+    stats = stats_collector.get_unformatted_stats()
+
+    assert [item.code for item in stats["courses_failed"]] == ["MO-DBIP"]
+    assert not Course.objects.filter(external_course_id="MO-DBIP").exists()
+
+    # The rest of the batch still syncs.
+    assert [item.code for item in stats["courses_created"]] == ["MO-PCCY"]
+    assert Course.objects.filter(external_course_id="MO-PCCY").exists()
+
+
+def _fail_first_course_after_page_creation(mocker):
+    """Make the first course raise an IntegrityError after its page was created."""
+    return mocker.patch(
+        "courses.sync_external_courses.external_course_sync_api"
+        ".create_common_child_pages_for_external_courses",
+        side_effect=[IntegrityError("late failure"), None],
+    )
+
+
+@pytest.mark.django_db
+def test_update_external_course_runs_recovers_after_rollback_following_page_creation(
+    mocker,
+):
+    """
+    A rollback that undoes a course page must not break the courses that follow.
+
+    `course_index_page` is fetched once, before the loop, and `add_child()` bumps its
+    in-memory `numchild` while the database copy is updated separately. After a
+    rollback the cached value is too high, and treebeard then computes the next
+    child's path from `get_last_child()`, which is `None` when the index page has no
+    children in the database.
+    """
+    home_page = HomePageFactory.create(title="Home Page", subhead="<p>subhead</p>")
+    CourseIndexPageFactory.create(parent=home_page, title="Courses")
+    _fail_first_course_after_page_creation(mocker)
+
+    stats_collector = update_external_course_runs(
+        [
+            _external_course_row("MO-DBIP", "MO-DBIP-99-09#1"),
+            _external_course_row("MO-PCCY", "MO-PCCY-99-09#1"),
+        ],
+        keymap=EmeritusKeyMap(),
+    )
+    stats = stats_collector.get_unformatted_stats()
+
+    assert [item.code for item in stats["courses_failed"]] == ["MO-DBIP"]
+    assert not Course.objects.filter(external_course_id="MO-DBIP").exists()
+    assert Course.objects.filter(external_course_id="MO-PCCY").exists()
+
+
+@pytest.mark.django_db
+def test_update_external_course_runs_discards_stats_for_rolled_back_course(mocker):
+    """
+    Work undone by a rollback must not be reported as created in the sync email.
+
+    Success stats are recorded as each step of a course succeeds, but the whole
+    course is rolled back if a later step fails.
+    """
+    home_page = HomePageFactory.create(title="Home Page", subhead="<p>subhead</p>")
+    CourseIndexPageFactory.create(parent=home_page, title="Courses")
+    _fail_first_course_after_page_creation(mocker)
+
+    stats_collector = update_external_course_runs(
+        [
+            _external_course_row("MO-DBIP", "MO-DBIP-99-09#1"),
+            _external_course_row("MO-PCCY", "MO-PCCY-99-09#1"),
+        ],
+        keymap=EmeritusKeyMap(),
+    )
+    stats = stats_collector.get_unformatted_stats()
+
+    assert [item.code for item in stats["courses_failed"]] == ["MO-DBIP"]
+    for key in ("courses_created", "course_pages_created"):
+        assert [item.code for item in stats[key]] == ["MO-PCCY"], (
+            f"{key} still reports the rolled-back course"
+        )
+    for key in ("course_runs_created", "products_created", "product_versions_created"):
+        codes = [item.code for item in stats[key]]
+        assert not any("DBIP" in code for code in codes), (
+            f"{key} still reports rolled-back work: {codes}"
+        )

--- a/courses/sync_external_courses/utils.py
+++ b/courses/sync_external_courses/utils.py
@@ -98,6 +98,11 @@ class StatsCollector:
                 "existing_courses",
                 "External Course Codes",
             ),
+            "courses_failed": StatItemsCollection(
+                "courses_failed",
+                "External Course Codes",
+                display_name="Courses Failed to Sync",
+            ),
             "course_runs_created": StatItemsCollection(
                 "course_runs_created",
                 "External Course Run Codes",
@@ -176,6 +181,25 @@ class StatsCollector:
         """
         for code in codes:
             self.add_stat(key, code)
+
+    def snapshot(self):
+        """
+        Capture the currently collected items so they can be restored later.
+
+        Returns:
+            dict: a mapping of stat key to a copy of that stat's items
+        """
+        return {key: set(stat.items) for key, stat in self.stats.items()}
+
+    def restore(self, snapshot):
+        """
+        Roll the collected stats back to a previously captured snapshot.
+
+        Args:
+            snapshot(dict): a mapping returned by `snapshot()`
+        """
+        for key, items in snapshot.items():
+            self.stats[key].items = set(items)
 
     def remove_duplicates(self, target_stat_key, reference_stat_key):
         """

--- a/mail/templates/external_data_sync/body.html
+++ b/mail/templates/external_data_sync/body.html
@@ -45,6 +45,22 @@
               {% else %}No courses created during this sync.{% endif %}
             </li>
             <li>
+              <span style="color: #ff0000"
+                >Courses Failed to Sync ({{ stats.courses_failed|length }}):</span
+              >
+              {% if stats.courses_failed %}
+              <ul>
+                {% for course in stats.courses_failed %}
+                <li>
+                  {{ course.code }}
+                  ({{ course.title }}) -
+                  {{ course.msg }}
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}No courses failed to sync.{% endif %}
+            </li>
+            <li>
               <span style="color: #008000"
                 >Existing Courses ({{ stats.existing_courses|length }}):</span
               >


### PR DESCRIPTION
### What are the relevant tickets?

Fixes mitodl/hq#13223 ([Sentry XPRO-8EF](https://mit-office-of-digital-learning.sentry.io/issues/7692518038/)).

### Description (What does it do?)

External courses from different vendors could receive the same readable ID because the vendor prefix was removed. For example, `MXP-MCPO` and `MO-MCPO` both became `course-v1:xPRO+MCPO`, causing a database error that stopped the remaining courses for that vendor from syncing.

- Keeps the vendor prefix in new course IDs, such as `course-v1:xPRO+MO_MCPO`, and replaces dots and hyphens with underscores.
- Rolls back a course that encounters a database integrity error, records it in the sync email, and continues syncing the remaining courses.
- Preserves existing course IDs and URLs; no data migration is needed.

### How can this be tested?

Regression tests cover distinct IDs for different vendors, course-code normalization, syncing alongside an existing course with a legacy ID, and continuing after an integrity error.

Validation completed:

- 715 tests passed across `courses/`, `cms/`, and `mail/`.
- Migration checks and Ruff lint/format checks passed.
- Local sync with both vendors confirmed that an existing `course-v1:xPRO+MCPO` course and a new `course-v1:xPRO+MO_MCPO` course coexist, and both URLs return HTTP 200.

To validate, run `uv run pytest courses/sync_external_courses/external_course_sync_api_test.py`. For a manual check, sync two vendors with the same course tag and confirm they create separate courses. Trigger a course ID collision and confirm the remaining courses sync and the failed course appears in the sync email.

### Additional Context

New course URLs include the vendor prefix. Courses with the same tag from different vendors remain separate catalog entries; whether they should appear as one offering is a separate product decision.
